### PR TITLE
[codex] Keep preview server alive

### DIFF
--- a/packages/serve-sim/src/index.ts
+++ b/packages/serve-sim/src/index.ts
@@ -1041,12 +1041,13 @@ async function serve(servePort: number, devices: string[], portExplicit: boolean
   // Try requested port; if busy and the user didn't pin it, scan forward.
   const maxScan = portExplicit ? 1 : 50;
   let boundPort = servePort;
+  let previewServer: ReturnType<typeof Bun.serve> | null = null;
   let lastErr: unknown;
   let bound = false;
   for (let i = 0; i < maxScan; i++) {
     const p = servePort + i;
     try {
-      bindPreviewServer(p, middleware);
+      previewServer = bindPreviewServer(p, middleware);
       boundPort = p;
       bound = true;
       break;
@@ -1074,9 +1075,16 @@ async function serve(servePort: number, devices: string[], portExplicit: boolean
   if (networkIP) console.log(`  - Network: http://${networkIP}:${boundPort}`);
   console.log("");
 
+  const keepAlive = setInterval(() => {}, 1 << 30);
+
   // Exit cleanly on Ctrl+C
-  process.on("SIGINT", () => process.exit(0));
-  process.on("SIGTERM", () => process.exit(0));
+  const shutdown = () => {
+    clearInterval(keepAlive);
+    previewServer?.stop(true);
+    process.exit(0);
+  };
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
   await new Promise(() => {});
 }
 


### PR DESCRIPTION
## Summary

Keep the preview server process alive after binding so `serve-sim` continues serving the browser UI instead of exiting immediately after printing the local URL.

## Root Cause

The preview path called `bindPreviewServer(...)` without retaining the returned `Bun.serve` instance, then awaited an unresolved Promise. In this runtime path, the process could exit after printing the preview URL, leaving `localhost:3200` unavailable and causing browser checks to fail with `ERR_CONNECTION_REFUSED`.

## Changes

- Retain the preview `Bun.serve` instance after a successful bind.
- Add an explicit keep-alive timer for the preview process.
- Stop the retained server during SIGINT/SIGTERM shutdown.

## Validation

- `bun run --filter serve-sim build`
- Started the built preview server on port 3200 and verified `GET /api` returned the active simulator stream state.
- Verified via Playwright that the preview loaded as `Simulator - iPhone 16e` and reported the stream as live.