### PR TITLE
ref: unify endpoints handling in the client

### DIFF
--- a/packages/serve-sim/dev.ts
+++ b/packages/serve-sim/dev.ts
@@ -45,6 +45,15 @@ const STATE_DIR = join(tmpdir(), "serve-sim");
 const CLIENT_DIR = resolve(import.meta.dir, "src/client");
 const CLIENT_ENTRY = resolve(CLIENT_DIR, "client.tsx");
 
+interface ServeSimState {
+  pid: number;
+  port: number;
+  device: string;
+  url: string;
+  streamUrl: string;
+  wsUrl: string;
+}
+
 // ─── Serve-sim state ───
 
 // Cache simctl's booted-device set briefly (1.5s). dev.ts calls
@@ -78,7 +87,7 @@ function getBootedUdids(): Set<string> | null {
   }
 }
 
-function readServeSimStates() {
+function readServeSimStates(): ServeSimState[] {
   let files: string[];
   try {
     files = readdirSync(STATE_DIR).filter(
@@ -88,7 +97,7 @@ function readServeSimStates() {
     return [];
   }
   const booted = getBootedUdids();
-  const states: any[] = [];
+  const states: ServeSimState[] = [];
   for (const f of files) {
     const path = join(STATE_DIR, f);
     try {
@@ -114,6 +123,16 @@ function readServeSimStates() {
     } catch {}
   }
   return states;
+}
+
+function selectServeSimState(
+  states: ServeSimState[],
+  device?: string | null,
+): ServeSimState | null {
+  if (device) {
+    return states.find((state) => state.device === device) ?? null;
+  }
+  return states[0] ?? null;
 }
 
 // ─── Client bundler with watch ───
@@ -164,12 +183,59 @@ watch(CLIENT_DIR, { recursive: true }, (_event, filename) => {
 
 // ─── HTML shell ───
 
-function buildHtml(): string {
+function endpoint(path: string): string {
+  return path;
+}
+
+function endpointForDevice(path: string, device: string): string {
+  return `${path}?device=${encodeURIComponent(device)}`;
+}
+
+function previewConfig(state: ServeSimState | null) {
+  const config: {
+    basePath: string;
+    endpoints: {
+      api: string;
+      exec: string;
+      logs?: string;
+      appState?: string;
+    };
+    state?: ServeSimState;
+    helper?: {
+      url: string;
+      stream: string;
+      ws: string;
+      config: string;
+    };
+  } = {
+    basePath: "/",
+    endpoints: {
+      api: endpoint("/api"),
+      exec: endpoint("/exec"),
+    },
+  };
+  if (state) {
+    config.state = state;
+    config.helper = {
+      url: state.url,
+      stream: state.streamUrl,
+      ws: state.wsUrl,
+      config: `${state.url}/config`,
+    };
+    config.endpoints.logs = endpointForDevice("/logs", state.device);
+    config.endpoints.appState = endpointForDevice("/appstate", state.device);
+  }
+  return config;
+}
+
+function inlineJson(value: unknown): string {
+  return JSON.stringify(value)!.replace(/</g, "\\u003c");
+}
+
+function buildHtml(device?: string | null): string {
   const states = readServeSimStates();
-  const state = states[0] ?? null;
-  const configScript = state
-    ? `<script>window.__SIM_PREVIEW__=${JSON.stringify({ ...state, logsEndpoint: "/logs" })}</script>`
-    : "";
+  const state = selectServeSimState(states, device);
+  const configScript = `<script>window.__SIM_PREVIEW__=${inlineJson(previewConfig(state))}</script>`;
 
   return `<!doctype html>
 <html><head>
@@ -221,7 +287,8 @@ Bun.serve({
     // Serve-sim state API
     if (url.pathname === "/api") {
       const states = readServeSimStates();
-      return Response.json(states[0] ?? null, {
+      const state = selectServeSimState(states, url.searchParams.get("device"));
+      return Response.json(state, {
         headers: { "Cache-Control": "no-store" },
       });
     }
@@ -248,10 +315,11 @@ Bun.serve({
     // SSE logs
     if (url.pathname === "/logs") {
       const states = readServeSimStates();
-      if (states.length === 0) {
+      const state = selectServeSimState(states, url.searchParams.get("device"));
+      if (!state) {
         return new Response("No serve-sim device", { status: 404 });
       }
-      const udid = states[0].device;
+      const udid = state.device;
       const stream = new ReadableStream({
         start(controller) {
           const child: ChildProcess = spawn("xcrun", [
@@ -294,10 +362,11 @@ Bun.serve({
     // SSE foreground-app changes (filtered in the CLI; browser just listens).
     if (url.pathname === "/appstate") {
       const states = readServeSimStates();
-      if (states.length === 0) {
+      const state = selectServeSimState(states, url.searchParams.get("device"));
+      if (!state) {
         return new Response("No serve-sim device", { status: 404 });
       }
-      const udid = states[0].device;
+      const udid = state.device;
       const stream = new ReadableStream({
         start(controller) {
           const child: ChildProcess = spawn("xcrun", [
@@ -348,7 +417,7 @@ Bun.serve({
     }
 
     // Serve the HTML page (fresh on every request — picks up state + rebuild)
-    return new Response(buildHtml(), {
+    return new Response(buildHtml(url.searchParams.get("device")), {
       headers: {
         "Content-Type": "text/html; charset=utf-8",
         "Cache-Control": "no-store",

--- a/packages/serve-sim/src/__tests__/middleware-selection.test.ts
+++ b/packages/serve-sim/src/__tests__/middleware-selection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { selectServeSimState, type ServeSimState } from "../middleware";
+import { buildSimPreviewConfig, selectServeSimState, type ServeSimState } from "../middleware";
 
 const states: ServeSimState[] = [
   {
@@ -31,5 +31,45 @@ describe("selectServeSimState", () => {
 
   test("returns null when the requested device is not running", () => {
     expect(selectServeSimState(states, "DEVICE-C")).toBeNull();
+  });
+});
+
+describe("buildSimPreviewConfig", () => {
+  test("injects middleware endpoints without helper URLs when no state is running", () => {
+    expect(buildSimPreviewConfig("/.sim", null)).toEqual({
+      basePath: "/.sim",
+      endpoints: {
+        api: "/.sim/api",
+        exec: "/.sim/exec",
+      },
+    });
+  });
+
+  test("separates middleware endpoints from helper stream/control URLs", () => {
+    expect(buildSimPreviewConfig("/.sim", states[1]!)).toEqual({
+      basePath: "/.sim",
+      endpoints: {
+        api: "/.sim/api",
+        exec: "/.sim/exec",
+        logs: "/.sim/logs?device=DEVICE-B",
+        appState: "/.sim/appstate?device=DEVICE-B",
+      },
+      state: states[1],
+      helper: {
+        url: "http://127.0.0.1:3101",
+        stream: "http://127.0.0.1:3101/stream.mjpeg",
+        ws: "ws://127.0.0.1:3101/ws",
+        config: "http://127.0.0.1:3101/config",
+      },
+    });
+  });
+
+  test("uses root-relative middleware endpoints for root-mounted preview", () => {
+    expect(buildSimPreviewConfig("", states[0]!).endpoints).toEqual({
+      api: "/api",
+      exec: "/exec",
+      logs: "/logs?device=DEVICE-A",
+      appState: "/appstate?device=DEVICE-A",
+    });
   });
 });

--- a/packages/serve-sim/src/client/client.tsx
+++ b/packages/serve-sim/src/client/client.tsx
@@ -219,20 +219,11 @@ declare global {
   }
 }
 
-function defaultBasePath(): string {
-  const path = window.location.pathname.replace(/\/+$/, "");
-  return path || "/";
-}
-
-function endpointPath(basePath: string, path: string): string {
-  return basePath === "/" ? `/${path}` : `${basePath}/${path}`;
-}
-
 function previewEndpoint(name: keyof SimPreviewConfig["endpoints"]): string {
   const preview = window.__SIM_PREVIEW__;
   const endpoint = preview?.endpoints[name];
   if (endpoint) return endpoint;
-  return endpointPath(preview?.basePath ?? defaultBasePath(), name === "appState" ? "appstate" : name);
+  throw new Error(`Endpoint "${name}" not found in preview config`);
 }
 
 function endpointWithDevice(endpoint: string, device: string): string {
@@ -1494,7 +1485,11 @@ function App() {
     return () => window.removeEventListener("resize", onResize);
   }, []);
   useEffect(() => {
-    const es = new EventSource(config.endpoints.appState ?? previewEndpoint("appState"));
+    if (!config.endpoints.appState) {
+      console.warn("appState endpoint is not configured");
+      return;
+    }
+    const es = new EventSource(config.endpoints.appState);
     let timer: ReturnType<typeof setTimeout> | null = null;
     es.onmessage = (e) => {
       try {

--- a/packages/serve-sim/src/client/client.tsx
+++ b/packages/serve-sim/src/client/client.tsx
@@ -18,7 +18,7 @@ import {
  * Chrome doesn't support multipart/x-mixed-replace in <img> tags,
  * so we manually read the stream and extract JPEG boundaries.
  */
-function useMjpegStream(streamUrl: string | null) {
+function useMjpegStream(streamUrl: string | null, configUrl: string | null) {
   const [config, setConfig] = useState<StreamConfig | null>(null);
   const subscribersRef = useRef<Set<(blobUrl: string) => void>>(new Set());
 
@@ -31,13 +31,12 @@ function useMjpegStream(streamUrl: string | null) {
   );
 
   useEffect(() => {
-    if (!streamUrl) return;
+    if (!streamUrl || !configUrl) return;
     const controller = new AbortController();
     let stopped = false;
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
 
     // Poll config for screen dimensions + requested orientation.
-    const baseUrl = streamUrl.replace(/\/stream\.mjpeg$/, "");
     const applyConfig = (c: StreamConfig) => {
       if (c.width <= 0 || c.height <= 0) return;
       setConfig((prev) =>
@@ -50,7 +49,7 @@ function useMjpegStream(streamUrl: string | null) {
       );
     };
     const fetchConfig = () => {
-      fetch(`${baseUrl}/config`, { signal: controller.signal })
+      fetch(configUrl, { signal: controller.signal })
         .then((r) => r.json())
         .then(applyConfig)
         .catch(() => {});
@@ -145,7 +144,7 @@ function useMjpegStream(streamUrl: string | null) {
       controller.abort();
       clearInterval(configInterval);
     };
-  }, [streamUrl]);
+  }, [streamUrl, configUrl]);
 
   return { subscribeFrame, frame: null, config };
 }
@@ -188,24 +187,58 @@ function hidUsageForCode(code: string): number | null {
 
 // ─── Types ───
 
+interface SimPreviewState {
+  pid: number;
+  port: number;
+  device: string;
+  url: string;
+  streamUrl: string;
+  wsUrl: string;
+}
+
+interface SimPreviewConfig {
+  basePath: string;
+  endpoints: {
+    api: string;
+    exec: string;
+    logs?: string;
+    appState?: string;
+  };
+  state?: SimPreviewState;
+  helper?: {
+    url: string;
+    stream: string;
+    ws: string;
+    config: string;
+  };
+}
+
 declare global {
   interface Window {
-    __SIM_PREVIEW__?: {
-      url: string;
-      streamUrl: string;
-      wsUrl: string;
-      port: number;
-      device: string;
-      basePath: string;
-      logsEndpoint?: string;
-      appStateEndpoint?: string;
-    };
+    __SIM_PREVIEW__?: SimPreviewConfig;
   }
 }
 
-function simEndpoint(path: string): string {
-  const basePath = window.__SIM_PREVIEW__?.basePath ?? "/";
+function defaultBasePath(): string {
+  const path = window.location.pathname.replace(/\/+$/, "");
+  return path || "/";
+}
+
+function endpointPath(basePath: string, path: string): string {
   return basePath === "/" ? `/${path}` : `${basePath}/${path}`;
+}
+
+function previewEndpoint(name: keyof SimPreviewConfig["endpoints"]): string {
+  const preview = window.__SIM_PREVIEW__;
+  const endpoint = preview?.endpoints[name];
+  if (endpoint) return endpoint;
+  return endpointPath(preview?.basePath ?? defaultBasePath(), name === "appState" ? "appstate" : name);
+}
+
+function endpointWithDevice(endpoint: string, device: string): string {
+  const url = new URL(endpoint, window.location.href);
+  url.searchParams.set("device", device);
+  return url.toString();
 }
 
 // ─── Exec / devices ───
@@ -213,7 +246,7 @@ function simEndpoint(path: string): string {
 interface ExecResult { stdout: string; stderr: string; exitCode: number }
 
 async function execOnHost(command: string): Promise<ExecResult> {
-  const res = await fetch(simEndpoint("exec"), {
+  const res = await fetch(previewEndpoint("exec"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ command }),
@@ -1012,10 +1045,9 @@ function AppPermissionsTool({
 
 // ─── Empty state: pick a simulator to boot ───
 //
-// When no serve-sim helper is running, the middleware has no state file to
-// inject and `window.__SIM_PREVIEW__` is undefined. Instead of telling the
-// user to drop into a terminal, list available simulators inline and let
-// them boot one + start `serve-sim --detach` from the browser.
+// When no serve-sim helper is running, the middleware still injects its host
+// endpoints. List available simulators inline and let the user boot one +
+// start `serve-sim --detach` from the browser.
 
 function BootEmptyState({
   devices,
@@ -1047,7 +1079,7 @@ function BootEmptyState({
       // race where the user sees the empty state again because we reloaded
       // before serve-sim wrote its server-*.json.
       const deadline = Date.now() + 15_000;
-      const apiUrl = `${simEndpoint("api")}?device=${encodeURIComponent(d.udid)}`;
+      const apiUrl = endpointWithDevice(previewEndpoint("api"), d.udid);
       while (Date.now() < deadline) {
         try {
           const r = await fetch(apiUrl, { cache: "no-store" });
@@ -1261,8 +1293,8 @@ function App() {
 
   // Stream simctl logs into the browser console with colors + grouping
   useEffect(() => {
-    if (!config?.logsEndpoint) return;
-    const es = new EventSource(config.logsEndpoint);
+    if (!config?.endpoints.logs) return;
+    const es = new EventSource(config.endpoints.logs);
 
     const procColors = new Map<string, string>();
     const palette = [
@@ -1327,9 +1359,9 @@ function App() {
       if (groupOpen) console.groupEnd();
       es.close();
     };
-  }, [config?.logsEndpoint]);
+  }, [config?.endpoints.logs]);
 
-  if (!config) {
+  if (!config?.state || !config.helper) {
     return (
       <BootEmptyState
         devices={devices}
@@ -1340,7 +1372,8 @@ function App() {
     );
   }
 
-  const selectedDevice = devices.find((d) => d.udid === config.device) ?? null;
+  const { state, helper } = config;
+  const selectedDevice = devices.find((d) => d.udid === state.device) ?? null;
 
   useEffect(() => {
     document.title = selectedDevice?.name
@@ -1351,7 +1384,7 @@ function App() {
   const deviceType: DeviceType = getDeviceType(selectedDevice?.name);
 
   // Parse MJPEG stream into individual frames (Chrome doesn't support multipart/x-mixed-replace in <img>)
-  const mjpeg = useMjpegStream(config.streamUrl);
+  const mjpeg = useMjpegStream(helper.stream, helper.config);
   const [liveStreamConfig, setLiveStreamConfig] = useState<StreamConfig | null>(null);
   const activeStreamConfig = liveStreamConfig ?? mjpeg.config ?? fallbackScreenSize(deviceType, selectedDevice?.name);
   const imgBorderRadius = screenBorderRadius(deviceType, activeStreamConfig);
@@ -1374,7 +1407,7 @@ function App() {
     };
 
     const connect = () => {
-      const ws = new WebSocket(config.wsUrl);
+      const ws = new WebSocket(helper.ws);
       ws.binaryType = "arraybuffer";
       currentWs = ws;
       wsRef.current = ws;
@@ -1395,7 +1428,7 @@ function App() {
       if (wsRef.current === currentWs) wsRef.current = null;
       currentWs?.close();
     };
-  }, [config.wsUrl]);
+  }, [helper.ws]);
 
   const sendWs = useCallback((tag: number, payload: object) => {
     const ws = wsRef.current;
@@ -1426,7 +1459,7 @@ function App() {
 
   useEffect(() => {
     setLiveStreamConfig(null);
-  }, [config.streamUrl]);
+  }, [helper.stream]);
 
   useEffect(() => {
     const confirmedConfig = mjpeg.config;
@@ -1461,7 +1494,7 @@ function App() {
     return () => window.removeEventListener("resize", onResize);
   }, []);
   useEffect(() => {
-    const es = new EventSource(config.appStateEndpoint ?? simEndpoint("appstate"));
+    const es = new EventSource(config.endpoints.appState ?? previewEndpoint("appState"));
     let timer: ReturnType<typeof setTimeout> | null = null;
     es.onmessage = (e) => {
       try {
@@ -1474,7 +1507,7 @@ function App() {
       } catch {}
     };
     return () => { if (timer) clearTimeout(timer); es.close(); };
-  }, [config.appStateEndpoint]);
+  }, [config.endpoints.appState]);
 
   // Cmd+R to reload the RN/Expo bundle. RCTKeyCommands on iOS listens for
   // this combo and triggers DevSupport reload. We hold Meta, tap R, release.
@@ -1539,9 +1572,9 @@ function App() {
         e.preventDefault();
         if (type === "down" && !e.repeat) {
           // simctl has no toggle; query current, invert, set.
-          execOnHost(`xcrun simctl ui ${config.device} appearance`).then((r) => {
+          execOnHost(`xcrun simctl ui ${state.device} appearance`).then((r) => {
             const next = r.stdout.trim() === "dark" ? "light" : "dark";
-            return execOnHost(`xcrun simctl ui ${config.device} appearance ${next}`);
+            return execOnHost(`xcrun simctl ui ${state.device} appearance ${next}`);
           }).catch(() => {});
         }
         return;
@@ -1563,10 +1596,10 @@ function App() {
       window.removeEventListener("keydown", down);
       window.removeEventListener("keyup", up);
     };
-  }, [sendWs, config.device]);
+  }, [sendWs, state.device]);
 
   const switchToDevice = useCallback(async (d: SimDevice) => {
-    if (switching || d.udid === config.device) return;
+    if (switching || d.udid === state.device) return;
     setSwitching(true);
     // Ensure the target simulator is booted (serve-sim boots on --detach but
     // this keeps the flow snappy) and spin up a helper bound to it. Do not
@@ -1583,14 +1616,14 @@ function App() {
     } catch {
       setSwitching(false);
     }
-  }, [switching, config.device]);
+  }, [switching, state.device]);
 
   // Drag/drop images, videos, or .ipa files onto the simulator.
   // Media → Photos (addmedia); .ipa → install.
   const uploads = useUploadToasts();
   const mediaDrop = useMediaDrop({
     exec: execOnHost,
-    udid: config.device,
+    udid: state.device,
     enabled: streaming,
     onUploadStart: uploads.add,
     onUploadEnd: (id, ok, message) =>
@@ -1645,14 +1678,14 @@ function App() {
           exec={execOnHost}
           onRotate={rotateDevice}
           orientation={activeStreamConfig.orientation ?? null}
-          deviceUdid={config.device}
+          deviceUdid={state.device}
           deviceName={selectedDevice?.name ?? null}
           deviceRuntime={selectedDevice?.runtime ?? null}
           streaming={streaming}
         >
           <DevicePicker
             devices={devices}
-            selectedUdid={config.device}
+            selectedUdid={state.device}
             loading={devicesLoading}
             error={devicesError}
             stoppingUdids={stoppingUdids}
@@ -1692,7 +1725,7 @@ function App() {
           {...mediaDrop.dropZoneProps}
         >
           <SimulatorView
-            url={config.url}
+            url={helper.url}
             style={{ width: "100%", height: "100%", border: "none" }}
             imageStyle={{
               borderRadius: imgBorderRadius,
@@ -1759,7 +1792,7 @@ function App() {
       <ToolsPanel
         open={panelOpen}
         onClose={() => setPanelOpen(false)}
-        udid={config.device}
+        udid={state.device}
         currentApp={currentApp}
       />
 

--- a/packages/serve-sim/src/client/client.tsx
+++ b/packages/serve-sim/src/client/client.tsx
@@ -196,10 +196,16 @@ declare global {
       wsUrl: string;
       port: number;
       device: string;
+      basePath: string;
       logsEndpoint?: string;
       appStateEndpoint?: string;
     };
   }
+}
+
+function simEndpoint(path: string): string {
+  const basePath = window.__SIM_PREVIEW__?.basePath ?? "/";
+  return basePath === "/" ? `/${path}` : `${basePath}/${path}`;
 }
 
 // ─── Exec / devices ───
@@ -207,7 +213,7 @@ declare global {
 interface ExecResult { stdout: string; stderr: string; exitCode: number }
 
 async function execOnHost(command: string): Promise<ExecResult> {
-  const res = await fetch("/exec", {
+  const res = await fetch(simEndpoint("exec"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ command }),
@@ -1037,11 +1043,11 @@ function BootEmptyState({
       const detach = await execOnHost(`bunx serve-sim --detach ${d.udid}`);
       if (detach.exitCode !== 0) throw new Error(detach.stderr || "Failed to start serve-sim");
 
-      // Poll /api until the state file is picked up, then reload. Avoids a
+      // Poll the middleware API until the state file is picked up, then reload. Avoids a
       // race where the user sees the empty state again because we reloaded
       // before serve-sim wrote its server-*.json.
       const deadline = Date.now() + 15_000;
-      const apiUrl = `/api?device=${encodeURIComponent(d.udid)}`;
+      const apiUrl = `${simEndpoint("api")}?device=${encodeURIComponent(d.udid)}`;
       while (Date.now() < deadline) {
         try {
           const r = await fetch(apiUrl, { cache: "no-store" });
@@ -1455,7 +1461,7 @@ function App() {
     return () => window.removeEventListener("resize", onResize);
   }, []);
   useEffect(() => {
-    const es = new EventSource(config.appStateEndpoint ?? "/appstate");
+    const es = new EventSource(config.appStateEndpoint ?? simEndpoint("appstate"));
     let timer: ReturnType<typeof setTimeout> | null = null;
     es.onmessage = (e) => {
       try {

--- a/packages/serve-sim/src/middleware.ts
+++ b/packages/serve-sim/src/middleware.ts
@@ -164,7 +164,7 @@ function endpoint(base: string, path: string, device?: string): string {
   return `${value}?device=${encodeURIComponent(device)}`;
 }
 
-function previewConfig(base: string, state: ServeSimState | null): SimPreviewConfig {
+export function buildSimPreviewConfig(base: string, state: ServeSimState | null): SimPreviewConfig {
   const config: SimPreviewConfig = {
     basePath: base || "/",
     endpoints: {
@@ -227,7 +227,7 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
       const states = readServeSimStates();
       const state = selectServeSimState(states, selectedDevice);
       let html = loadHtml();
-      const configScript = `<script>window.__SIM_PREVIEW__=${inlineJson(previewConfig(base, state))}</script>`;
+      const configScript = `<script>window.__SIM_PREVIEW__=${inlineJson(buildSimPreviewConfig(base, state))}</script>`;
       html = html.replace("<!--__SIM_PREVIEW_CONFIG__-->", configScript);
 
       res.writeHead(200, {

--- a/packages/serve-sim/src/middleware.ts
+++ b/packages/serve-sim/src/middleware.ts
@@ -190,6 +190,7 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
         // and connects to the WS directly (WS has no CORS).
         const config = JSON.stringify({
           ...state,
+          basePath: base,
           logsEndpoint: endpoint(base, "/logs", state.device),
           appStateEndpoint: endpoint(base, "/appstate", state.device),
         });

--- a/packages/serve-sim/src/middleware.ts
+++ b/packages/serve-sim/src/middleware.ts
@@ -16,6 +16,23 @@ export interface ServeSimState {
   wsUrl: string;
 }
 
+export interface SimPreviewConfig {
+  basePath: string;
+  endpoints: {
+    api: string;
+    exec: string;
+    logs?: string;
+    appState?: string;
+  };
+  state?: ServeSimState;
+  helper?: {
+    url: string;
+    stream: string;
+    ws: string;
+    config: string;
+  };
+}
+
 // Known bundle IDs that are always React Native shells (used as a fallback
 // before the app-container path resolves, since simctl can lag after launch).
 const RN_BUNDLE_IDS = new Set<string>([
@@ -141,9 +158,36 @@ function queryDevice(rawUrl: string): string | null {
   return new URLSearchParams(rawUrl.slice(qIndex + 1)).get("device");
 }
 
-function endpoint(base: string, path: string, device: string): string {
+function endpoint(base: string, path: string, device?: string): string {
   const value = `${base}${path}`;
+  if (!device) return value;
   return `${value}?device=${encodeURIComponent(device)}`;
+}
+
+function previewConfig(base: string, state: ServeSimState | null): SimPreviewConfig {
+  const config: SimPreviewConfig = {
+    basePath: base || "/",
+    endpoints: {
+      api: endpoint(base, "/api"),
+      exec: endpoint(base, "/exec"),
+    },
+  };
+  if (state) {
+    config.state = state;
+    config.helper = {
+      url: state.url,
+      stream: state.streamUrl,
+      ws: state.wsUrl,
+      config: `${state.url}/config`,
+    };
+    config.endpoints.logs = endpoint(base, "/logs", state.device);
+    config.endpoints.appState = endpoint(base, "/appstate", state.device);
+  }
+  return config;
+}
+
+function inlineJson(value: unknown): string {
+  return JSON.stringify(value)!.replace(/</g, "\\u003c");
 }
 
 let _html: string | null = null;
@@ -183,20 +227,8 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
       const states = readServeSimStates();
       const state = selectServeSimState(states, selectedDevice);
       let html = loadHtml();
-
-      if (state) {
-        // Pass real serve-sim URLs directly. The client parses the MJPEG
-        // stream via fetch() (CORS is fine — serve-sim sends Access-Control-Allow-Origin: *)
-        // and connects to the WS directly (WS has no CORS).
-        const config = JSON.stringify({
-          ...state,
-          basePath: base,
-          logsEndpoint: endpoint(base, "/logs", state.device),
-          appStateEndpoint: endpoint(base, "/appstate", state.device),
-        });
-        const configScript = `<script>window.__SIM_PREVIEW__=${config}</script>`;
-        html = html.replace("<!--__SIM_PREVIEW_CONFIG__-->", configScript);
-      }
+      const configScript = `<script>window.__SIM_PREVIEW__=${inlineJson(previewConfig(base, state))}</script>`;
+      html = html.replace("<!--__SIM_PREVIEW_CONFIG__-->", configScript);
 
       res.writeHead(200, {
         "Content-Type": "text/html; charset=utf-8",


### PR DESCRIPTION
- Based on https://github.com/EvanBacon/serve-sim/pull/18

This refactors the preview config from a flat object into a small route manifest. The important change is that middleware routes and helper routes are now separate.

/api, /exec, /logs, and /appstate come from the host middleware under the configured preview base path. 

/stream.mjpeg, /ws, and /config come from the per-device Swift helper on its own localhost port.

The new config shape is roughly:

```
{
  basePath: "/.sim",
  endpoints: {
    api: "/.sim/api",
    exec: "/.sim/exec",
    logs: "/.sim/logs?device=...",
    appState: "/.sim/appstate?device=..."
  },
  helper: {
    url: "http://127.0.0.1:3100",
    stream: "http://127.0.0.1:3100/stream.mjpeg",
    ws: "ws://127.0.0.1:3100/ws",
    config: "http://127.0.0.1:3100/config"
  }
}
```

This also injects the preview config even when no helper is running, so the empty state can still call middleware endpoints
like /exec.