### PR TITLE
fix: resolve Xcode framework path dynamically via xcode-select

### DIFF
--- a/packages/serve-sim/Package.swift
+++ b/packages/serve-sim/Package.swift
@@ -1,5 +1,10 @@
 // swift-tools-version: 5.9
 import PackageDescription
+import Foundation
+
+let developerDir = ProcessInfo.processInfo.environment["DEVELOPER_DIR"]
+    ?? "/Applications/Xcode.app/Contents/Developer"
+let privateFrameworks = "\(developerDir)/Library/PrivateFrameworks"
 
 let package = Package(
     name: "SimStreamHelper",
@@ -17,15 +22,15 @@ let package = Package(
             swiftSettings: [
                 .unsafeFlags([
                     "-F/Library/Developer/PrivateFrameworks",
-                    "-F/Applications/Xcode.app/Contents/Developer/Library/PrivateFrameworks",
+                    "-F\(privateFrameworks)",
                 ]),
             ],
             linkerSettings: [
                 .unsafeFlags([
                     "-F/Library/Developer/PrivateFrameworks",
-                    "-F/Applications/Xcode.app/Contents/Developer/Library/PrivateFrameworks",
+                    "-F\(privateFrameworks)",
                     "-Xlinker", "-rpath", "-Xlinker", "/Library/Developer/PrivateFrameworks",
-                    "-Xlinker", "-rpath", "-Xlinker", "/Applications/Xcode.app/Contents/Developer/Library/PrivateFrameworks",
+                    "-Xlinker", "-rpath", "-Xlinker", "\(privateFrameworks)",
                 ]),
                 .linkedFramework("CoreSimulator"),
                 .linkedFramework("SimulatorKit"),

--- a/packages/serve-sim/build.sh
+++ b/packages/serve-sim/build.sh
@@ -6,6 +6,8 @@ cd "$SCRIPT_DIR"
 
 echo "Building serve-sim-bin (arm64)..."
 
+export DEVELOPER_DIR=$(xcode-select -p)
+
 swift build \
     -c release \
     --arch arm64 \


### PR DESCRIPTION
Hardcoded `/Applications/Xcode.app` paths in Package.swift and build.sh break on systems where Xcode is installed under a versioned name (e.g. `Xcode-26.0.0.app`) as managed by tools like Xcodes.

- Package.swift: read DEVELOPER_DIR env var at manifest evaluation time, falling back to the conventional Xcode.app path
- build.sh: export DEVELOPER_DIR=$(xcode-select -p) before swift build so the manifest always receives the active developer directory