### PR TITLE
fix: scroll simulator picker in empty state

### DIFF
--- a/packages/serve-sim/src/client/client.tsx
+++ b/packages/serve-sim/src/client/client.tsx
@@ -1683,6 +1683,9 @@ const bootListStyle: CSSProperties = {
   fontSize: 13,
   color: "#eee",
   textAlign: "left",
+  maxHeight: "70vh",
+  overflowY: "auto",
+  minHeight: 0,
 };
 
 // ─── App ───


### PR DESCRIPTION
## Summary
- Constrain the boot picker list to `70vh` with `overflowY: auto` so the simulator list scrolls instead of running off the viewport when no simulator is booted.

## Test plan
- [ ] Shut down all simulators (`xcrun simctl shutdown all`), open the preview UI, confirm the picker scrolls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)