### PR TITLE
fix: route sim client requests via base path

### DIFF
--- a/packages/serve-sim/src/client/client.tsx
+++ b/packages/serve-sim/src/client/client.tsx
@@ -196,10 +196,16 @@ declare global {
       wsUrl: string;
       port: number;
       device: string;
+      basePath: string;
       logsEndpoint?: string;
       appStateEndpoint?: string;
     };
   }
+}
+
+function simEndpoint(path: string): string {
+  const basePath = window.__SIM_PREVIEW__?.basePath ?? "/";
+  return basePath === "/" ? `/${path}` : `${basePath}/${path}`;
 }
 
 // ─── Exec / devices ───
@@ -207,7 +213,7 @@ declare global {
 interface ExecResult { stdout: string; stderr: string; exitCode: number }
 
 async function execOnHost(command: string): Promise<ExecResult> {
-  const res = await fetch("/exec", {
+  const res = await fetch(simEndpoint("exec"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ command }),
@@ -1037,11 +1043,11 @@ function BootEmptyState({
       const detach = await execOnHost(`bunx serve-sim --detach ${d.udid}`);
       if (detach.exitCode !== 0) throw new Error(detach.stderr || "Failed to start serve-sim");
 
-      // Poll /api until the state file is picked up, then reload. Avoids a
+      // Poll the middleware API until the state file is picked up, then reload. Avoids a
       // race where the user sees the empty state again because we reloaded
       // before serve-sim wrote its server-*.json.
       const deadline = Date.now() + 15_000;
-      const apiUrl = `/api?device=${encodeURIComponent(d.udid)}`;
+      const apiUrl = `${simEndpoint("api")}?device=${encodeURIComponent(d.udid)}`;
       while (Date.now() < deadline) {
         try {
           const r = await fetch(apiUrl, { cache: "no-store" });
@@ -1455,7 +1461,7 @@ function App() {
     return () => window.removeEventListener("resize", onResize);
   }, []);
   useEffect(() => {
-    const es = new EventSource(config.appStateEndpoint ?? "/appstate");
+    const es = new EventSource(config.appStateEndpoint ?? simEndpoint("appstate"));
     let timer: ReturnType<typeof setTimeout> | null = null;
     es.onmessage = (e) => {
       try {

--- a/packages/serve-sim/src/middleware.ts
+++ b/packages/serve-sim/src/middleware.ts
@@ -190,6 +190,7 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
         // and connects to the WS directly (WS has no CORS).
         const config = JSON.stringify({
           ...state,
+          basePath: base,
           logsEndpoint: endpoint(base, "/logs", state.device),
           appStateEndpoint: endpoint(base, "/appstate", state.device),
         });


### PR DESCRIPTION
When using the `middleware` function, some requests like `exec` were not routed correctly from the client UI.

Before:
<img width="1488" height="480" alt="Screenshot 2026-05-03 at 13 14 45" src="https://github.com/user-attachments/assets/016ad2be-de02-45d3-b3f6-758e032747b3" />


After:
<img width="1489" height="432" alt="Screenshot 2026-05-03 at 13 12 29" src="https://github.com/user-attachments/assets/ec6f529e-7842-45f2-a5c9-aa98f4812696" />
