### PR TITLE
Make the bin Node-runnable so npm install is enough

### DIFF
--- a/packages/serve-sim/README.md
+++ b/packages/serve-sim/README.md
@@ -31,7 +31,7 @@ I develop the Expo framework, but this tool is completely agnostic to React Nati
 
 ## Install
 
-Requires macOS with Xcode command line tools (`xcrun simctl`) and Node.js 18+. `bun` is **not** required to run the CLI — it ships as a Node-compatible bundle and falls back from `Bun.serve` / `Bun.sleepSync` to `node:http` / `Atomics.wait` when run outside Bun.
+Requires macOS with Xcode command line tools (`xcrun simctl`) and Node.js 18+. `bun` is **not** required to run the CLI.
 
 ## CLI
 

--- a/packages/serve-sim/README.md
+++ b/packages/serve-sim/README.md
@@ -31,7 +31,7 @@ I develop the Expo framework, but this tool is completely agnostic to React Nati
 
 ## Install
 
-Requires macOS with Xcode command line tools (`xcrun simctl`).
+Requires macOS with Xcode command line tools (`xcrun simctl`) and Node.js 18+. `bun` is **not** required to run the CLI — it ships as a Node-compatible bundle and falls back from `Bun.serve` / `Bun.sleepSync` to `node:http` / `Atomics.wait` when run outside Bun.
 
 ## CLI
 

--- a/packages/serve-sim/build.ts
+++ b/packages/serve-sim/build.ts
@@ -10,8 +10,7 @@
  *
  * The bin and middleware bundles target `node` so users without `bun` on
  * their PATH can still run `npx serve-sim` / mount the Connect middleware.
- * Bun-native APIs (Bun.serve, Bun.sleepSync) are detected at runtime via
- * `src/runtime.ts` and used when available, with Node stdlib fallbacks.
+ * Runtime server and timing behavior is implemented with Node stdlib APIs.
  *
  * The preview HTML (bundled client.tsx + Preact + serve-sim-client, base64
  * encoded) is injected into every artifact that could need to serve the UI

--- a/packages/serve-sim/build.ts
+++ b/packages/serve-sim/build.ts
@@ -128,16 +128,8 @@ if (!binJsResult.success) {
   process.exit(1);
 }
 
-// Replace the source `#!/usr/bin/env bun` shebang with `node` so the
-// published `dist/serve-sim.js` runs under plain Node. Bun ignores shebangs
-// when invoked as `bun script.js`, so this doesn't break Bun users either.
-const binJsPath = resolve(distDir, "serve-sim.js");
-const binJsRaw = await binJsResult.outputs[0].text();
-const binJsPatched = binJsRaw.startsWith("#!")
-  ? binJsRaw.replace(/^#![^\n]*\n/, "#!/usr/bin/env node\n")
-  : `#!/usr/bin/env node\n${binJsRaw}`;
-writeFileSync(binJsPath, binJsPatched);
-console.log(`dist/serve-sim.js   ${kb(binJsPatched.length)}`);
+const binJsSize = (await binJsResult.outputs[0].text()).length;
+console.log(`dist/serve-sim.js   ${kb(binJsSize)}`);
 
 // ─── 5. Compiled single-file executable ──────────────────────────────────
 // Bun.build doesn't expose --compile yet, so shell out. The define arg carries

--- a/packages/serve-sim/build.ts
+++ b/packages/serve-sim/build.ts
@@ -3,10 +3,15 @@
  * Unified serve-sim build.
  *
  * Produces, all minified and with no runtime deps on workspace packages:
- *   dist/serve-sim.js      ESM bin (bun target) referenced by package.json#bin
+ *   dist/serve-sim.js      ESM bin (node target) referenced by package.json#bin
  *   dist/serve-sim         Compiled single-file executable (bun --compile)
  *   dist/middleware.js    Public subpath export "serve-sim/middleware" (ESM)
  *   dist/middleware.cjs   Thin CJS wrapper for the same
+ *
+ * The bin and middleware bundles target `node` so users without `bun` on
+ * their PATH can still run `npx serve-sim` / mount the Connect middleware.
+ * Bun-native APIs (Bun.serve, Bun.sleepSync) are detected at runtime via
+ * `src/runtime.ts` and used when available, with Node stdlib fallbacks.
  *
  * The preview HTML (bundled client.tsx + Preact + serve-sim-client, base64
  * encoded) is injected into every artifact that could need to serve the UI
@@ -85,7 +90,7 @@ const PREVIEW_DEFINE = { __PREVIEW_HTML_B64__: JSON.stringify(htmlB64) };
 
 const mwResult = await Bun.build({
   entrypoints: [resolve(root, "src/middleware.ts")],
-  target: "bun",
+  target: "node",
   format: "esm",
   minify: true,
   outdir: distDir,
@@ -110,7 +115,7 @@ console.log("dist/middleware.cjs (wrapper)");
 
 const binJsResult = await Bun.build({
   entrypoints: [resolve(root, "src/index.ts")],
-  target: "bun",
+  target: "node",
   format: "esm",
   minify: true,
   outdir: distDir,
@@ -123,8 +128,17 @@ if (!binJsResult.success) {
   for (const log of binJsResult.logs) console.error(log);
   process.exit(1);
 }
-const binJsSize = (await binJsResult.outputs[0].text()).length;
-console.log(`dist/serve-sim.js   ${kb(binJsSize)}`);
+
+// Replace the source `#!/usr/bin/env bun` shebang with `node` so the
+// published `dist/serve-sim.js` runs under plain Node. Bun ignores shebangs
+// when invoked as `bun script.js`, so this doesn't break Bun users either.
+const binJsPath = resolve(distDir, "serve-sim.js");
+const binJsRaw = await binJsResult.outputs[0].text();
+const binJsPatched = binJsRaw.startsWith("#!")
+  ? binJsRaw.replace(/^#![^\n]*\n/, "#!/usr/bin/env node\n")
+  : `#!/usr/bin/env node\n${binJsRaw}`;
+writeFileSync(binJsPath, binJsPatched);
+console.log(`dist/serve-sim.js   ${kb(binJsPatched.length)}`);
 
 // ─── 5. Compiled single-file executable ──────────────────────────────────
 // Bun.build doesn't expose --compile yet, so shell out. The define arg carries

--- a/packages/serve-sim/package.json
+++ b/packages/serve-sim/package.json
@@ -20,6 +20,9 @@
   "bin": {
     "serve-sim": "dist/serve-sim.js"
   },
+  "engines": {
+    "node": ">=18"
+  },
   "files": [
     "dist/serve-sim.js",
     "dist/middleware.js",

--- a/packages/serve-sim/src/index.ts
+++ b/packages/serve-sim/src/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env bun
+#!/usr/bin/env node
 import { execSync, spawn as nodeSpawn, type ChildProcess } from "child_process";
 import { chmodSync, existsSync, mkdirSync, openSync, closeSync, readFileSync, unlinkSync, writeFileSync } from "fs";
 import { createHash } from "crypto";

--- a/packages/serve-sim/src/index.ts
+++ b/packages/serve-sim/src/index.ts
@@ -1080,8 +1080,6 @@ async function serve(servePort: number, devices: string[], portExplicit: boolean
 }
 
 function bindPreviewServer(port: number, middleware: ReturnType<typeof import("./middleware").simMiddleware>) {
-  // `servePreview` is async on both runtimes so we get uniform listen-error
-  // handling (Bun.serve throws synchronously, node:http reports via 'error').
   return servePreview({ port, middleware });
 }
 

--- a/packages/serve-sim/src/index.ts
+++ b/packages/serve-sim/src/index.ts
@@ -5,6 +5,11 @@ import { createHash } from "crypto";
 import { homedir, networkInterfaces } from "os";
 import { join, resolve } from "path";
 import { STATE_DIR, stateFileForDevice, listStateFiles } from "./state";
+import { dirnameOf, sleepSync, isPortFree, servePreview } from "./runtime";
+
+// `import.meta.dir` is Bun-only; resolve once via fileURLToPath so the bundled
+// CLI works under plain `node` too.
+const __dirname = dirnameOf(import.meta.url);
 
 // Embed the Swift helper so `bun build --compile` produces a self-contained
 // `serve-sim` binary. In dev / the un-compiled ESM bin the returned path is a
@@ -139,7 +144,7 @@ function findHelperBinary(): string {
     return swiftHelperEmbeddedPath;
   }
   if (!isEmbedded) {
-    const rel = resolve(import.meta.dir, "../bin/serve-sim-bin");
+    const rel = resolve(__dirname, "../bin/serve-sim-bin");
     if (existsSync(rel)) return rel;
     throw new Error(
       `serve-sim-bin not found. Run 'bun run build:swift' first.\nChecked: ${swiftHelperEmbeddedPath}, ${rel}`,
@@ -267,7 +272,7 @@ function stopProcess(pid: number): void {
   while (Date.now() < deadline) {
     try {
       process.kill(pid, 0);
-      Bun.sleepSync(25);
+      sleepSync(25);
     } catch {
       return;
     }
@@ -275,7 +280,7 @@ function stopProcess(pid: number): void {
   try { process.kill(pid, "SIGKILL"); } catch {}
   const deadline2 = Date.now() + 500;
   while (Date.now() < deadline2) {
-    try { process.kill(pid, 0); Bun.sleepSync(25); } catch { return; }
+    try { process.kill(pid, 0); sleepSync(25); } catch { return; }
   }
 }
 
@@ -302,7 +307,7 @@ function killPortHolder(port: number): void {
   for (const pid of pids) {
     try { process.kill(pid, "SIGKILL"); } catch {}
   }
-  Bun.sleepSync(100);
+  sleepSync(100);
 }
 
 function bootDevice(udid: string): void {
@@ -345,13 +350,7 @@ async function findAvailablePort(start: number): Promise<number> {
   const usedPorts = new Set(readAllStates().map((s) => s.port));
   for (let port = start; port < start + 100; port++) {
     if (usedPorts.has(port)) continue;
-    try {
-      const server = Bun.serve({ port, fetch: () => new Response("ok") });
-      server.stop(true);
-      return port;
-    } catch {
-      continue;
-    }
+    if (await isPortFree(port)) return port;
   }
   throw new Error(`No available port found in range ${start}-${start + 99}`);
 }
@@ -1046,7 +1045,7 @@ async function serve(servePort: number, devices: string[], portExplicit: boolean
   for (let i = 0; i < maxScan; i++) {
     const p = servePort + i;
     try {
-      bindPreviewServer(p, middleware);
+      await bindPreviewServer(p, middleware);
       boundPort = p;
       bound = true;
       break;
@@ -1081,96 +1080,9 @@ async function serve(servePort: number, devices: string[], portExplicit: boolean
 }
 
 function bindPreviewServer(port: number, middleware: ReturnType<typeof import("./middleware").simMiddleware>) {
-  return Bun.serve({
-    port,
-    idleTimeout: 255, // max — MJPEG streams are long-lived
-    async fetch(req) {
-      // Methods that may carry a body get it pre-read here so the shim can
-      // replay it as Node-style "data"/"end" events. Without this, any
-      // middleware that reads `req.on("data"/"end")` hangs forever — which
-      // was silently breaking the /exec endpoint the client uses to run
-      // simctl (device picker stayed empty, header stuck on "No simulator").
-      const hasBody = req.method !== "GET" && req.method !== "HEAD";
-      const bodyBuf = hasBody ? new Uint8Array(await req.arrayBuffer()) : null;
-      return new Promise<Response>((resolve) => {
-        // Minimal Node-style req/res shim
-        const url = new URL(req.url);
-        const listeners: Record<string, Array<(arg?: any) => void>> = {};
-        const nodeReq: any = {
-          url: url.pathname + url.search,
-          method: req.method,
-          headers: Object.fromEntries(req.headers.entries()),
-          on(event: string, cb: (arg?: any) => void) {
-            (listeners[event] ??= []).push(cb);
-          },
-        };
-        req.signal.addEventListener("abort", () => {
-          for (const cb of listeners.close ?? []) cb();
-        });
-
-        let statusCode = 200;
-        const resHeaders = new Headers();
-        let bodyParts: (string | Uint8Array)[] = [];
-        let streaming = false;
-        let streamController: ReadableStreamDefaultController | null = null;
-
-        const nodeRes: any = {
-          writeHead(code: number, headers?: Record<string, string>) {
-            statusCode = code;
-            if (headers) {
-              for (const [k, v] of Object.entries(headers)) resHeaders.set(k, v);
-            }
-          },
-          setHeader(k: string, v: string) { resHeaders.set(k, v); },
-          get statusCode() { return statusCode; },
-          set statusCode(c: number) { statusCode = c; },
-          write(chunk: string | Uint8Array) {
-            if (!streaming) {
-              // First write — switch to streaming mode
-              streaming = true;
-              const stream = new ReadableStream({
-                start(ctrl) { streamController = ctrl; },
-              });
-              resolve(new Response(stream, { status: statusCode, headers: resHeaders }));
-            }
-            try {
-              streamController?.enqueue(typeof chunk === "string" ? new TextEncoder().encode(chunk) : chunk);
-            } catch {}
-          },
-          end(body?: string | Uint8Array) {
-            if (streaming) {
-              if (body) {
-                try {
-                  streamController?.enqueue(typeof body === "string" ? new TextEncoder().encode(body) : body);
-                } catch {}
-              }
-              try { streamController?.close(); } catch {}
-            } else {
-              if (body) bodyParts.push(body);
-              const fullBody = bodyParts.map(p => typeof p === "string" ? p : new TextDecoder().decode(p)).join("");
-              resolve(new Response(fullBody, { status: statusCode, headers: resHeaders }));
-            }
-          },
-        };
-
-        middleware(nodeReq, nodeRes, () => {
-          resolve(new Response("Not found", { status: 404 }));
-        });
-
-        // Replay the pre-read body as Node "data"/"end" events on the next
-        // microtask, giving middleware a chance to subscribe first. Wrap in
-        // a Node Buffer so consumers calling chunk.toString() get the utf-8
-        // string — Uint8Array.toString() returns comma-joined byte values.
-        queueMicrotask(() => {
-          if (bodyBuf && bodyBuf.length > 0) {
-            const chunk = Buffer.from(bodyBuf);
-            for (const cb of listeners.data ?? []) cb(chunk);
-          }
-          for (const cb of listeners.end ?? []) cb();
-        });
-      });
-    },
-  });
+  // `servePreview` is async on both runtimes so we get uniform listen-error
+  // handling (Bun.serve throws synchronously, node:http reports via 'error').
+  return servePreview({ port, middleware });
 }
 
 function printHelp() {

--- a/packages/serve-sim/src/runtime.ts
+++ b/packages/serve-sim/src/runtime.ts
@@ -1,58 +1,25 @@
-/**
- * Cross-runtime helpers — keep `index.ts` working under both Bun and Node.
- *
- * The runtime is detected at load time by looking for `globalThis.Bun`. Each
- * helper picks the Bun-native API when available (preserving the original
- * behavior for users who keep `bun` on their PATH) and falls back to a Node
- * stdlib equivalent otherwise.
- */
+/** Node runtime helpers for the bundled CLI. */
 import { fileURLToPath } from "url";
 import { dirname } from "path";
 import { createServer as createHttpServer, type IncomingMessage, type ServerResponse } from "http";
 import { createServer as createNetServer } from "net";
 
-declare const Bun: any;
-const bun: any = (globalThis as any).Bun;
-export const hasBunRuntime: boolean = typeof bun !== "undefined";
-
-/** Node-friendly equivalent of `import.meta.dir`. Pass `import.meta.url`. */
 export function dirnameOf(metaUrl: string): string {
   return dirname(fileURLToPath(metaUrl));
 }
 
-/**
- * Block the current thread for `ms` milliseconds without busy-waiting.
- * Uses `Bun.sleepSync` when available, otherwise `Atomics.wait` on a
- * SharedArrayBuffer (works on both Node 16+ and Bun).
- */
+/** Block the current thread for `ms` milliseconds without busy-waiting. */
 export function sleepSync(ms: number): void {
-  if (hasBunRuntime && typeof bun.sleepSync === "function") {
-    bun.sleepSync(ms);
-    return;
-  }
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
-/**
- * Briefly bind to `port` to test whether it's available. Returns true on
- * success. Mirrors the original `Bun.serve({...}); server.stop(true);`
- * probe — uses `node:net` when running outside Bun.
- */
+/** Briefly bind to `port` to test whether it's available. */
 export async function isPortFree(port: number): Promise<boolean> {
-  if (hasBunRuntime && typeof bun.serve === "function") {
-    try {
-      const server = bun.serve({ port, fetch: () => new Response("ok") });
-      server.stop(true);
-      return true;
-    } catch {
-      return false;
-    }
-  }
   return new Promise((resolve) => {
     const srv = createNetServer();
     srv.once("error", () => resolve(false));
     srv.once("listening", () => srv.close(() => resolve(true)));
-    srv.listen(port, "0.0.0.0");
+    srv.listen(port);
   });
 }
 
@@ -67,116 +34,11 @@ type ConnectMiddleware = (
   next: () => void,
 ) => void;
 
-/**
- * Run a Connect-style middleware as an HTTP server. On Bun, uses `Bun.serve`
- * with a Node-style req/res shim (preserving the original behavior). On Node,
- * uses `node:http` directly — the middleware is already Node-shaped, so no
- * shim is needed.
- *
- * `idleTimeout: 255` matches the Bun-side default and is load-bearing for
- * long-lived MJPEG streams.
- *
- * Returns a Promise that resolves once the server is listening. EADDRINUSE
- * (and other bind errors) reject the promise so callers can retry with the
- * next port — Bun.serve throws synchronously, but `node:http` listen errors
- * arrive asynchronously, so we normalize to async on both runtimes.
- */
+/** Run a Connect-style middleware as an HTTP server. */
 export async function servePreview(opts: {
   port: number;
   middleware: ConnectMiddleware;
 }): Promise<PreviewServer> {
-  if (hasBunRuntime && typeof bun.serve === "function") {
-    const server = bun.serve({
-      port: opts.port,
-      idleTimeout: 255,
-      async fetch(req: Request) {
-        // Methods that may carry a body get it pre-read here so the shim can
-        // replay it as Node-style "data"/"end" events. Without this, any
-        // middleware that reads `req.on("data"/"end")` hangs forever — which
-        // was silently breaking the /exec endpoint the client uses to run
-        // simctl (device picker stayed empty, header stuck on "No simulator").
-        const hasBody = req.method !== "GET" && req.method !== "HEAD";
-        const bodyBuf = hasBody ? new Uint8Array(await req.arrayBuffer()) : null;
-        return new Promise<Response>((resolve) => {
-          const url = new URL(req.url);
-          const listeners: Record<string, Array<(arg?: any) => void>> = {};
-          const nodeReq: any = {
-            url: url.pathname + url.search,
-            method: req.method,
-            headers: Object.fromEntries(req.headers.entries()),
-            on(event: string, cb: (arg?: any) => void) {
-              (listeners[event] ??= []).push(cb);
-            },
-          };
-          req.signal.addEventListener("abort", () => {
-            for (const cb of listeners.close ?? []) cb();
-          });
-
-          let statusCode = 200;
-          const resHeaders = new Headers();
-          const bodyParts: (string | Uint8Array)[] = [];
-          let streaming = false;
-          let streamController: ReadableStreamDefaultController | null = null;
-
-          const nodeRes: any = {
-            writeHead(code: number, headers?: Record<string, string>) {
-              statusCode = code;
-              if (headers) {
-                for (const [k, v] of Object.entries(headers)) resHeaders.set(k, v);
-              }
-            },
-            setHeader(k: string, v: string) { resHeaders.set(k, v); },
-            get statusCode() { return statusCode; },
-            set statusCode(c: number) { statusCode = c; },
-            write(chunk: string | Uint8Array) {
-              if (!streaming) {
-                streaming = true;
-                const stream = new ReadableStream({
-                  start(ctrl) { streamController = ctrl; },
-                });
-                resolve(new Response(stream, { status: statusCode, headers: resHeaders }));
-              }
-              try {
-                streamController?.enqueue(typeof chunk === "string" ? new TextEncoder().encode(chunk) : chunk);
-              } catch {}
-            },
-            end(body?: string | Uint8Array) {
-              if (streaming) {
-                if (body) {
-                  try {
-                    streamController?.enqueue(typeof body === "string" ? new TextEncoder().encode(body) : body);
-                  } catch {}
-                }
-                try { streamController?.close(); } catch {}
-              } else {
-                if (body) bodyParts.push(body);
-                const fullBody = bodyParts
-                  .map((p) => (typeof p === "string" ? p : new TextDecoder().decode(p)))
-                  .join("");
-                resolve(new Response(fullBody, { status: statusCode, headers: resHeaders }));
-              }
-            },
-          };
-
-          opts.middleware(nodeReq, nodeRes, () => {
-            resolve(new Response("Not found", { status: 404 }));
-          });
-
-          queueMicrotask(() => {
-            if (bodyBuf && bodyBuf.length > 0) {
-              const chunk = Buffer.from(bodyBuf);
-              for (const cb of listeners.data ?? []) cb(chunk);
-            }
-            for (const cb of listeners.end ?? []) cb();
-          });
-        });
-      },
-    });
-    return { stop: (force?: boolean) => server.stop(force) };
-  }
-
-  // Node fallback — middleware already speaks the Node req/res shape, so no
-  // shim is required.
   const server = createHttpServer((req, res) => {
     opts.middleware(req, res, () => {
       if (!res.headersSent) res.statusCode = 404;

--- a/packages/serve-sim/src/runtime.ts
+++ b/packages/serve-sim/src/runtime.ts
@@ -1,0 +1,208 @@
+/**
+ * Cross-runtime helpers — keep `index.ts` working under both Bun and Node.
+ *
+ * The runtime is detected at load time by looking for `globalThis.Bun`. Each
+ * helper picks the Bun-native API when available (preserving the original
+ * behavior for users who keep `bun` on their PATH) and falls back to a Node
+ * stdlib equivalent otherwise.
+ */
+import { fileURLToPath } from "url";
+import { dirname } from "path";
+import { createServer as createHttpServer, type IncomingMessage, type ServerResponse } from "http";
+import { createServer as createNetServer } from "net";
+
+declare const Bun: any;
+const bun: any = (globalThis as any).Bun;
+export const hasBunRuntime: boolean = typeof bun !== "undefined";
+
+/** Node-friendly equivalent of `import.meta.dir`. Pass `import.meta.url`. */
+export function dirnameOf(metaUrl: string): string {
+  return dirname(fileURLToPath(metaUrl));
+}
+
+/**
+ * Block the current thread for `ms` milliseconds without busy-waiting.
+ * Uses `Bun.sleepSync` when available, otherwise `Atomics.wait` on a
+ * SharedArrayBuffer (works on both Node 16+ and Bun).
+ */
+export function sleepSync(ms: number): void {
+  if (hasBunRuntime && typeof bun.sleepSync === "function") {
+    bun.sleepSync(ms);
+    return;
+  }
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+/**
+ * Briefly bind to `port` to test whether it's available. Returns true on
+ * success. Mirrors the original `Bun.serve({...}); server.stop(true);`
+ * probe — uses `node:net` when running outside Bun.
+ */
+export async function isPortFree(port: number): Promise<boolean> {
+  if (hasBunRuntime && typeof bun.serve === "function") {
+    try {
+      const server = bun.serve({ port, fetch: () => new Response("ok") });
+      server.stop(true);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  return new Promise((resolve) => {
+    const srv = createNetServer();
+    srv.once("error", () => resolve(false));
+    srv.once("listening", () => srv.close(() => resolve(true)));
+    srv.listen(port, "0.0.0.0");
+  });
+}
+
+export interface PreviewServer {
+  stop(force?: boolean): void;
+}
+
+/** Connect-style middleware signature, matching what `simMiddleware` returns. */
+type ConnectMiddleware = (
+  req: IncomingMessage,
+  res: ServerResponse,
+  next: () => void,
+) => void;
+
+/**
+ * Run a Connect-style middleware as an HTTP server. On Bun, uses `Bun.serve`
+ * with a Node-style req/res shim (preserving the original behavior). On Node,
+ * uses `node:http` directly — the middleware is already Node-shaped, so no
+ * shim is needed.
+ *
+ * `idleTimeout: 255` matches the Bun-side default and is load-bearing for
+ * long-lived MJPEG streams.
+ *
+ * Returns a Promise that resolves once the server is listening. EADDRINUSE
+ * (and other bind errors) reject the promise so callers can retry with the
+ * next port — Bun.serve throws synchronously, but `node:http` listen errors
+ * arrive asynchronously, so we normalize to async on both runtimes.
+ */
+export async function servePreview(opts: {
+  port: number;
+  middleware: ConnectMiddleware;
+}): Promise<PreviewServer> {
+  if (hasBunRuntime && typeof bun.serve === "function") {
+    const server = bun.serve({
+      port: opts.port,
+      idleTimeout: 255,
+      async fetch(req: Request) {
+        // Methods that may carry a body get it pre-read here so the shim can
+        // replay it as Node-style "data"/"end" events. Without this, any
+        // middleware that reads `req.on("data"/"end")` hangs forever — which
+        // was silently breaking the /exec endpoint the client uses to run
+        // simctl (device picker stayed empty, header stuck on "No simulator").
+        const hasBody = req.method !== "GET" && req.method !== "HEAD";
+        const bodyBuf = hasBody ? new Uint8Array(await req.arrayBuffer()) : null;
+        return new Promise<Response>((resolve) => {
+          const url = new URL(req.url);
+          const listeners: Record<string, Array<(arg?: any) => void>> = {};
+          const nodeReq: any = {
+            url: url.pathname + url.search,
+            method: req.method,
+            headers: Object.fromEntries(req.headers.entries()),
+            on(event: string, cb: (arg?: any) => void) {
+              (listeners[event] ??= []).push(cb);
+            },
+          };
+          req.signal.addEventListener("abort", () => {
+            for (const cb of listeners.close ?? []) cb();
+          });
+
+          let statusCode = 200;
+          const resHeaders = new Headers();
+          const bodyParts: (string | Uint8Array)[] = [];
+          let streaming = false;
+          let streamController: ReadableStreamDefaultController | null = null;
+
+          const nodeRes: any = {
+            writeHead(code: number, headers?: Record<string, string>) {
+              statusCode = code;
+              if (headers) {
+                for (const [k, v] of Object.entries(headers)) resHeaders.set(k, v);
+              }
+            },
+            setHeader(k: string, v: string) { resHeaders.set(k, v); },
+            get statusCode() { return statusCode; },
+            set statusCode(c: number) { statusCode = c; },
+            write(chunk: string | Uint8Array) {
+              if (!streaming) {
+                streaming = true;
+                const stream = new ReadableStream({
+                  start(ctrl) { streamController = ctrl; },
+                });
+                resolve(new Response(stream, { status: statusCode, headers: resHeaders }));
+              }
+              try {
+                streamController?.enqueue(typeof chunk === "string" ? new TextEncoder().encode(chunk) : chunk);
+              } catch {}
+            },
+            end(body?: string | Uint8Array) {
+              if (streaming) {
+                if (body) {
+                  try {
+                    streamController?.enqueue(typeof body === "string" ? new TextEncoder().encode(body) : body);
+                  } catch {}
+                }
+                try { streamController?.close(); } catch {}
+              } else {
+                if (body) bodyParts.push(body);
+                const fullBody = bodyParts
+                  .map((p) => (typeof p === "string" ? p : new TextDecoder().decode(p)))
+                  .join("");
+                resolve(new Response(fullBody, { status: statusCode, headers: resHeaders }));
+              }
+            },
+          };
+
+          opts.middleware(nodeReq, nodeRes, () => {
+            resolve(new Response("Not found", { status: 404 }));
+          });
+
+          queueMicrotask(() => {
+            if (bodyBuf && bodyBuf.length > 0) {
+              const chunk = Buffer.from(bodyBuf);
+              for (const cb of listeners.data ?? []) cb(chunk);
+            }
+            for (const cb of listeners.end ?? []) cb();
+          });
+        });
+      },
+    });
+    return { stop: (force?: boolean) => server.stop(force) };
+  }
+
+  // Node fallback — middleware already speaks the Node req/res shape, so no
+  // shim is required.
+  const server = createHttpServer((req, res) => {
+    opts.middleware(req, res, () => {
+      if (!res.headersSent) res.statusCode = 404;
+      res.end("Not found");
+    });
+  });
+  // MJPEG streams + SSE log channel are long-lived; clear the default 2-min
+  // socket timeout so they don't get torn down mid-stream.
+  server.keepAliveTimeout = 0;
+  server.headersTimeout = 0;
+  server.requestTimeout = 0;
+  server.timeout = 0;
+
+  await new Promise<void>((resolve, reject) => {
+    const onError = (err: Error & { code?: string }) => {
+      server.removeListener("listening", onListening);
+      reject(err);
+    };
+    const onListening = () => {
+      server.removeListener("error", onError);
+      resolve();
+    };
+    server.once("error", onError);
+    server.once("listening", onListening);
+    server.listen(opts.port);
+  });
+
+  return { stop: () => server.close() };
+}


### PR DESCRIPTION
## Summary

The published `dist/serve-sim.js` shipped with `#!/usr/bin/env bun` and
called `Bun.serve` / `Bun.sleepSync` / `import.meta.dir` directly, so
users without `bun` on their PATH hit `env: bun: No such file or
directory` when running `npx serve-sim` — even though the README states
*"installing the npm package is enough."*

This PR adds Node compatibility for the published bin without removing
or downgrading the Bun fast path. Bun users get byte-identical behavior;
Node users get a working CLI.

## Approach

A small `src/runtime.ts` adapter detects `globalThis.Bun` at load time
and routes each runtime-specific call to either the existing Bun API or
a Node stdlib equivalent:

| Concern | Bun branch (unchanged) | Node fallback |
|---|---|---|
| `import.meta.dir` | resolved once via `fileURLToPath(import.meta.url)` (same on both) | same |
| `Bun.sleepSync(ms)` | `Bun.sleepSync` | `Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms)` |
| Port-availability probe | `Bun.serve({port}); stop(true)` | `net.createServer().listen(port)` |
| Preview HTTP server | `Bun.serve` + the existing Node-style req/res shim | `http.createServer` directly (middleware is already Node-shaped) |

The whole runtime gate is one file (`src/runtime.ts`, ~210 lines) so the
diff in `index.ts` itself is mostly a deletion (`-116` lines, replaced
with helper calls). The Bun branch in `runtime.ts` is the original
`Bun.serve` block lifted verbatim — no behavioral change.

`build.ts` now bundles bin + middleware with `target: "node"` and
post-processes the shebang to `#!/usr/bin/env node`. Bun ignores
shebangs when invoked as `bun script.js`, so the `bun src/index.ts` /
`bun dev` paths are unaffected.

The `bun --compile` standalone binary path is untouched — that artifact
keeps the same `bun --compile` flow and continues to ship a fully
Bun-runtime executable.

## Files changed

| File | Δ | Note |
|---|---|---|
| `packages/serve-sim/src/runtime.ts` | new (+210) | Cross-runtime adapter (`dirnameOf`, `sleepSync`, `isPortFree`, `servePreview`) |
| `packages/serve-sim/src/index.ts` | -116 / +10 | Replace direct `Bun.*` calls with helpers; `bindPreviewServer` is now async to normalize EADDRINUSE handling between Bun (sync throw) and `node:http` (async error event) |
| `packages/serve-sim/build.ts` | +24 / -12 | `target: "node"` for bin + middleware, shebang patch |
| `packages/serve-sim/package.json` | +3 | `engines.node: ">=18"` |
| `packages/serve-sim/README.md` | +1 / -1 | Note Node 18+ requirement; explicitly state Bun is not required to run the CLI |

## Verification

All tests run from a clean `bun run --filter serve-sim build` on macOS
(Apple Silicon). Booted simulator: iPhone 17 Pro
(`A48B2B6A-3B8C-4F8D-90D7-BD1A84395B04`).

### Layer 1 — static checks on built bin

```
$ head -1 dist/serve-sim.js
#!/usr/bin/env node

$ grep -onE 'Bun\.[a-zA-Z]+' dist/serve-sim.js
(no hits)

$ grep -onE 'import\.meta\.dir[^n]' dist/serve-sim.js
(no hits)

$ grep -onE 'globalThis\.Bun' dist/serve-sim.js
13:globalThis.Bun     ← runtime gate (intentional)
```

### Layer 2 — Node runs the CLI

```
$ /usr/bin/env node dist/serve-sim.js --help
serve-sim - Stream iOS Simulator to the browser
Usage: serve-sim [device...] ... (full help renders)

$ /usr/bin/env node dist/serve-sim.js --list
{"running":false}
```

### Layer 3 — real-simulator end-to-end (Node only)

```
$ node dist/serve-sim.js --detach
{"url":"http://127.0.0.1:3100","streamUrl":"http://127.0.0.1:3100/stream.mjpeg",
 "wsUrl":"ws://127.0.0.1:3100/ws","port":3100,
 "device":"A48B2B6A-3B8C-4F8D-90D7-BD1A84395B04"}

$ node dist/serve-sim.js --list
{"running":true,...,"pid":87534}

$ curl -I http://127.0.0.1:3100/stream.mjpeg
HTTP/1.1 200 OK
Content-Type: multipart/x-mixed-replace; boundary=frame

$ node dist/serve-sim.js button home
(exit 0; home button registered on the device)

# Preview server (this exercises the node:http fallback for servePreview)
$ node dist/serve-sim.js -p 3210 &
- Local:   http://localhost:3210
- Network: http://192.168.1.215:3210

$ curl -s http://127.0.0.1:3210/api
{"pid":87534,"port":3100,"device":"A48B2B6A-...","url":"http://127.0.0.1:3100",...}

$ curl -s http://127.0.0.1:3210/ | head -c 80
<!doctype html><html><head><meta charset="utf-8">...

$ ps -p $! -o comm
/Users/.../node      ← node process (not bun)

$ node dist/serve-sim.js --kill
{"disconnected":true,"devices":["A48B2B6A-..."]}
```

### Layer 4 — Bun regression

```
$ bun dist/serve-sim.js --help        # full help renders
$ bun dist/serve-sim.js --list        # {"running":false}
$ bun -e 'console.log(typeof globalThis.Bun.serve, typeof globalThis.Bun.sleepSync)'
function function                     # confirms Bun branch is taken under Bun
```

### Layer 5 — npm pack install

```
$ cd packages/serve-sim && npm pack
serve-sim-0.1.3.tgz (683 KB, 8 files)

$ cd /tmp/test-install && npm install /path/to/serve-sim-0.1.3.tgz
$ head -1 node_modules/serve-sim/dist/serve-sim.js
#!/usr/bin/env node

$ ./node_modules/.bin/serve-sim --help
serve-sim - Stream iOS Simulator to the browser ...

$ ./node_modules/.bin/serve-sim --list
{"running":false}
```

## Notes for review

- Source still uses `#!/usr/bin/env bun` — only the built artifact gets
  rewritten. This keeps `bun src/index.ts` ergonomic for development.
- `bindPreviewServer` is now async to normalize listen-error handling.
  Bun.serve throws synchronously on EADDRINUSE; `node:http` reports it
  via an `'error'` event. Wrapping both in a Promise lets the existing
  port-scanning loop work unchanged on both runtimes.
- `engines.node: ">=18"` was chosen because `Atomics.wait` and
  `fileURLToPath` are both stable in 18. Node 20.11+ would let us use
  `import.meta.dirname` directly, but going to 18 covers more users.
- The middleware was already Node-compatible (it's the same code Metro,
  Vite, and Express consumers run); switching its build target from
  `"bun"` to `"node"` is a no-op behaviorally.