### PR TITLE
Fix multiple preview instances

### DIFF
--- a/packages/serve-sim/src/__tests__/middleware-selection.test.ts
+++ b/packages/serve-sim/src/__tests__/middleware-selection.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { selectServeSimState, type ServeSimState } from "../middleware";
+
+const states: ServeSimState[] = [
+  {
+    pid: 101,
+    port: 3100,
+    device: "DEVICE-A",
+    url: "http://127.0.0.1:3100",
+    streamUrl: "http://127.0.0.1:3100/stream.mjpeg",
+    wsUrl: "ws://127.0.0.1:3100/ws",
+  },
+  {
+    pid: 102,
+    port: 3101,
+    device: "DEVICE-B",
+    url: "http://127.0.0.1:3101",
+    streamUrl: "http://127.0.0.1:3101/stream.mjpeg",
+    wsUrl: "ws://127.0.0.1:3101/ws",
+  },
+];
+
+describe("selectServeSimState", () => {
+  test("keeps existing first-state behavior when no device is requested", () => {
+    expect(selectServeSimState(states)?.device).toBe("DEVICE-A");
+  });
+
+  test("selects the requested device state", () => {
+    expect(selectServeSimState(states, "DEVICE-B")?.device).toBe("DEVICE-B");
+  });
+
+  test("returns null when the requested device is not running", () => {
+    expect(selectServeSimState(states, "DEVICE-C")).toBeNull();
+  });
+});

--- a/packages/serve-sim/src/client/client.tsx
+++ b/packages/serve-sim/src/client/client.tsx
@@ -152,6 +152,7 @@ declare global {
       port: number;
       device: string;
       logsEndpoint?: string;
+      appStateEndpoint?: string;
     };
   }
 }
@@ -581,11 +582,14 @@ function BootEmptyState({
       // race where the user sees the empty state again because we reloaded
       // before serve-sim wrote its server-*.json.
       const deadline = Date.now() + 15_000;
+      const apiUrl = `/api?device=${encodeURIComponent(d.udid)}`;
       while (Date.now() < deadline) {
         try {
-          const r = await fetch("/api", { cache: "no-store" });
+          const r = await fetch(apiUrl, { cache: "no-store" });
           if (r.ok && (await r.json())) {
-            window.location.reload();
+            const nextUrl = new URL(window.location.href);
+            nextUrl.searchParams.set("device", d.udid);
+            window.location.assign(nextUrl.toString());
             return;
           }
         } catch {}
@@ -853,7 +857,7 @@ function App() {
   // Without this, the reload button flickers while an RN app is still loading.
   const [currentApp, setCurrentApp] = useState<{ bundleId: string; isReactNative: boolean } | null>(null);
   useEffect(() => {
-    const es = new EventSource("/appstate");
+    const es = new EventSource(config.appStateEndpoint ?? "/appstate");
     let timer: ReturnType<typeof setTimeout> | null = null;
     es.onmessage = (e) => {
       try {
@@ -866,7 +870,7 @@ function App() {
       } catch {}
     };
     return () => { if (timer) clearTimeout(timer); es.close(); };
-  }, []);
+  }, [config.appStateEndpoint]);
 
   // Cmd+R to reload the RN/Expo bundle. RCTKeyCommands on iOS listens for
   // this combo and triggers DevSupport reload. We hold Meta, tap R, release.
@@ -961,16 +965,17 @@ function App() {
     if (switching || d.udid === config.device) return;
     setSwitching(true);
     // Ensure the target simulator is booted (serve-sim boots on --detach but
-    // this keeps the flow snappy) and spin up a helper bound to it. The
-    // preview reads whichever server-*.json state file exists, so the new
-    // helper becomes the active stream after reload.
+    // this keeps the flow snappy) and spin up a helper bound to it. Do not
+    // kill the current helper here; another preview window may be using it.
     try {
       if (d.state !== "Booted") {
         await execOnHost(`xcrun simctl boot ${d.udid}`);
       }
-      await execOnHost(`bunx serve-sim --kill ${config.device}`);
-      await execOnHost(`bunx serve-sim --detach ${d.udid}`);
-      window.location.reload();
+      const detach = await execOnHost(`bunx serve-sim --detach ${d.udid}`);
+      if (detach.exitCode !== 0) throw new Error(detach.stderr || "Failed to start serve-sim");
+      const nextUrl = new URL(window.location.href);
+      nextUrl.searchParams.set("device", d.udid);
+      window.location.assign(nextUrl.toString());
     } catch {
       setSwitching(false);
     }

--- a/packages/serve-sim/src/index.ts
+++ b/packages/serve-sim/src/index.ts
@@ -1028,15 +1028,25 @@ async function memoryWarning(args: string[]) {
 // ─── Serve preview ───
 
 async function serve(servePort: number, devices: string[], portExplicit: boolean) {
-  // Ensure a serve-sim stream is running (start one if not)
-  const existing = readAllStates();
-  if (existing.length === 0) {
-    console.log("Starting simulator stream...");
-    await detach(devices, 3100);
+  let targetDevice: string | undefined;
+
+  if (devices.length > 0) {
+    const states = await detach(devices, 3100);
+    targetDevice = states[0]?.device;
+  } else {
+    // Ensure a serve-sim stream is running (start one if not)
+    const existing = readAllStates();
+    if (existing.length > 0) {
+      targetDevice = existing[0]?.device;
+    } else {
+      console.log("Starting simulator stream...");
+      const states = await detach(devices, 3100);
+      targetDevice = states[0]?.device;
+    }
   }
 
   const { simMiddleware } = await import("./middleware");
-  const middleware = simMiddleware({ basePath: "/" });
+  const middleware = simMiddleware({ basePath: "/", device: targetDevice });
 
   // Try requested port; if busy and the user didn't pin it, scan forward.
   const maxScan = portExplicit ? 1 : 50;

--- a/packages/serve-sim/src/middleware.ts
+++ b/packages/serve-sim/src/middleware.ts
@@ -7,7 +7,7 @@ import { join } from "path";
 declare const __PREVIEW_HTML_B64__: string;
 const STATE_DIR = join(tmpdir(), "serve-sim");
 
-interface ServeSimState {
+export interface ServeSimState {
   pid: number;
   port: number;
   device: string;
@@ -125,6 +125,27 @@ function readServeSimStates(): ServeSimState[] {
   return states;
 }
 
+export function selectServeSimState(
+  states: ServeSimState[],
+  device?: string | null,
+): ServeSimState | null {
+  if (device) {
+    return states.find((state) => state.device === device) ?? null;
+  }
+  return states[0] ?? null;
+}
+
+function queryDevice(rawUrl: string): string | null {
+  const qIndex = rawUrl.indexOf("?");
+  if (qIndex === -1) return null;
+  return new URLSearchParams(rawUrl.slice(qIndex + 1)).get("device");
+}
+
+function endpoint(base: string, path: string, device: string): string {
+  const value = `${base}${path}`;
+  return `${value}?device=${encodeURIComponent(device)}`;
+}
+
 let _html: string | null = null;
 function loadHtml(): string {
   if (!_html) {
@@ -136,6 +157,8 @@ function loadHtml(): string {
 export interface SimMiddlewareOptions {
   /** Base path to serve the preview at. Default: "/.sim" */
   basePath?: string;
+  /** Pin this preview server to a specific simulator UDID. */
+  device?: string;
 }
 
 /**
@@ -153,11 +176,12 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
     const rawUrl: string = req.url ?? "";
     const qIndex = rawUrl.indexOf("?");
     const url = qIndex === -1 ? rawUrl : rawUrl.slice(0, qIndex);
+    const selectedDevice = queryDevice(rawUrl) ?? options?.device ?? null;
 
     // Serve the preview page
     if (url === base || url === base + "/") {
       const states = readServeSimStates();
-      const state = states[0] ?? null;
+      const state = selectServeSimState(states, selectedDevice);
       let html = loadHtml();
 
       if (state) {
@@ -166,7 +190,8 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
         // and connects to the WS directly (WS has no CORS).
         const config = JSON.stringify({
           ...state,
-          logsEndpoint: base + "/logs",
+          logsEndpoint: endpoint(base, "/logs", state.device),
+          appStateEndpoint: endpoint(base, "/appstate", state.device),
         });
         const configScript = `<script>window.__SIM_PREVIEW__=${config}</script>`;
         html = html.replace("<!--__SIM_PREVIEW_CONFIG__-->", configScript);
@@ -183,11 +208,12 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
     // JSON API: serve-sim state
     if (url === base + "/api") {
       const states = readServeSimStates();
+      const state = selectServeSimState(states, selectedDevice);
       res.writeHead(200, {
         "Content-Type": "application/json",
         "Cache-Control": "no-store",
       });
-      res.end(JSON.stringify(states[0] || null));
+      res.end(JSON.stringify(state || null));
       return;
     }
 
@@ -224,12 +250,13 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
     // SSE: simctl log stream
     if (url === base + "/logs") {
       const states = readServeSimStates();
-      if (states.length === 0) {
+      const state = selectServeSimState(states, selectedDevice);
+      if (!state) {
         res.writeHead(404);
         res.end("No serve-sim device");
         return;
       }
-      const udid = states[0].device;
+      const udid = state.device;
       res.writeHead(200, {
         "Content-Type": "text/event-stream",
         "Cache-Control": "no-cache",
@@ -266,12 +293,13 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
     // stays narrow and the client can listen without rate-limit concerns.
     if (url === base + "/appstate") {
       const states = readServeSimStates();
-      if (states.length === 0) {
+      const state = selectServeSimState(states, selectedDevice);
+      if (!state) {
         res.writeHead(404);
         res.end("No serve-sim device");
         return;
       }
-      const udid = states[0].device;
+      const udid = state.device;
       res.writeHead(200, {
         "Content-Type": "text/event-stream",
         "Cache-Control": "no-cache",


### PR DESCRIPTION
## Summary
- start the requested simulator stream even when another stream is already running
- pin preview middleware, logs, and app-state events to the requested simulator UDID
- keep device switching from killing helpers that another preview window may be using

## Verification
- bun test packages/serve-sim/src/__tests__/middleware-selection.test.ts packages/serve-sim/src/__tests__/multi-device.test.ts
- bun test packages/serve-sim/src/__tests__ packages/serve-sim-client/src/__tests__
- bun run --filter serve-sim build
- manually verified two preview servers at localhost:3200 and localhost:3201 stream different simulators simultaneously

Fixes #7

https://github.com/user-attachments/assets/236b3ef5-4440-41dd-99de-12c73e239453


