### PR TITLE
Add `expo-serve-sim` and `withSimServe` helper

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,9 +5,20 @@
     "": {
       "name": "serve-sim-repo",
     },
+    "packages/expo-serve-sim": {
+      "name": "expo-serve-sim",
+      "version": "0.1.0",
+      "dependencies": {
+        "serve-sim": "^0.1.3",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "typescript": "^5.7.0",
+      },
+    },
     "packages/serve-sim": {
       "name": "serve-sim",
-      "version": "0.0.9",
+      "version": "0.1.10",
       "bin": {
         "serve-sim": "dist/serve-sim.js",
       },
@@ -104,6 +115,8 @@
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
     "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
+
+    "expo-serve-sim": ["expo-serve-sim@workspace:packages/expo-serve-sim"],
 
     "fast-xml-parser": ["fast-xml-parser@5.3.3", "", { "dependencies": { "strnum": "^2.1.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-2O3dkPAAC6JavuMm8+4+pgTk+5hoAs+CjZ+sWcQLkX9+/tHRuTkQh/Oaifr8qDmZ8iEHb771Ea6G8CdwkrgvYA=="],
 

--- a/packages/expo-serve-sim/README.md
+++ b/packages/expo-serve-sim/README.md
@@ -1,0 +1,34 @@
+# expo-serve-sim
+
+Expo Metro integration for [`serve-sim`](../serve-sim). Mounts the serve-sim preview UI on your Expo dev server.
+
+```sh
+npm install --save-dev expo-serve-sim serve-sim
+```
+
+Customize `metro.config.js` (`bunx expo customize`) and wrap the Metro config:
+
+```js
+const { getDefaultConfig } = require("expo/metro-config");
+const { withSimServe } = require("expo-serve-sim");
+
+/** @type {import('expo/metro-config').MetroConfig} */
+const config = getDefaultConfig(__dirname);
+
+module.exports = withSimServe(config);
+// or: module.exports = withSimServe(config, { basePath: "/.sim" });
+```
+
+Start the simulator stream in one terminal:
+
+```sh
+npx serve-sim --detach
+```
+
+Run Expo in another terminal and open the preview:
+
+```sh
+npx expo start
+```
+
+Open `http://localhost:8081/.sim` to view and control the booted simulator. `expo-serve-sim` only mounts the preview middleware; it does not start or stop `serve-sim`.

--- a/packages/expo-serve-sim/package.json
+++ b/packages/expo-serve-sim/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "expo-serve-sim",
+  "version": "0.1.0",
+  "description": "Expo Metro integration for serve-sim.",
+  "type": "module",
+  "author": {
+    "name": "Evan Bacon",
+    "email": "baconbrix@gmail.com",
+    "url": "https://evanbacon.dev"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/EvanBacon/serve-sim.git",
+    "directory": "packages/expo-serve-sim"
+  },
+  "homepage": "https://github.com/EvanBacon/serve-sim#readme",
+  "bugs": {
+    "url": "https://github.com/EvanBacon/serve-sim/issues"
+  },
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "src/index.ts",
+  "files": [
+    "dist/index.js",
+    "dist/index.cjs",
+    "src/index.ts",
+    "README.md"
+  ],
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js",
+      "types": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "build": "bun build src/index.ts --target bun --format esm --outfile dist/index.js --external serve-sim/middleware && bun build src/index.ts --target node --format cjs --outfile dist/index.cjs --external serve-sim/middleware"
+  },
+  "dependencies": {
+    "serve-sim": "^0.1.3"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.7.0"
+  }
+}

--- a/packages/expo-serve-sim/src/index.ts
+++ b/packages/expo-serve-sim/src/index.ts
@@ -1,0 +1,62 @@
+import { simMiddleware, type SimMiddlewareOptions } from "serve-sim/middleware";
+
+export type ExpoServeSimOptions = SimMiddlewareOptions;
+
+type ConnectMiddleware = (
+  req: any,
+  res: any,
+  next: (err?: unknown) => void,
+) => void;
+
+interface MetroLikeConfig {
+  server?: {
+    enhanceMiddleware?: (
+      middleware: ConnectMiddleware,
+      server: unknown,
+    ) => ConnectMiddleware;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+/**
+ * Patch a Metro config so the `serve-sim` preview UI is mounted on the dev
+ * server. Drop-in: the returned config is the same object, mutated in place.
+ *
+ * ```js
+ * const { getDefaultConfig } = require("expo/metro-config");
+ * const { withSimServe } = require("expo-serve-sim");
+ *
+ * module.exports = withSimServe(getDefaultConfig(__dirname));
+ * // → preview at http://localhost:8081/.sim
+ * ```
+ *
+ * Composes cleanly with an existing `server.enhanceMiddleware`: requests under
+ * the basePath are handled by serve-sim, anything else falls through to the
+ * downstream Metro middleware via `next()` — no `connect` dependency needed.
+ * Start `serve-sim` separately with `serve-sim --detach`.
+ */
+export function withSimServe<T extends MetroLikeConfig>(
+  config: T,
+  options?: ExpoServeSimOptions,
+): T {
+  if (!config.server) {
+    (config as MetroLikeConfig).server = {};
+  }
+  const server = config.server!;
+  const originalEnhanceMiddleware = server.enhanceMiddleware;
+  const sim = simMiddleware(options);
+
+  server.enhanceMiddleware = (metroMiddleware, metroServer) => {
+    const wrapped: ConnectMiddleware = (req, res, next) => {
+      sim(req, res, () => metroMiddleware(req, res, next));
+    };
+    return originalEnhanceMiddleware
+      ? originalEnhanceMiddleware(wrapped, metroServer)
+      : wrapped;
+  };
+
+  return config;
+}
+
+export type { SimMiddlewareOptions };

--- a/packages/serve-sim/README.md
+++ b/packages/serve-sim/README.md
@@ -95,31 +95,27 @@ Create a `.claude/launch.json` and define a server:
 
 Automatically start the serve-sim process with `npx expo start` and access the URL at `http://localhost:8081/.sim`.
 
-First, customize the `metro.config.js` file (`bunx expo customize`):
+Install the Expo integration package, customize `metro.config.js` (`bunx expo customize`), and wrap the config with `withSimServe`:
+
+```sh
+npm install --save-dev expo-serve-sim serve-sim
+```
 
 ```js
 // Learn more https://docs.expo.io/guides/customizing-metro
 const { getDefaultConfig } = require("expo/metro-config");
-const connect = require("connect");
-const { simMiddleware } = require("serve-sim/middleware");
+const { withSimServe } = require("expo-serve-sim");
 
 /** @type {import('expo/metro-config').MetroConfig} */
 const config = getDefaultConfig(__dirname);
 
-config.server = config.server || {};
-const originalEnhanceMiddleware = config.server.enhanceMiddleware;
-config.server.enhanceMiddleware = (metroMiddleware, server) => {
-  const middleware = originalEnhanceMiddleware
-    ? originalEnhanceMiddleware(metroMiddleware, server)
-    : metroMiddleware;
-  const app = connect();
-  app.use(simMiddleware({ basePath: "/.sim" }));
-  app.use(middleware);
-  return app;
-};
-
-module.exports = config;
+module.exports = withSimServe(config);
+// or: withSimServe(config, { basePath: "/.sim" })
 ```
+
+`withSimServe` accepts a Metro config and returns the same config with `server.enhanceMiddleware` patched to mount the preview. It composes with any existing `enhanceMiddleware` you've already set.
+
+Start the simulator stream separately with `npx serve-sim --detach`, then run `npx expo start` and open `http://localhost:8081/.sim`.
 
 ## Embed in your dev server
 


### PR DESCRIPTION
Replaces the verbose enhanceMiddleware + connect snippet in the README with a one-liner: `withSimServe(getDefaultConfig(__dirname))`. The helper mutates the Metro config in place and composes with any existing `server.enhanceMiddleware`, falling through to Metro's middleware via `next()` so no `connect` dependency is needed.