### PR TITLE
feat(annotations): comment picker + clipboard markdown bundle for agents

### DIFF
--- a/packages/serve-sim/dev.ts
+++ b/packages/serve-sim/dev.ts
@@ -5,11 +5,25 @@
  *
  * Run: bun --watch dev.ts
  */
-import { readdirSync, readFileSync, existsSync, unlinkSync, watch } from "fs";
+import { readdirSync, readFileSync, existsSync, unlinkSync, watch, statSync, createReadStream } from "fs";
 import { execSync, spawn, exec, execFile, type ChildProcess } from "child_process";
 import { tmpdir } from "os";
 import { join, resolve } from "path";
+import { Readable } from "stream";
 import { createAxStreamerCache } from "./src/ax";
+import {
+  createAnnotation,
+  deleteAllAnnotations,
+  deleteAnnotation,
+  getAnnotation,
+  listAnnotations,
+  resolveAnnotationAsset,
+  updateAnnotation,
+} from "./src/annotations";
+import type {
+  AnnotationCreateRequest,
+  AnnotationUpdateRequest,
+} from "./src/annotations-shared";
 
 const RN_BUNDLE_IDS = new Set<string>([
   "host.exp.Exponent",
@@ -172,6 +186,7 @@ function buildHtml(): string {
   const configScript = state
     ? `<script>window.__SIM_PREVIEW__=${JSON.stringify({
         ...state,
+        basePath: "/",
         logsEndpoint: "/logs",
         axEndpoint: "/ax",
       })}</script>`
@@ -379,6 +394,11 @@ Bun.serve({
       });
     }
 
+    // ─── Annotations API ───
+    if (url.pathname === "/api/annotations" || url.pathname.startsWith("/api/annotations/")) {
+      return handleAnnotationsBunRequest(req, url);
+    }
+
     // Serve the HTML page (fresh on every request — picks up state + rebuild)
     return new Response(buildHtml(), {
       headers: {
@@ -390,3 +410,112 @@ Bun.serve({
 });
 
 console.log(`\n  \x1b[36mserve-sim dev\x1b[0m  http://localhost:${PORT}\n`);
+
+// ─── Annotations route handler (Bun.serve flavor) ───
+
+const ANNOTATION_CORS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET,POST,PATCH,DELETE,OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+};
+
+function jsonRes(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+      ...ANNOTATION_CORS,
+    },
+  });
+}
+
+function pickAnnotationDeviceForBun(url: URL): string | null {
+  const fromQuery = url.searchParams.get("device");
+  if (fromQuery) return fromQuery;
+  const states = readServeSimStates();
+  return states[0]?.device ?? null;
+}
+
+async function handleAnnotationsBunRequest(req: Request, url: URL): Promise<Response> {
+  const method = req.method;
+  if (method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: ANNOTATION_CORS });
+  }
+
+  const after = url.pathname.slice("/api/annotations".length);
+
+  if (after === "" || after === "/") {
+    if (method === "GET") {
+      const udid = pickAnnotationDeviceForBun(url);
+      if (!udid) return jsonRes([]);
+      return jsonRes(listAnnotations(udid));
+    }
+    if (method === "POST") {
+      let body: AnnotationCreateRequest;
+      try { body = (await req.json()) as AnnotationCreateRequest; }
+      catch (err) { return jsonRes({ error: String((err as Error).message) }, 400); }
+      const udid = pickAnnotationDeviceForBun(url);
+      if (udid && !body?.device?.udid) {
+        body.device = { udid, name: body.device?.name ?? "" };
+      }
+      if (!body?.device?.udid) return jsonRes({ error: "no device available" }, 400);
+      const result = createAnnotation(body);
+      if ("error" in result) return jsonRes(result, 400);
+      return jsonRes(result.annotation, 201);
+    }
+    if (method === "DELETE") {
+      const udid = pickAnnotationDeviceForBun(url);
+      if (!udid) return jsonRes({ error: "no device" }, 404);
+      return jsonRes({ removed: deleteAllAnnotations(udid) });
+    }
+    return new Response(null, { status: 405, headers: ANNOTATION_CORS });
+  }
+
+  const itemMatch = /^\/([A-Za-z0-9_-]+)(?:\/(crop|frame))?$/.exec(after);
+  if (!itemMatch) return new Response("Not found", { status: 404, headers: ANNOTATION_CORS });
+  const id = itemMatch[1]!;
+  const sub = itemMatch[2];
+  const udid = pickAnnotationDeviceForBun(url);
+  if (!udid) return jsonRes({ error: "no device" }, 404);
+
+  if (sub === "crop" || sub === "frame") {
+    if (method !== "GET") return new Response(null, { status: 405, headers: ANNOTATION_CORS });
+    const annotation = getAnnotation(udid, id);
+    if (!annotation) return jsonRes({ error: "not found" }, 404);
+    const relPath = sub === "crop" ? annotation.screenshotPath : annotation.fullFramePath;
+    if (!relPath) return jsonRes({ error: "asset missing" }, 404);
+    const abs = resolveAnnotationAsset(udid, relPath);
+    if (!abs) return jsonRes({ error: "file gone" }, 404);
+    let size = "";
+    try { size = String(statSync(abs).size); } catch {}
+    return new Response(Readable.toWeb(createReadStream(abs)) as unknown as ReadableStream, {
+      headers: {
+        "Content-Type": "image/jpeg",
+        ...(size && { "Content-Length": size }),
+        "Cache-Control": "no-store",
+        "Access-Control-Allow-Origin": "*",
+      },
+    });
+  }
+
+  if (method === "GET") {
+    const annotation = getAnnotation(udid, id);
+    if (!annotation) return jsonRes({ error: "not found" }, 404);
+    return jsonRes(annotation);
+  }
+  if (method === "PATCH") {
+    let patch: AnnotationUpdateRequest;
+    try { patch = (await req.json()) as AnnotationUpdateRequest; }
+    catch (err) { return jsonRes({ error: String((err as Error).message) }, 400); }
+    const updated = updateAnnotation(udid, id, patch);
+    if (!updated) return jsonRes({ error: "not found" }, 404);
+    return jsonRes(updated);
+  }
+  if (method === "DELETE") {
+    const ok = deleteAnnotation(udid, id);
+    if (!ok) return jsonRes({ error: "not found" }, 404);
+    return jsonRes({ id });
+  }
+  return new Response(null, { status: 405, headers: ANNOTATION_CORS });
+}

--- a/packages/serve-sim/package.json
+++ b/packages/serve-sim/package.json
@@ -27,6 +27,8 @@
     "dist/serve-sim.js",
     "dist/middleware.js",
     "dist/middleware.cjs",
+    "src/annotations-shared.ts",
+    "src/annotations.ts",
     "src/ax-shared.ts",
     "src/ax.ts",
     "src/middleware.ts",

--- a/packages/serve-sim/src/annotations-shared.ts
+++ b/packages/serve-sim/src/annotations-shared.ts
@@ -1,0 +1,83 @@
+/**
+ * Comment annotations — shared types between server, middleware, and client.
+ *
+ * An Annotation is a single user-authored comment anchored to a point on the
+ * simulator preview. The `context` block is best-effort: PR1 fills only the
+ * fields the AX (Accessibility) snapshot can give us. Future PRs (DevTools
+ * backend, react-native-grab) will populate componentName / sourceFile / etc.
+ */
+
+export type AnnotationStatus = "pending" | "sent" | "archived";
+
+export interface AnnotationPoint {
+  /** x in simulator point space (NOT browser pixels). */
+  x: number;
+  /** y in simulator point space. */
+  y: number;
+}
+
+export interface AnnotationRegion {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface AnnotationContext {
+  /** Component name from React DevTools / react-native-grab. */
+  componentName?: string;
+  /** Absolute or cwd-relative source path. */
+  sourceFile?: string;
+  sourceLine?: number;
+  sourceColumn?: number;
+  /** Accessibility label resolved via the AX (axe) snapshot. */
+  accessibilityLabel?: string;
+  /** Accessibility role (button, link, image, ...). */
+  accessibilityRole?: string;
+  /** AX type (UIA element type). */
+  accessibilityType?: string;
+  /** AXUniqueId when present, otherwise the AX path. */
+  accessibilityId?: string;
+  /** Native view ID (Fabric ShadowTree). */
+  nativeId?: string;
+  /** Shallow snapshot of relevant props. Functions stripped before save. */
+  props?: Record<string, unknown>;
+}
+
+export interface AnnotationDevice {
+  udid: string;
+  name: string;
+}
+
+export interface Annotation {
+  id: string;
+  createdAt: string;
+  device: AnnotationDevice;
+  point: AnnotationPoint;
+  region?: AnnotationRegion;
+  /** Relative path from the annotations dir to the JPEG crop. */
+  screenshotPath: string;
+  /** Relative path to the full-frame JPEG, when captured. */
+  fullFramePath?: string;
+  context?: AnnotationContext;
+  comment: string;
+  status: AnnotationStatus;
+}
+
+/** Body shape the client POSTs to create an annotation. */
+export interface AnnotationCreateRequest {
+  device: AnnotationDevice;
+  point: AnnotationPoint;
+  region?: AnnotationRegion;
+  context?: AnnotationContext;
+  comment: string;
+  /** data:image/jpeg;base64,... — required. */
+  cropDataUri: string;
+  /** Optional full-frame data URI. */
+  fullFrameDataUri?: string;
+}
+
+export interface AnnotationUpdateRequest {
+  comment?: string;
+  status?: AnnotationStatus;
+}

--- a/packages/serve-sim/src/annotations.ts
+++ b/packages/serve-sim/src/annotations.ts
@@ -22,6 +22,7 @@ import {
   existsSync,
   mkdirSync,
   readFileSync,
+  rmSync,
   unlinkSync,
   writeFileSync,
 } from "fs";
@@ -226,6 +227,30 @@ function isStatus(value: unknown): value is AnnotationStatus {
 function tryUnlink(path: string) {
   try {
     unlinkSync(path);
+  } catch {}
+}
+
+/**
+ * Wipe a device's annotation directory entirely — JSONL, crops, frames, and
+ * the directory itself. Used by `serve-sim --kill` so killing a helper also
+ * tears down its annotations, matching how the per-device `server-{udid}.json`
+ * state file is unlinked. Best-effort: silently no-ops if the dir doesn't
+ * exist.
+ */
+export function purgeAnnotations(udid: string): void {
+  if (!udid) return;
+  try {
+    rmSync(deviceDir(udid), { recursive: true, force: true });
+  } catch {}
+}
+
+/**
+ * Wipe the whole annotations root — every device's subtree. Used by
+ * `serve-sim --kill` (no udid) which kills every helper.
+ */
+export function purgeAllAnnotations(): void {
+  try {
+    rmSync(ROOT, { recursive: true, force: true });
   } catch {}
 }
 

--- a/packages/serve-sim/src/annotations.ts
+++ b/packages/serve-sim/src/annotations.ts
@@ -1,0 +1,232 @@
+/**
+ * Storage layer for comment annotations.
+ *
+ * On-disk layout (rooted at $TMPDIR/serve-sim/annotations):
+ *   {udid}/annotations.jsonl   — append-only JSON Lines, one Annotation per line
+ *   {udid}/crops/anno-{id}.jpg — JPEG crops referenced by Annotation.screenshotPath
+ *   {udid}/frames/anno-{id}.jpg — optional full-frame JPEGs
+ *
+ * Per-device segregation matches serve-sim's existing convention (each helper
+ * tracks its own device under STATE_DIR/server-{udid}.json). It also keeps
+ * cross-tab / multi-sim sessions tidy: kill one sim → its annotations stay,
+ * but they don't pollute another sim's dropdown.
+ *
+ * Concurrency: append-only JSONL means a writer only ever does
+ * `fs.appendFile`, so multiple processes (CLI + middleware) can each append
+ * without corrupting state. Updates and deletes rewrite the file under a
+ * single in-process lock.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { randomBytes } from "crypto";
+import type {
+  Annotation,
+  AnnotationCreateRequest,
+  AnnotationStatus,
+  AnnotationUpdateRequest,
+} from "./annotations-shared";
+
+const ROOT = join(tmpdir(), "serve-sim", "annotations");
+
+function deviceDir(udid: string) {
+  return join(ROOT, sanitizeUdid(udid));
+}
+
+function jsonlPath(udid: string) {
+  return join(deviceDir(udid), "annotations.jsonl");
+}
+
+function cropsDir(udid: string) {
+  return join(deviceDir(udid), "crops");
+}
+
+function framesDir(udid: string) {
+  return join(deviceDir(udid), "frames");
+}
+
+/**
+ * UDIDs are well-formed UUIDs in practice, but defensive sanitation prevents
+ * a hostile or malformed value from breaking out of the annotations root.
+ */
+function sanitizeUdid(udid: string): string {
+  return udid.replace(/[^A-Za-z0-9._-]/g, "_");
+}
+
+function ensureDeviceLayout(udid: string) {
+  mkdirSync(cropsDir(udid), { recursive: true });
+  mkdirSync(framesDir(udid), { recursive: true });
+}
+
+/** 12-hex-char ID, URL-safe and short enough to fit in a filename. */
+function newId(): string {
+  return randomBytes(6).toString("hex");
+}
+
+/** Strip the `data:image/jpeg;base64,` prefix and decode. */
+function decodeDataUri(uri: string): Buffer | null {
+  const match = /^data:image\/(?:jpeg|jpg|png);base64,(.+)$/.exec(uri);
+  if (!match) return null;
+  try {
+    return Buffer.from(match[1]!, "base64");
+  } catch {
+    return null;
+  }
+}
+
+export function listAnnotations(udid: string): Annotation[] {
+  const path = jsonlPath(udid);
+  if (!existsSync(path)) return [];
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch {
+    return [];
+  }
+  const out: Annotation[] = [];
+  for (const line of raw.split(/\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const parsed = JSON.parse(trimmed) as Annotation;
+      if (parsed && typeof parsed === "object" && parsed.id) out.push(parsed);
+    } catch {
+      // Skip malformed lines silently — append-only logs occasionally have a
+      // partial last line if the writer crashed mid-flush.
+    }
+  }
+  return out;
+}
+
+export function getAnnotation(udid: string, id: string): Annotation | null {
+  return listAnnotations(udid).find((a) => a.id === id) ?? null;
+}
+
+export interface CreatedAnnotation {
+  annotation: Annotation;
+}
+
+export function createAnnotation(
+  req: AnnotationCreateRequest,
+): CreatedAnnotation | { error: string } {
+  if (!req?.device?.udid) return { error: "device.udid required" };
+  if (typeof req.comment !== "string") return { error: "comment required" };
+  if (!req.cropDataUri) return { error: "cropDataUri required" };
+  const cropBytes = decodeDataUri(req.cropDataUri);
+  if (!cropBytes) return { error: "cropDataUri must be a data:image/* URI" };
+
+  ensureDeviceLayout(req.device.udid);
+
+  const id = newId();
+  const cropFilename = `anno-${id}.jpg`;
+  const cropAbs = join(cropsDir(req.device.udid), cropFilename);
+  writeFileSync(cropAbs, cropBytes);
+
+  let fullFramePath: string | undefined;
+  if (req.fullFrameDataUri) {
+    const fullBytes = decodeDataUri(req.fullFrameDataUri);
+    if (fullBytes) {
+      const filename = `anno-${id}.jpg`;
+      writeFileSync(join(framesDir(req.device.udid), filename), fullBytes);
+      fullFramePath = `frames/${filename}`;
+    }
+  }
+
+  const annotation: Annotation = {
+    id,
+    createdAt: new Date().toISOString(),
+    device: { udid: req.device.udid, name: req.device.name ?? "" },
+    point: req.point,
+    region: req.region,
+    screenshotPath: `crops/${cropFilename}`,
+    fullFramePath,
+    context: req.context,
+    comment: req.comment,
+    status: "pending",
+  };
+
+  appendFileSync(jsonlPath(req.device.udid), JSON.stringify(annotation) + "\n");
+  return { annotation };
+}
+
+export function updateAnnotation(
+  udid: string,
+  id: string,
+  patch: AnnotationUpdateRequest,
+): Annotation | null {
+  const all = listAnnotations(udid);
+  const idx = all.findIndex((a) => a.id === id);
+  if (idx === -1) return null;
+  const current = all[idx]!;
+  const next: Annotation = {
+    ...current,
+    comment: typeof patch.comment === "string" ? patch.comment : current.comment,
+    status: isStatus(patch.status) ? patch.status : current.status,
+  };
+  all[idx] = next;
+  rewriteJsonl(udid, all);
+  return next;
+}
+
+export function deleteAnnotation(udid: string, id: string): boolean {
+  const all = listAnnotations(udid);
+  const target = all.find((a) => a.id === id);
+  if (!target) return false;
+  const remaining = all.filter((a) => a.id !== id);
+  rewriteJsonl(udid, remaining);
+  // Best-effort cleanup of crop / frame on disk.
+  tryUnlink(join(deviceDir(udid), target.screenshotPath));
+  if (target.fullFramePath) {
+    tryUnlink(join(deviceDir(udid), target.fullFramePath));
+  }
+  return true;
+}
+
+export function deleteAllAnnotations(udid: string): number {
+  const all = listAnnotations(udid);
+  for (const anno of all) {
+    tryUnlink(join(deviceDir(udid), anno.screenshotPath));
+    if (anno.fullFramePath) tryUnlink(join(deviceDir(udid), anno.fullFramePath));
+  }
+  rewriteJsonl(udid, []);
+  return all.length;
+}
+
+/** Resolve a relative path stored in `Annotation.screenshotPath` to absolute. */
+export function resolveAnnotationAsset(
+  udid: string,
+  relativePath: string,
+): string | null {
+  // Reject path traversal — relativePath comes from disk but is reflected in
+  // HTTP responses, and the GET /:id/crop handler maps id → file via this.
+  if (relativePath.includes("..")) return null;
+  const abs = join(deviceDir(udid), relativePath);
+  if (!existsSync(abs)) return null;
+  return abs;
+}
+
+function rewriteJsonl(udid: string, annotations: Annotation[]) {
+  ensureDeviceLayout(udid);
+  const body = annotations.map((a) => JSON.stringify(a)).join("\n");
+  writeFileSync(jsonlPath(udid), body ? body + "\n" : "");
+}
+
+function isStatus(value: unknown): value is AnnotationStatus {
+  return value === "pending" || value === "sent" || value === "archived";
+}
+
+function tryUnlink(path: string) {
+  try {
+    unlinkSync(path);
+  } catch {}
+}
+
+export const ANNOTATIONS_ROOT = ROOT;

--- a/packages/serve-sim/src/ax.ts
+++ b/packages/serve-sim/src/ax.ts
@@ -1,5 +1,4 @@
 import { execFile } from "child_process";
-import { promisify } from "util";
 import { AXE_NOT_INSTALLED_ERROR } from "./ax-shared";
 import type { AxElement, AxRect, AxSnapshot } from "./ax-shared";
 
@@ -10,7 +9,6 @@ const MAX_ELEMENTS = 500;
 const POLL_INTERVAL_MS = 500;
 const MAX_POLL_INTERVAL_MS = 2000;
 const UNAVAILABLE_RETRY_INTERVAL_MS = 15_000;
-const execFileAsync = promisify(execFile);
 
 interface RawAxeNode {
   AXUniqueId: string | null;
@@ -23,12 +21,34 @@ interface RawAxeNode {
   children: RawAxeNode[];
 }
 
-async function execFileText(command: string, args: string[]) {
-  const { stdout } = await execFileAsync(command, args, {
-    timeout: SNAPSHOT_TIMEOUT_MS,
-    maxBuffer: 8 * 1024 * 1024,
+/**
+ * Run a binary and return its stdout as a string. Hand-rolled instead of
+ * `promisify(execFile)` because Bun's promisify wrapper drops stdout/stderr
+ * (returns undefined) — verified against Bun 1.1.x. This callback form works
+ * on both Node and Bun.
+ */
+function execFileText(command: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      command,
+      args,
+      {
+        timeout: SNAPSHOT_TIMEOUT_MS,
+        maxBuffer: 8 * 1024 * 1024,
+        encoding: "utf-8",
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          const enriched = error as NodeJS.ErrnoException & { stderr?: string; stdout?: string };
+          enriched.stderr = typeof stderr === "string" ? stderr : stderr?.toString?.() ?? "";
+          enriched.stdout = typeof stdout === "string" ? stdout : stdout?.toString?.() ?? "";
+          reject(enriched);
+          return;
+        }
+        resolve(typeof stdout === "string" ? stdout : stdout?.toString?.() ?? "");
+      },
+    );
   });
-  return stdout.toString();
 }
 
 function chooseScreenFrame(roots: RawAxeNode[]) {

--- a/packages/serve-sim/src/client/annotations/index.tsx
+++ b/packages/serve-sim/src/client/annotations/index.tsx
@@ -1,0 +1,1492 @@
+/**
+ * Comment annotations UI — picker overlay + dropdown + toolbar buttons.
+ *
+ * Flow:
+ *   1. User clicks the picker (grab) icon in the toolbar → `pickerActive` flips.
+ *   2. PickerOverlay renders absolute over the simulator surface, intercepts
+ *      pointer events. Hover highlights the smallest AX element under the
+ *      cursor (Tier 3 + AX). Click freezes the bbox, captures a JPEG crop
+ *      from the live MJPEG <img>, and shows the inline composer.
+ *   3. User types a comment + Enter (or clicks ↑). We POST to the server's
+ *      /api/annotations endpoint, which writes JSONL + crop to disk and
+ *      returns the persisted Annotation. The annotations list refreshes,
+ *      the badge counter ticks up, and picker stays active for the next pick.
+ *   4. CommentsDropdown shows the accumulated list with delete-one /
+ *      delete-all and a Copy button that builds a markdown bundle for the
+ *      user to paste into Claude/Codex/Cursor.
+ *
+ * The picker uses AxSnapshotContext for hit-testing. If AX is unavailable
+ * (axe CLI not installed), it falls back to plain coordinates (Tier 3 only).
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
+import { SimulatorToolbar } from "serve-sim-client/simulator";
+import type {
+  Annotation,
+  AnnotationContext as AnnotationContextMeta,
+  AnnotationCreateRequest,
+  AnnotationDevice,
+  AnnotationPoint,
+  AnnotationRegion,
+} from "../../annotations-shared";
+import type { AxElement, AxSnapshot } from "../../ax-shared";
+
+// ─── API client ───
+
+function apiBase(basePath: string): string {
+  return basePath === "/" ? "" : basePath.replace(/\/+$/, "");
+}
+
+function endpointFor(basePath: string, suffix: string, device?: string): string {
+  const url = `${apiBase(basePath)}/api/annotations${suffix}`;
+  return device ? `${url}?device=${encodeURIComponent(device)}` : url;
+}
+
+async function fetchAnnotations(basePath: string, device: string): Promise<Annotation[]> {
+  try {
+    const res = await fetch(endpointFor(basePath, "", device));
+    if (!res.ok) return [];
+    return (await res.json()) as Annotation[];
+  } catch {
+    return [];
+  }
+}
+
+async function postAnnotation(
+  basePath: string,
+  device: string,
+  req: AnnotationCreateRequest,
+): Promise<Annotation | null> {
+  try {
+    const res = await fetch(endpointFor(basePath, "", device), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(req),
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as Annotation;
+  } catch {
+    return null;
+  }
+}
+
+async function deleteAnnotationApi(
+  basePath: string,
+  device: string,
+  id: string,
+): Promise<boolean> {
+  try {
+    const res = await fetch(endpointFor(basePath, `/${id}`, device), { method: "DELETE" });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function deleteAllAnnotationsApi(basePath: string, device: string): Promise<boolean> {
+  try {
+    const res = await fetch(endpointFor(basePath, "", device), { method: "DELETE" });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+// ─── Context ───
+
+interface AnnotationsContextValue {
+  annotations: Annotation[];
+  pickerActive: boolean;
+  setPickerActive: (value: boolean) => void;
+  dropdownOpen: boolean;
+  setDropdownOpen: (value: boolean) => void;
+  refresh: () => void;
+  create: (req: Omit<AnnotationCreateRequest, "device">) => Promise<Annotation | null>;
+  remove: (id: string) => Promise<void>;
+  removeAll: () => Promise<void>;
+  /** AX key (axElementKey output) to flash a bbox highlight in the picker overlay. */
+  flashKey: string | null;
+  setFlashKey: (key: string | null) => void;
+  basePath: string;
+  device: AnnotationDevice | null;
+  /** DOM anchor for the Comments dropdown — set by the toolbar button. */
+  commentsAnchor: HTMLElement | null;
+  setCommentsAnchor: (el: HTMLElement | null) => void;
+}
+
+const AnnotationsContext = createContext<AnnotationsContextValue | null>(null);
+
+export function useAnnotations(): AnnotationsContextValue {
+  const ctx = useContext(AnnotationsContext);
+  if (!ctx) throw new Error("useAnnotations: missing <AnnotationsProvider>");
+  return ctx;
+}
+
+export function AnnotationsProvider({
+  basePath,
+  device,
+  pickerActive,
+  onPickerActiveChange,
+  dropdownOpen,
+  onDropdownOpenChange,
+  children,
+}: {
+  basePath: string;
+  device: AnnotationDevice | null;
+  /** Lifted up so the parent can also drive the AX endpoint subscription. */
+  pickerActive: boolean;
+  onPickerActiveChange: (value: boolean) => void;
+  dropdownOpen: boolean;
+  onDropdownOpenChange: (value: boolean) => void;
+  children: ReactNode;
+}) {
+  const [annotations, setAnnotations] = useState<Annotation[]>([]);
+  const [flashKey, setFlashKey] = useState<string | null>(null);
+  const [commentsAnchor, setCommentsAnchor] = useState<HTMLElement | null>(null);
+  const flashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const refresh = useCallback(() => {
+    if (!device?.udid) {
+      setAnnotations([]);
+      return;
+    }
+    void fetchAnnotations(basePath, device.udid).then(setAnnotations);
+  }, [basePath, device?.udid]);
+
+  // Initial load + reload when device changes.
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  // Reset state when the active device changes — annotations are device-scoped.
+  const lastUdidRef = useRef(device?.udid ?? null);
+  useEffect(() => {
+    if (lastUdidRef.current !== (device?.udid ?? null)) {
+      onPickerActiveChange(false);
+      onDropdownOpenChange(false);
+      lastUdidRef.current = device?.udid ?? null;
+    }
+  }, [device?.udid, onPickerActiveChange, onDropdownOpenChange]);
+
+  const setPickerActive = useCallback((value: boolean) => {
+    onPickerActiveChange(value);
+    if (!value) setFlashKey(null);
+  }, [onPickerActiveChange]);
+
+  const setDropdownOpen = useCallback((value: boolean) => {
+    onDropdownOpenChange(value);
+  }, [onDropdownOpenChange]);
+
+  const setFlashKeyTimed = useCallback((key: string | null) => {
+    setFlashKey(key);
+    if (flashTimerRef.current) clearTimeout(flashTimerRef.current);
+    if (key) {
+      flashTimerRef.current = setTimeout(() => setFlashKey(null), 1200);
+    }
+  }, []);
+
+  const create = useCallback(
+    async (req: Omit<AnnotationCreateRequest, "device">): Promise<Annotation | null> => {
+      if (!device?.udid) return null;
+      const created = await postAnnotation(basePath, device.udid, { ...req, device });
+      if (created) setAnnotations((prev) => [...prev, created]);
+      return created;
+    },
+    [basePath, device],
+  );
+
+  const remove = useCallback(
+    async (id: string) => {
+      if (!device?.udid) return;
+      const ok = await deleteAnnotationApi(basePath, device.udid, id);
+      if (ok) setAnnotations((prev) => prev.filter((a) => a.id !== id));
+    },
+    [basePath, device?.udid],
+  );
+
+  const removeAll = useCallback(async () => {
+    if (!device?.udid) return;
+    const ok = await deleteAllAnnotationsApi(basePath, device.udid);
+    if (ok) setAnnotations([]);
+  }, [basePath, device?.udid]);
+
+  const value = useMemo<AnnotationsContextValue>(
+    () => ({
+      annotations,
+      pickerActive,
+      setPickerActive,
+      dropdownOpen,
+      setDropdownOpen,
+      refresh,
+      create,
+      remove,
+      removeAll,
+      flashKey,
+      setFlashKey: setFlashKeyTimed,
+      basePath,
+      device,
+      commentsAnchor,
+      setCommentsAnchor,
+    }),
+    [
+      annotations,
+      pickerActive,
+      setPickerActive,
+      dropdownOpen,
+      setDropdownOpen,
+      refresh,
+      create,
+      remove,
+      removeAll,
+      flashKey,
+      setFlashKeyTimed,
+      basePath,
+      device,
+      commentsAnchor,
+    ],
+  );
+
+  return <AnnotationsContext.Provider value={value}>{children}</AnnotationsContext.Provider>;
+}
+
+// ─── AX hit-testing ───
+
+function axElementContainsPoint(el: AxElement, x: number, y: number): boolean {
+  return (
+    x >= el.frame.x &&
+    x <= el.frame.x + el.frame.width &&
+    y >= el.frame.y &&
+    y <= el.frame.y + el.frame.height
+  );
+}
+
+function pickAxElement(snapshot: AxSnapshot | null, xScreen: number, yScreen: number): AxElement | null {
+  if (!snapshot || snapshot.elements.length === 0) return null;
+  let best: AxElement | null = null;
+  let bestArea = Infinity;
+  for (const el of snapshot.elements) {
+    if (!axElementContainsPoint(el, xScreen, yScreen)) continue;
+    const area = Math.max(1, el.frame.width) * Math.max(1, el.frame.height);
+    if (area < bestArea) {
+      best = el;
+      bestArea = area;
+    }
+  }
+  return best;
+}
+
+function axElementKey(el: AxElement): string {
+  return el.id;
+}
+
+function axElementLabel(el: AxElement): string {
+  return el.label || el.role || el.type || "element";
+}
+
+function axElementContext(el: AxElement): AnnotationContextMeta {
+  const ctx: AnnotationContextMeta = {};
+  if (el.label) ctx.accessibilityLabel = el.label;
+  if (el.role) ctx.accessibilityRole = el.role;
+  if (el.type) ctx.accessibilityType = el.type;
+  if (el.id) ctx.accessibilityId = el.id;
+  return ctx;
+}
+
+// ─── Crop capture ───
+
+const CROP_MAX_DIMENSION = 256;
+const CROP_DEFAULT_RADIUS = 96; // half-width when no AX bbox is available
+const CROP_QUALITY = 0.7;
+
+function findStreamImage(container: HTMLElement | null): HTMLImageElement | null {
+  if (!container) return null;
+  const imgs = container.querySelectorAll("img");
+  for (const img of imgs) {
+    if (!(img instanceof HTMLImageElement)) continue;
+    if (img.style.display === "none") continue;
+    if (img.naturalWidth === 0 || img.naturalHeight === 0) continue;
+    return img;
+  }
+  return null;
+}
+
+interface CropResult {
+  cropDataUri: string;
+  /** Region cropped, in physical pixel coords on the source image. */
+  pixelRegion: { x: number; y: number; w: number; h: number };
+}
+
+function captureCrop(
+  img: HTMLImageElement,
+  pixelRegion: { x: number; y: number; w: number; h: number },
+): CropResult | null {
+  const sx = Math.max(0, Math.floor(pixelRegion.x));
+  const sy = Math.max(0, Math.floor(pixelRegion.y));
+  const sw = Math.min(img.naturalWidth - sx, Math.ceil(pixelRegion.w));
+  const sh = Math.min(img.naturalHeight - sy, Math.ceil(pixelRegion.h));
+  if (sw <= 0 || sh <= 0) return null;
+
+  const longest = Math.max(sw, sh);
+  const scale = longest > CROP_MAX_DIMENSION ? CROP_MAX_DIMENSION / longest : 1;
+  const dw = Math.max(1, Math.round(sw * scale));
+  const dh = Math.max(1, Math.round(sh * scale));
+
+  const canvas = document.createElement("canvas");
+  canvas.width = dw;
+  canvas.height = dh;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return null;
+  try {
+    ctx.drawImage(img, sx, sy, sw, sh, 0, 0, dw, dh);
+  } catch {
+    return null;
+  }
+  let cropDataUri: string;
+  try {
+    cropDataUri = canvas.toDataURL("image/jpeg", CROP_QUALITY);
+  } catch {
+    return null;
+  }
+  return { cropDataUri, pixelRegion: { x: sx, y: sy, w: sw, h: sh } };
+}
+
+// ─── Toolbar icons ───
+
+const PickerIcon = (
+  // Crosshair + arrow — same visual language as react-grab's grab cursor.
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+    strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M12 2v4" />
+    <path d="M12 18v4" />
+    <path d="M2 12h4" />
+    <path d="M18 12h4" />
+    <circle cx="12" cy="12" r="3.2" />
+  </svg>
+);
+
+const CommentsIcon = (
+  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+    strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+  </svg>
+);
+
+const TrashIcon = (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+    strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M3 6h18" />
+    <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+    <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+  </svg>
+);
+
+const SubmitIcon = (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+    strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M12 19V5" />
+    <path d="M5 12l7-7 7 7" />
+  </svg>
+);
+
+// ─── Toolbar buttons ───
+
+export function AnnotationsToolbarButtons() {
+  const {
+    pickerActive,
+    setPickerActive,
+    dropdownOpen,
+    setDropdownOpen,
+    annotations,
+    setCommentsAnchor,
+  } = useAnnotations();
+  const pendingCount = annotations.length;
+  const commentsRef = useCallback(
+    (el: HTMLButtonElement | null) => {
+      setCommentsAnchor(el);
+    },
+    [setCommentsAnchor],
+  );
+
+  return (
+    <>
+      <SimulatorToolbar.Button
+        aria-label={pickerActive ? "Exit comment picker" : "Enter comment picker"}
+        aria-pressed={pickerActive}
+        title={pickerActive ? "Exit picker (Esc)" : "Pick element to comment"}
+        onClick={() => setPickerActive(!pickerActive)}
+        style={pickerActive ? { ...activeButtonStyle } : undefined}
+      >
+        {PickerIcon}
+      </SimulatorToolbar.Button>
+      <SimulatorToolbar.Button
+        ref={commentsRef}
+        aria-label={dropdownOpen ? "Close comments" : "Open comments"}
+        aria-pressed={dropdownOpen}
+        title={
+          pendingCount === 0
+            ? "Comments (none yet)"
+            : `Comments (${pendingCount})`
+        }
+        onClick={() => setDropdownOpen(!dropdownOpen)}
+        style={
+          dropdownOpen
+            ? { ...activeButtonStyle, position: "relative" }
+            : { position: "relative" }
+        }
+      >
+        {CommentsIcon}
+        {pendingCount > 0 && <span style={badgeStyle}>{pendingCount}</span>}
+      </SimulatorToolbar.Button>
+    </>
+  );
+}
+
+// ─── Tools panel section ───
+
+export function AnnotationsTool({
+  enabled,
+  onToggleEnabled,
+  axeUnavailable,
+}: {
+  enabled: boolean;
+  onToggleEnabled: () => void;
+  axeUnavailable: boolean;
+}) {
+  const { annotations } = useAnnotations();
+  return (
+    <section style={toolSection}>
+      <div style={toolHeader}>
+        <span style={toolTitle}>Comments</span>
+        <button
+          type="button"
+          onClick={onToggleEnabled}
+          aria-pressed={enabled}
+          style={enabled ? toolToggleActive : toolToggle}
+        >
+          {enabled ? "Enabled" : "Enable"}
+        </button>
+      </div>
+      {!enabled && (
+        <div style={toolBody}>
+          Pick elements on the simulator and attach comments. Export as a markdown
+          bundle for Claude Code, Cursor or Codex.
+        </div>
+      )}
+      {enabled && axeUnavailable && (
+        <div style={toolWarn}>
+          <strong>AX unavailable</strong> — install{" "}
+          <a
+            href="https://github.com/cameroncooke/AXe"
+            target="_blank"
+            rel="noreferrer"
+            style={toolLink}
+          >
+            AXe
+          </a>{" "}
+          to highlight real elements while picking.
+          <br />
+          <code style={toolCode}>brew install cameroncooke/axe/axe</code>
+        </div>
+      )}
+      {enabled && !axeUnavailable && annotations.length === 0 && (
+        <div style={toolBody}>
+          Use the picker icon in the toolbar — tap an element to add a comment.
+        </div>
+      )}
+      {enabled && annotations.length > 0 && (
+        <div style={toolBody}>
+          {annotations.length} pending — open the comments dropdown to copy the
+          markdown bundle.
+        </div>
+      )}
+    </section>
+  );
+}
+
+const toolSection: CSSProperties = {
+  background: "#1c1c1e",
+  border: "1px solid rgba(255,255,255,0.08)",
+  borderRadius: 10,
+  padding: "8px 12px",
+};
+const toolHeader: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: 8,
+};
+const toolTitle: CSSProperties = {
+  fontSize: 11,
+  fontWeight: 600,
+  color: "rgba(255,255,255,0.5)",
+  textTransform: "uppercase",
+  letterSpacing: "0.08em",
+};
+const toolToggle: CSSProperties = {
+  background: "transparent",
+  border: "1px solid rgba(255,255,255,0.18)",
+  color: "rgba(255,255,255,0.85)",
+  fontSize: 11,
+  padding: "3px 10px",
+  borderRadius: 6,
+  cursor: "pointer",
+  fontFamily: "inherit",
+};
+const toolToggleActive: CSSProperties = {
+  ...toolToggle,
+  background: "rgba(96,165,250,0.18)",
+  borderColor: "rgba(96,165,250,0.5)",
+  color: "#bfdbfe",
+};
+const toolBody: CSSProperties = {
+  fontSize: 12,
+  color: "rgba(226,232,240,0.7)",
+  lineHeight: 1.45,
+  marginTop: 8,
+};
+const toolWarn: CSSProperties = {
+  fontSize: 12,
+  color: "#fbbf24",
+  background: "rgba(251,191,36,0.08)",
+  border: "1px solid rgba(251,191,36,0.25)",
+  borderRadius: 8,
+  padding: "8px 10px",
+  lineHeight: 1.5,
+  marginTop: 8,
+};
+const toolLink: CSSProperties = {
+  color: "#fbbf24",
+  textDecoration: "underline",
+};
+const toolCode: CSSProperties = {
+  display: "inline-block",
+  marginTop: 4,
+  fontFamily: "ui-monospace, monospace",
+  fontSize: 11,
+  background: "rgba(0,0,0,0.35)",
+  padding: "2px 6px",
+  borderRadius: 4,
+  color: "#fde68a",
+};
+
+// ─── Picker overlay ───
+
+interface PickerComposerState {
+  point: AnnotationPoint;
+  region?: AnnotationRegion;
+  axElement: AxElement | null;
+  cropDataUri: string;
+  /** Anchor for the composer popover, in overlay-normalized 0..1 coords. */
+  anchor: { x: number; y: number };
+}
+
+export function AnnotationsPickerOverlay({
+  snapshot,
+  containerRef,
+}: {
+  snapshot: AxSnapshot | null;
+  /** Ref to the relative-positioned simulator container that holds <SimulatorView>. */
+  containerRef: React.MutableRefObject<HTMLDivElement | null>;
+}) {
+  const {
+    pickerActive,
+    setPickerActive,
+    create,
+    annotations,
+    flashKey,
+  } = useAnnotations();
+
+  const [hover, setHover] = useState<{
+    el: AxElement | null;
+    xNorm: number;
+    yNorm: number;
+  } | null>(null);
+  const [composer, setComposer] = useState<PickerComposerState | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [comment, setComment] = useState("");
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  // Reset all transient state when picker turns off.
+  useEffect(() => {
+    if (!pickerActive) {
+      setHover(null);
+      setComposer(null);
+      setComment("");
+    }
+  }, [pickerActive]);
+
+  // Focus the composer input when it opens.
+  useEffect(() => {
+    if (composer && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [composer]);
+
+  // ESC exits picker mode (also closes composer if open).
+  useEffect(() => {
+    if (!pickerActive) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        if (composer) {
+          setComposer(null);
+          setComment("");
+        } else {
+          setPickerActive(false);
+        }
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [pickerActive, composer, setPickerActive]);
+
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      if (composer) return; // freeze hover while composing
+      const rect = overlayRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      const xNorm = (e.clientX - rect.left) / rect.width;
+      const yNorm = (e.clientY - rect.top) / rect.height;
+      let el: AxElement | null = null;
+      if (snapshot && snapshot.screen.width > 1 && snapshot.screen.height > 1) {
+        const xScreen = xNorm * snapshot.screen.width;
+        const yScreen = yNorm * snapshot.screen.height;
+        el = pickAxElement(snapshot, xScreen, yScreen);
+      }
+      setHover({ el, xNorm, yNorm });
+    },
+    [snapshot, composer],
+  );
+
+  const handleMouseLeave = useCallback(() => {
+    if (composer) return;
+    setHover(null);
+  }, [composer]);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const rect = overlayRef.current?.getBoundingClientRect();
+      const container = containerRef.current;
+      if (!rect || !container) return;
+      const img = findStreamImage(container);
+      if (!img) return;
+      const xNorm = (e.clientX - rect.left) / rect.width;
+      const yNorm = (e.clientY - rect.top) / rect.height;
+
+      let el: AxElement | null = null;
+      let pointSim: AnnotationPoint;
+      let region: AnnotationRegion | undefined;
+      let pixelRegion: { x: number; y: number; w: number; h: number };
+
+      if (snapshot && snapshot.screen.width > 1 && snapshot.screen.height > 1) {
+        const xScreen = xNorm * snapshot.screen.width;
+        const yScreen = yNorm * snapshot.screen.height;
+        pointSim = { x: Math.round(xScreen), y: Math.round(yScreen) };
+        el = pickAxElement(snapshot, xScreen, yScreen);
+        const scaleX = img.naturalWidth / snapshot.screen.width;
+        const scaleY = img.naturalHeight / snapshot.screen.height;
+        if (el) {
+          region = {
+            x: el.frame.x,
+            y: el.frame.y,
+            w: el.frame.width,
+            h: el.frame.height,
+          };
+          pixelRegion = {
+            x: el.frame.x * scaleX,
+            y: el.frame.y * scaleY,
+            w: el.frame.width * scaleX,
+            h: el.frame.height * scaleY,
+          };
+        } else {
+          // No bbox — crop a square around the click point.
+          pixelRegion = {
+            x: xNorm * img.naturalWidth - CROP_DEFAULT_RADIUS,
+            y: yNorm * img.naturalHeight - CROP_DEFAULT_RADIUS,
+            w: CROP_DEFAULT_RADIUS * 2,
+            h: CROP_DEFAULT_RADIUS * 2,
+          };
+        }
+      } else {
+        // No AX snapshot at all (Tier 3 plain).
+        pointSim = {
+          x: Math.round(xNorm * img.naturalWidth),
+          y: Math.round(yNorm * img.naturalHeight),
+        };
+        pixelRegion = {
+          x: xNorm * img.naturalWidth - CROP_DEFAULT_RADIUS,
+          y: yNorm * img.naturalHeight - CROP_DEFAULT_RADIUS,
+          w: CROP_DEFAULT_RADIUS * 2,
+          h: CROP_DEFAULT_RADIUS * 2,
+        };
+      }
+
+      const cropped = captureCrop(img, pixelRegion);
+      if (!cropped) return;
+
+      // Shift+click = quick-add with empty comment.
+      if (e.shiftKey) {
+        void create({
+          point: pointSim,
+          region,
+          context: el ? axElementContext(el) : undefined,
+          comment: "",
+          cropDataUri: cropped.cropDataUri,
+        });
+        return;
+      }
+
+      setComposer({
+        point: pointSim,
+        region,
+        axElement: el,
+        cropDataUri: cropped.cropDataUri,
+        anchor: { x: xNorm, y: yNorm },
+      });
+      setComment("");
+    },
+    [snapshot, create, containerRef],
+  );
+
+  const submitComposer = useCallback(async () => {
+    if (!composer || submitting) return;
+    setSubmitting(true);
+    try {
+      const created = await create({
+        point: composer.point,
+        region: composer.region,
+        context: composer.axElement ? axElementContext(composer.axElement) : undefined,
+        comment: comment.trim(),
+        cropDataUri: composer.cropDataUri,
+      });
+      if (created) {
+        setComposer(null);
+        setComment("");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }, [composer, comment, create, submitting]);
+
+  // Show flashing bbox for "click an item in dropdown to locate it" — driven by
+  // flashKey from context.
+  const flashRect = useMemo(() => {
+    if (!flashKey || !snapshot) return null;
+    const matchingAnno = annotations.find(
+      (a) => a.context?.accessibilityId === flashKey || a.id === flashKey,
+    );
+    if (matchingAnno?.region) {
+      return {
+        x: matchingAnno.region.x / snapshot.screen.width,
+        y: matchingAnno.region.y / snapshot.screen.height,
+        w: matchingAnno.region.w / snapshot.screen.width,
+        h: matchingAnno.region.h / snapshot.screen.height,
+      };
+    }
+    return null;
+  }, [flashKey, snapshot, annotations]);
+
+  if (!pickerActive && !flashRect) return null;
+
+  const screen = snapshot?.screen;
+  const axBbox =
+    composer?.axElement?.frame ??
+    (hover && !composer ? hover.el?.frame : null) ??
+    null;
+  const showAxBbox = axBbox && screen && screen.width > 1 && screen.height > 1;
+  const composerAxElement = composer?.axElement ?? null;
+
+  return (
+    <div
+      ref={overlayRef}
+      onMouseMove={pickerActive ? handleMouseMove : undefined}
+      onMouseLeave={pickerActive ? handleMouseLeave : undefined}
+      onClick={pickerActive ? handleClick : undefined}
+      style={{
+        ...overlayStyle,
+        cursor: pickerActive ? "crosshair" : "default",
+        pointerEvents: pickerActive ? "auto" : "none",
+        background: pickerActive ? "rgba(99,102,241,0.04)" : "transparent",
+      }}
+    >
+      {showAxBbox && screen && axBbox && (
+        <div
+          aria-hidden="true"
+          style={{
+            ...bboxStyle,
+            left: `${(axBbox.x / screen.width) * 100}%`,
+            top: `${(axBbox.y / screen.height) * 100}%`,
+            width: `${(axBbox.width / screen.width) * 100}%`,
+            height: `${(axBbox.height / screen.height) * 100}%`,
+            borderColor: composer ? "#c084fc" : "#a78bfa",
+            background: composer ? "rgba(192,132,252,0.18)" : "rgba(167,139,250,0.14)",
+          }}
+        />
+      )}
+
+      {flashRect && screen && (
+        <div
+          aria-hidden="true"
+          style={{
+            ...bboxStyle,
+            left: `${flashRect.x * 100}%`,
+            top: `${flashRect.y * 100}%`,
+            width: `${flashRect.w * 100}%`,
+            height: `${flashRect.h * 100}%`,
+            borderColor: "#fbbf24",
+            background: "rgba(251,191,36,0.18)",
+            animation: "annotations-flash 1.2s ease-in-out",
+          }}
+        />
+      )}
+
+      {pickerActive && hover && !composer && hover.el && (
+        <PickerHoverBadge
+          xNorm={hover.xNorm}
+          yNorm={hover.yNorm}
+          element={hover.el}
+        />
+      )}
+
+      {pickerActive && composer && (
+        <PickerComposer
+          xNorm={composer.anchor.x}
+          yNorm={composer.anchor.y}
+          element={composerAxElement}
+          comment={comment}
+          submitting={submitting}
+          onChange={setComment}
+          onSubmit={submitComposer}
+          onCancel={() => {
+            setComposer(null);
+            setComment("");
+          }}
+          inputRef={inputRef}
+        />
+      )}
+    </div>
+  );
+}
+
+function PickerHoverBadge({
+  xNorm,
+  yNorm,
+  element,
+}: {
+  xNorm: number;
+  yNorm: number;
+  element: AxElement | null;
+}) {
+  const label = element ? axElementLabel(element) : "pick a point";
+  return (
+    <div style={floatBadgeStyle(xNorm, yNorm)}>
+      <span style={{ fontWeight: 600 }}>{label}</span>
+      {element?.role && element.role !== element.label && (
+        <span style={{ opacity: 0.7, marginLeft: 6 }}>{element.role}</span>
+      )}
+    </div>
+  );
+}
+
+function PickerComposer({
+  xNorm,
+  yNorm,
+  element,
+  comment,
+  submitting,
+  onChange,
+  onSubmit,
+  onCancel,
+  inputRef,
+}: {
+  xNorm: number;
+  yNorm: number;
+  element: AxElement | null;
+  comment: string;
+  submitting: boolean;
+  onChange: (next: string) => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+  inputRef: React.MutableRefObject<HTMLInputElement | null>;
+}) {
+  const label = element ? axElementLabel(element) : "Annotation";
+  return (
+    <div style={composerStyle(xNorm, yNorm)} onClick={(e) => e.stopPropagation()}>
+      <div style={composerLabelStyle}>
+        <span style={{ fontWeight: 600 }}>{label}</span>
+        {element?.role && element.role !== element.label && (
+          <span style={{ opacity: 0.7, marginLeft: 6, fontSize: 11 }}>{element.role}</span>
+        )}
+      </div>
+      <div style={composerInputRow}>
+        <input
+          ref={inputRef}
+          type="text"
+          placeholder="Add context"
+          value={comment}
+          onChange={(e) => onChange(e.currentTarget.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              onSubmit();
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              onCancel();
+            }
+          }}
+          disabled={submitting}
+          style={composerInputStyle}
+        />
+        <button
+          type="button"
+          aria-label="Submit comment"
+          title="Submit (Enter)"
+          onClick={onSubmit}
+          disabled={submitting}
+          style={composerSubmitStyle}
+        >
+          {SubmitIcon}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ─── Comments dropdown ───
+
+export function AnnotationsDropdown() {
+  const {
+    annotations,
+    dropdownOpen,
+    setDropdownOpen,
+    remove,
+    removeAll,
+    setFlashKey,
+    basePath,
+    commentsAnchor: anchor,
+  } = useAnnotations();
+  const ref = useRef<HTMLDivElement | null>(null);
+  const [position, setPosition] = useState<{ top: number; right: number } | null>(null);
+  const [confirmingClear, setConfirmingClear] = useState(false);
+  const [copyState, setCopyState] = useState<"idle" | "copied">("idle");
+
+  // Anchor positioning — recompute on open + on resize.
+  useEffect(() => {
+    if (!dropdownOpen || !anchor) return;
+    const compute = () => {
+      const rect = anchor.getBoundingClientRect();
+      setPosition({
+        top: rect.bottom + 8,
+        right: Math.max(8, window.innerWidth - rect.right),
+      });
+    };
+    compute();
+    window.addEventListener("resize", compute);
+    window.addEventListener("scroll", compute, true);
+    return () => {
+      window.removeEventListener("resize", compute);
+      window.removeEventListener("scroll", compute, true);
+    };
+  }, [dropdownOpen, anchor]);
+
+  // Click-outside + ESC.
+  useEffect(() => {
+    if (!dropdownOpen) return;
+    const onDown = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node) && !anchor?.contains(e.target as Node)) {
+        setDropdownOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setDropdownOpen(false);
+      if ((e.key === "c" || e.key === "C") && (e.metaKey || e.ctrlKey)) {
+        const target = e.target as HTMLElement | null;
+        if (target?.tagName === "INPUT" || target?.tagName === "TEXTAREA") return;
+        e.preventDefault();
+        void copyBundleToClipboard(annotations, basePath, () => setCopyState("copied"));
+        setTimeout(() => setCopyState("idle"), 1200);
+      }
+    };
+    window.addEventListener("mousedown", onDown);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("mousedown", onDown);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [dropdownOpen, anchor, setDropdownOpen, annotations, basePath]);
+
+  const handleCopy = useCallback(async () => {
+    await copyBundleToClipboard(annotations, basePath, () => setCopyState("copied"));
+    setTimeout(() => setCopyState("idle"), 1200);
+  }, [annotations, basePath]);
+
+  const handleClearAll = useCallback(async () => {
+    if (!confirmingClear) {
+      setConfirmingClear(true);
+      setTimeout(() => setConfirmingClear(false), 2500);
+      return;
+    }
+    await removeAll();
+    setConfirmingClear(false);
+  }, [confirmingClear, removeAll]);
+
+  if (!dropdownOpen) return null;
+
+  return (
+    <div
+      ref={ref}
+      role="dialog"
+      aria-label="Comments"
+      style={{
+        ...dropdownStyle,
+        top: position?.top ?? 96,
+        right: position?.right ?? 24,
+      }}
+    >
+      <div style={dropdownHeaderStyle}>
+        <span style={{ fontWeight: 600, fontSize: 13 }}>
+          Comments
+          {annotations.length > 0 && (
+            <span style={{ opacity: 0.5, marginLeft: 6 }}>{annotations.length}</span>
+          )}
+        </span>
+        <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+          <button
+            type="button"
+            onClick={handleCopy}
+            disabled={annotations.length === 0}
+            style={dropdownCopyStyle(annotations.length === 0)}
+            title="Copy markdown bundle to clipboard (Cmd/Ctrl+C)"
+          >
+            {copyState === "copied" ? "Copied" : "Copy"}
+          </button>
+          <button
+            type="button"
+            onClick={handleClearAll}
+            disabled={annotations.length === 0}
+            style={dropdownTrashStyle(confirmingClear, annotations.length === 0)}
+            aria-label={confirmingClear ? "Confirm clear all" : "Clear all comments"}
+            title={confirmingClear ? "Click again to confirm" : "Clear all"}
+          >
+            {TrashIcon}
+          </button>
+        </div>
+      </div>
+      {annotations.length === 0 ? (
+        <div style={dropdownEmptyStyle}>
+          No comments yet. Click the picker icon and select an element.
+        </div>
+      ) : (
+        <div style={dropdownListStyle} role="list">
+          {annotations.map((anno) => (
+            <DropdownItem
+              key={anno.id}
+              annotation={anno}
+              onDelete={() => remove(anno.id)}
+              onLocate={() => setFlashKey(anno.context?.accessibilityId ?? anno.id)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DropdownItem({
+  annotation,
+  onDelete,
+  onLocate,
+}: {
+  annotation: Annotation;
+  onDelete: () => void;
+  onLocate: () => void;
+}) {
+  const [hover, setHover] = useState(false);
+  const tag =
+    annotation.context?.accessibilityRole ||
+    annotation.context?.accessibilityType ||
+    annotation.context?.componentName ||
+    "element";
+  const label = annotation.context?.accessibilityLabel || annotation.context?.componentName;
+  const relative = formatRelativeTime(annotation.createdAt);
+
+  return (
+    <div
+      role="listitem"
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      onClick={onLocate}
+      style={{
+        ...dropdownItemStyle,
+        background: hover ? "rgba(255,255,255,0.06)" : "transparent",
+      }}
+    >
+      <div style={dropdownItemHeaderStyle}>
+        <span style={dropdownItemTagStyle}>{tag}</span>
+        {label && <span style={dropdownItemLabelStyle}>{label}</span>}
+        <span style={dropdownItemTimeStyle}>{relative}</span>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete();
+          }}
+          style={{
+            ...dropdownItemDeleteStyle,
+            opacity: hover ? 1 : 0,
+            pointerEvents: hover ? "auto" : "none",
+          }}
+          aria-label="Delete this comment"
+          title="Delete"
+        >
+          {TrashIcon}
+        </button>
+      </div>
+      {annotation.comment && (
+        <div style={dropdownItemCommentStyle}>{annotation.comment}</div>
+      )}
+    </div>
+  );
+}
+
+// ─── Markdown export ───
+
+function buildMarkdownBundle(
+  annotations: Annotation[],
+  basePath: string,
+  origin: string,
+): string {
+  const head = annotations[0];
+  const lines: string[] = [];
+  lines.push(`# Feedback from simulator session`);
+  if (head) {
+    lines.push(`Device: ${head.device.name || head.device.udid} (UDID: ${head.device.udid})`);
+  }
+  const now = new Date().toISOString();
+  lines.push(`Captured: ${annotations.length} annotation${annotations.length === 1 ? "" : "s"} · ${now}`);
+  lines.push("");
+  annotations.forEach((anno, index) => {
+    const num = index + 1;
+    const heading = anno.comment.trim() || "(no comment)";
+    lines.push(`## [${num}] ${heading}`);
+    const ctx = anno.context;
+    if (ctx?.componentName) {
+      const file = ctx.sourceFile
+        ? ctx.sourceLine
+          ? `${ctx.sourceFile}:${ctx.sourceLine}`
+          : ctx.sourceFile
+        : "";
+      lines.push(`- Component: ${ctx.componentName}${file ? ` (${file})` : ""}`);
+    } else if (ctx?.accessibilityLabel || ctx?.accessibilityRole) {
+      const role = ctx.accessibilityRole || ctx.accessibilityType || "element";
+      const label = ctx.accessibilityLabel ? `"${ctx.accessibilityLabel}"` : "";
+      lines.push(`- Element: ${role}${label ? ` ${label}` : ""}`);
+    }
+    lines.push(`- Location: (${Math.round(anno.point.x)}, ${Math.round(anno.point.y)})`);
+    const cropUrl = `${origin}${apiBase(basePath)}/api/annotations/${anno.id}/crop?device=${encodeURIComponent(anno.device.udid)}`;
+    lines.push(`- Screenshot: ${cropUrl}`);
+    lines.push("");
+  });
+  return lines.join("\n");
+}
+
+async function copyBundleToClipboard(
+  annotations: Annotation[],
+  basePath: string,
+  onSuccess: () => void,
+): Promise<void> {
+  if (annotations.length === 0) return;
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+  const md = buildMarkdownBundle(annotations, basePath, origin);
+  try {
+    await navigator.clipboard.writeText(md);
+    onSuccess();
+  } catch {
+    // Fallback for non-secure contexts.
+    const textarea = document.createElement("textarea");
+    textarea.value = md;
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    try { document.execCommand("copy"); onSuccess(); } catch {}
+    document.body.removeChild(textarea);
+  }
+}
+
+function formatRelativeTime(iso: string): string {
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return "";
+  const seconds = Math.max(0, Math.floor((Date.now() - t) / 1000));
+  if (seconds < 5) return "now";
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `${days}d`;
+}
+
+// ─── Styles ───
+
+const activeButtonStyle: CSSProperties = {
+  background: "rgba(96,165,250,0.18)",
+  color: "#bfdbfe",
+};
+
+const badgeStyle: CSSProperties = {
+  position: "absolute",
+  top: 0,
+  right: 0,
+  minWidth: 14,
+  height: 14,
+  padding: "0 4px",
+  borderRadius: 7,
+  background: "#60a5fa",
+  color: "#0a0a0a",
+  fontSize: 9,
+  fontWeight: 700,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  pointerEvents: "none",
+};
+
+const overlayStyle: CSSProperties = {
+  position: "absolute",
+  inset: 0,
+  zIndex: 40,
+  userSelect: "none",
+};
+
+const bboxStyle: CSSProperties = {
+  position: "absolute",
+  borderWidth: 1.5,
+  borderStyle: "solid",
+  borderRadius: 6,
+  pointerEvents: "none",
+  transition: "left 80ms ease, top 80ms ease, width 80ms ease, height 80ms ease",
+};
+
+function floatBadgeStyle(xNorm: number, yNorm: number): CSSProperties {
+  return {
+    position: "absolute",
+    left: `${xNorm * 100}%`,
+    top: `${yNorm * 100}%`,
+    transform: "translate(12px, 12px)",
+    background: "rgba(15,23,42,0.92)",
+    color: "#e2e8f0",
+    fontSize: 11,
+    fontFamily: "-apple-system, system-ui, sans-serif",
+    padding: "4px 8px",
+    borderRadius: 6,
+    border: "1px solid rgba(148,163,184,0.3)",
+    backdropFilter: "blur(6px)",
+    WebkitBackdropFilter: "blur(6px)",
+    boxShadow: "0 6px 24px rgba(0,0,0,0.4)",
+    pointerEvents: "none",
+    whiteSpace: "nowrap",
+  };
+}
+
+function composerStyle(xNorm: number, yNorm: number): CSSProperties {
+  // Anchor below the click; clamp to stay inside the surface via translate
+  // bias when near edges. Keep simple here — the surface clips anything
+  // truly off-screen.
+  const below = yNorm < 0.7;
+  return {
+    position: "absolute",
+    left: `${xNorm * 100}%`,
+    top: `${yNorm * 100}%`,
+    transform: below ? "translate(8px, 8px)" : "translate(8px, calc(-100% - 8px))",
+    minWidth: 220,
+    maxWidth: 320,
+    padding: "8px 10px",
+    background: "rgba(17,24,39,0.96)",
+    border: "1px solid rgba(148,163,184,0.35)",
+    borderRadius: 10,
+    boxShadow: "0 10px 32px rgba(0,0,0,0.5)",
+    backdropFilter: "blur(8px)",
+    WebkitBackdropFilter: "blur(8px)",
+    color: "#f8fafc",
+    fontFamily: "-apple-system, system-ui, sans-serif",
+    pointerEvents: "auto",
+    zIndex: 41,
+  };
+}
+
+const composerLabelStyle: CSSProperties = {
+  fontSize: 11,
+  marginBottom: 6,
+  color: "#cbd5e1",
+};
+
+const composerInputRow: CSSProperties = {
+  display: "flex",
+  gap: 6,
+  alignItems: "center",
+};
+
+const composerInputStyle: CSSProperties = {
+  flex: 1,
+  fontSize: 13,
+  padding: "5px 8px",
+  background: "rgba(15,23,42,0.85)",
+  color: "#f8fafc",
+  border: "1px solid rgba(148,163,184,0.4)",
+  borderRadius: 6,
+  outline: "none",
+  fontFamily: "inherit",
+};
+
+const composerSubmitStyle: CSSProperties = {
+  background: "rgba(96,165,250,0.18)",
+  border: "1px solid rgba(96,165,250,0.4)",
+  color: "#bfdbfe",
+  width: 26,
+  height: 26,
+  borderRadius: 6,
+  cursor: "pointer",
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  flexShrink: 0,
+};
+
+const dropdownStyle: CSSProperties = {
+  position: "fixed",
+  width: 320,
+  maxWidth: "calc(100vw - 24px)",
+  maxHeight: "70vh",
+  background: "rgba(17,24,39,0.96)",
+  border: "1px solid rgba(148,163,184,0.25)",
+  borderRadius: 12,
+  boxShadow: "0 18px 48px rgba(0,0,0,0.55)",
+  backdropFilter: "blur(8px)",
+  WebkitBackdropFilter: "blur(8px)",
+  color: "#f8fafc",
+  fontFamily: "-apple-system, system-ui, sans-serif",
+  display: "flex",
+  flexDirection: "column",
+  overflow: "hidden",
+  zIndex: 100,
+};
+
+const dropdownHeaderStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  padding: "10px 12px",
+  borderBottom: "1px solid rgba(148,163,184,0.12)",
+};
+
+function dropdownCopyStyle(disabled: boolean): CSSProperties {
+  return {
+    background: "rgba(255,255,255,0.06)",
+    border: "1px solid rgba(255,255,255,0.12)",
+    color: disabled ? "rgba(255,255,255,0.3)" : "#e2e8f0",
+    padding: "3px 10px",
+    fontSize: 11,
+    borderRadius: 6,
+    cursor: disabled ? "not-allowed" : "pointer",
+    fontFamily: "inherit",
+  };
+}
+
+function dropdownTrashStyle(confirming: boolean, disabled: boolean): CSSProperties {
+  return {
+    background: confirming ? "rgba(248,113,113,0.18)" : "transparent",
+    border: confirming ? "1px solid rgba(248,113,113,0.5)" : "1px solid transparent",
+    color: disabled ? "rgba(255,255,255,0.25)" : confirming ? "#fecaca" : "#f87171",
+    padding: 4,
+    borderRadius: 6,
+    cursor: disabled ? "not-allowed" : "pointer",
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+  };
+}
+
+const dropdownEmptyStyle: CSSProperties = {
+  padding: "20px 16px",
+  fontSize: 12,
+  color: "rgba(226,232,240,0.55)",
+  textAlign: "center",
+  lineHeight: 1.45,
+};
+
+const dropdownListStyle: CSSProperties = {
+  overflowY: "auto",
+  maxHeight: "60vh",
+};
+
+const dropdownItemStyle: CSSProperties = {
+  padding: "8px 12px",
+  borderBottom: "1px solid rgba(148,163,184,0.08)",
+  cursor: "pointer",
+  transition: "background 120ms ease",
+};
+
+const dropdownItemHeaderStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 6,
+  fontSize: 11,
+  marginBottom: 2,
+};
+
+const dropdownItemTagStyle: CSSProperties = {
+  fontWeight: 600,
+  color: "#bfdbfe",
+};
+
+const dropdownItemLabelStyle: CSSProperties = {
+  color: "rgba(226,232,240,0.7)",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+  whiteSpace: "nowrap",
+  flex: 1,
+};
+
+const dropdownItemTimeStyle: CSSProperties = {
+  color: "rgba(226,232,240,0.4)",
+  fontSize: 10,
+  fontVariantNumeric: "tabular-nums",
+  marginLeft: "auto",
+  flexShrink: 0,
+};
+
+const dropdownItemDeleteStyle: CSSProperties = {
+  background: "transparent",
+  border: "none",
+  color: "#f87171",
+  padding: 2,
+  cursor: "pointer",
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  transition: "opacity 120ms ease",
+  flexShrink: 0,
+};
+
+const dropdownItemCommentStyle: CSSProperties = {
+  fontSize: 12,
+  color: "rgba(226,232,240,0.85)",
+  whiteSpace: "pre-wrap",
+  wordBreak: "break-word",
+  marginTop: 2,
+};

--- a/packages/serve-sim/src/client/client.tsx
+++ b/packages/serve-sim/src/client/client.tsx
@@ -26,6 +26,13 @@ import {
   type SimulatorOrientation,
   type StreamConfig,
 } from "serve-sim-client/simulator";
+import {
+  AnnotationsProvider,
+  AnnotationsToolbarButtons,
+  AnnotationsPickerOverlay,
+  AnnotationsDropdown,
+  AnnotationsTool,
+} from "./annotations";
 
 /**
  * Fetches an MJPEG stream and parses out individual JPEG frames as blob URLs.
@@ -1630,6 +1637,8 @@ function ToolsPanel({
   currentApp,
   axOverlayEnabled,
   onToggleAxOverlay,
+  annotationsEnabled,
+  onToggleAnnotationsEnabled,
 }: {
   open: boolean;
   onClose: () => void;
@@ -1637,9 +1646,30 @@ function ToolsPanel({
   currentApp: { bundleId: string; isReactNative: boolean; pid?: number } | null;
   axOverlayEnabled: boolean;
   onToggleAxOverlay: () => void;
+  annotationsEnabled: boolean;
+  onToggleAnnotationsEnabled: () => void;
 }) {
+  const { snapshot } = useAxSnapshotContext();
+  const axeUnavailable = isAxeUnavailable(snapshot);
+  const panelRef = useRef<HTMLElement | null>(null);
+
+  // Close on outside click. We listen on the document in capture so we run
+  // before any handler that might call stopPropagation (e.g. dropdowns).
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      const target = e.target as Node | null;
+      if (!target) return;
+      if (panelRef.current?.contains(target)) return;
+      onClose();
+    };
+    document.addEventListener("mousedown", onDown, true);
+    return () => document.removeEventListener("mousedown", onDown, true);
+  }, [open, onClose]);
+
   return (
     <aside
+      ref={panelRef}
       style={{
         ...panelStyles.panel,
         transform: open ? "translateX(0)" : "translateX(calc(100% + 24px))",
@@ -1663,6 +1693,11 @@ function ToolsPanel({
           <AxTreeTool
             overlayEnabled={axOverlayEnabled}
             onToggleOverlay={onToggleAxOverlay}
+          />
+          <AnnotationsTool
+            enabled={annotationsEnabled}
+            onToggleEnabled={onToggleAnnotationsEnabled}
+            axeUnavailable={axeUnavailable}
           />
           <AppDetectionTool udid={udid} currentApp={currentApp} />
           <AppPermissionsTool udid={udid} bundleId={currentApp?.bundleId ?? null} />
@@ -1700,6 +1735,25 @@ function App() {
   const [stoppingUdids, setStoppingUdids] = useState<Set<string>>(new Set());
   const [switching, setSwitching] = useState(false);
   const [axOverlayEnabled, setAxOverlayEnabled] = useState(false);
+  const [annotationsEnabled, setAnnotationsEnabled] = useState(false);
+  const [annotationsPickerActive, setAnnotationsPickerActive] = useState(false);
+  const [annotationsDropdownOpen, setAnnotationsDropdownOpen] = useState(false);
+  const toggleAnnotationsEnabled = useCallback(() => {
+    setAnnotationsEnabled((prev) => {
+      const next = !prev;
+      if (!next) {
+        // Reset picker / dropdown when feature disables, so re-enabling
+        // starts clean.
+        setAnnotationsPickerActive(false);
+        setAnnotationsDropdownOpen(false);
+      } else {
+        // Close the Tools panel so the toolbar buttons that just appeared
+        // are visible — otherwise the change is hidden behind the panel.
+        setPanelOpen(false);
+      }
+      return next;
+    });
+  }, []);
 
   const fetchDevices = useCallback(async () => {
     setDevicesLoading(true);
@@ -1986,6 +2040,17 @@ function App() {
     // matches Simulator.app so muscle memory carries over.
     const onKey = (e: KeyboardEvent, type: "down" | "up") => {
       if (!simFocusedRef.current) return;
+      // If the user is typing in a composer / annotation input, never hijack
+      // their keys — let the input receive them and React handle Enter/Escape.
+      const active = document.activeElement as HTMLElement | null;
+      if (
+        active &&
+        (active.tagName === "INPUT" ||
+          active.tagName === "TEXTAREA" ||
+          active.isContentEditable)
+      ) {
+        return;
+      }
       // Cmd+Shift+H → Home button (Simulator.app's shortcut).
       if (e.code === "KeyH" && e.metaKey && e.shiftKey) {
         e.preventDefault();
@@ -2085,8 +2150,28 @@ function App() {
       ? PANEL_TOTAL
       : 0;
 
+  const annotationsDevice = useMemo(
+    () =>
+      config.device
+        ? { udid: config.device, name: selectedDevice?.name ?? "" }
+        : null,
+    [config.device, selectedDevice?.name],
+  );
+  const axEndpointActive =
+    axOverlayEnabled || (annotationsEnabled && annotationsPickerActive)
+      ? config?.axEndpoint
+      : undefined;
+
   return (
-    <AxStateProvider endpoint={axOverlayEnabled ? config?.axEndpoint : undefined}>
+    <AxStateProvider endpoint={axEndpointActive}>
+    <AnnotationsProvider
+      basePath={config.basePath ?? "/"}
+      device={annotationsDevice}
+      pickerActive={annotationsPickerActive}
+      onPickerActiveChange={setAnnotationsPickerActive}
+      dropdownOpen={annotationsDropdownOpen}
+      onDropdownOpenChange={setAnnotationsDropdownOpen}
+    >
     <div
       style={{
         ...s.page,
@@ -2141,6 +2226,7 @@ function App() {
               streaming={streaming}
               onToggleOverlay={() => setAxOverlayEnabled((enabled) => !enabled)}
             />
+            {annotationsEnabled && <AnnotationsToolbarButtons />}
             <SimulatorToolbar.RotateButton title="Rotate device" />
           </SimulatorToolbar.Actions>
         </SimulatorToolbar>
@@ -2173,6 +2259,7 @@ function App() {
             onScreenConfigChange={onScreenConfigChange}
           />
           {axOverlayEnabled && <AxDomOverlay />}
+          {annotationsEnabled && <AnnotationsPickerLayer containerRef={simContainerRef} />}
           {mediaDrop.isDragOver && (
             <div style={{ ...s.dropOverlay, borderRadius: imgBorderRadius }}>
               <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
@@ -2228,6 +2315,8 @@ function App() {
         currentApp={currentApp}
         axOverlayEnabled={axOverlayEnabled}
         onToggleAxOverlay={() => setAxOverlayEnabled((enabled) => !enabled)}
+        annotationsEnabled={annotationsEnabled}
+        onToggleAnnotationsEnabled={toggleAnnotationsEnabled}
       />
 
       {/* Status bar */}
@@ -2237,9 +2326,20 @@ function App() {
           {streaming ? "live" : "connecting"}
         </span>
       </div>
+      {annotationsEnabled && <AnnotationsDropdown />}
     </div>
+    </AnnotationsProvider>
     </AxStateProvider>
   );
+}
+
+function AnnotationsPickerLayer({
+  containerRef,
+}: {
+  containerRef: React.MutableRefObject<HTMLDivElement | null>;
+}) {
+  const { snapshot } = useAxSnapshotContext();
+  return <AnnotationsPickerOverlay snapshot={snapshot} containerRef={containerRef} />;
 }
 
 // ─── Styles (before mount — Preact renders synchronously) ───

--- a/packages/serve-sim/src/index.ts
+++ b/packages/serve-sim/src/index.ts
@@ -16,6 +16,7 @@ const __dirname = dirnameOf(import.meta.url);
 // real file on disk; inside a compiled binary it points at bun's virtual FS
 // and we extract the bytes to a cached location on first use.
 import swiftHelperEmbeddedPath from "../bin/serve-sim-bin" with { type: "file" };
+import { purgeAnnotations, purgeAllAnnotations } from "./annotations";
 
 interface ServerState {
   pid: number;
@@ -804,15 +805,22 @@ function killStreams(deviceArg?: string) {
     const udid = resolveDevice(deviceArg);
     const state = readState(udid);
     if (!state) {
+      // No live helper, but annotations from a previous run might still be
+      // around — the user explicitly asked us to tear this device down.
+      purgeAnnotations(udid);
       console.log(JSON.stringify({ disconnected: true, device: udid }));
       return;
     }
     try { process.kill(state.pid, "SIGTERM"); } catch {}
     clearState(udid);
+    purgeAnnotations(state.device);
     console.log(JSON.stringify({ disconnected: true, device: state.device }));
   } else {
     const states = readAllStates();
     if (states.length === 0) {
+      // Same logic as the single-device branch — wipe leftover annotations
+      // even if no helper is running.
+      purgeAllAnnotations();
       console.log(JSON.stringify({ disconnected: true, devices: [] }));
       return;
     }
@@ -822,6 +830,7 @@ function killStreams(deviceArg?: string) {
       devices.push(state.device);
     }
     clearState();
+    purgeAllAnnotations();
     console.log(JSON.stringify({ disconnected: true, devices }));
   }
 }

--- a/packages/serve-sim/src/middleware.ts
+++ b/packages/serve-sim/src/middleware.ts
@@ -1,8 +1,21 @@
-import { readdirSync, readFileSync, existsSync, unlinkSync } from "fs";
+import { readdirSync, readFileSync, existsSync, unlinkSync, statSync, createReadStream } from "fs";
 import { execSync, spawn, exec, execFile, type ChildProcess } from "child_process";
 import { tmpdir } from "os";
 import { join } from "path";
 import { createAxStreamerCache } from "./ax";
+import {
+  createAnnotation,
+  deleteAllAnnotations,
+  deleteAnnotation,
+  getAnnotation,
+  listAnnotations,
+  resolveAnnotationAsset,
+  updateAnnotation,
+} from "./annotations";
+import type {
+  AnnotationCreateRequest,
+  AnnotationUpdateRequest,
+} from "./annotations-shared";
 
 // Injected at build time as a base64-encoded string via `define`
 declare const __PREVIEW_HTML_B64__: string;
@@ -375,7 +388,176 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
       return;
     }
 
+    // ─── Annotations API ───
+    if (url === base + "/api/annotations" || url.startsWith(base + "/api/annotations/")) {
+      handleAnnotationsRequest(req, res, base, selectedDevice);
+      return;
+    }
+
     // Not ours — pass through
     if (next) next();
   };
+}
+
+// ─── Annotations route handlers ───
+
+function readJsonBody(req: any): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    let body = "";
+    let size = 0;
+    const MAX = 16 * 1024 * 1024; // 16MB safety ceiling — crops are ~30KB each
+    req.on("data", (chunk: Buffer | string) => {
+      const piece = typeof chunk === "string" ? chunk : chunk.toString();
+      size += piece.length;
+      if (size > MAX) {
+        reject(new Error("body too large"));
+        req.destroy();
+        return;
+      }
+      body += piece;
+    });
+    req.on("end", () => {
+      if (!body) return resolve({});
+      try {
+        resolve(JSON.parse(body));
+      } catch (err) {
+        reject(err);
+      }
+    });
+    req.on("error", reject);
+  });
+}
+
+function jsonResponse(res: any, status: number, body: unknown) {
+  res.writeHead(status, {
+    "Content-Type": "application/json",
+    "Cache-Control": "no-store",
+    "Access-Control-Allow-Origin": "*",
+  });
+  res.end(JSON.stringify(body));
+}
+
+function pickAnnotationDevice(req: any, fallback: string | null): string | null {
+  const rawUrl: string = req.url ?? "";
+  const qIndex = rawUrl.indexOf("?");
+  if (qIndex !== -1) {
+    const device = new URLSearchParams(rawUrl.slice(qIndex + 1)).get("device");
+    if (device) return device;
+  }
+  if (fallback) return fallback;
+  // Last resort: pick the first running serve-sim helper.
+  const states = readServeSimStates();
+  return states[0]?.device ?? null;
+}
+
+function handleAnnotationsRequest(
+  req: any,
+  res: any,
+  base: string,
+  selectedDevice: string | null,
+): void {
+  const rawUrl: string = req.url ?? "";
+  const qIndex = rawUrl.indexOf("?");
+  const path = qIndex === -1 ? rawUrl : rawUrl.slice(0, qIndex);
+  const after = path.slice((base + "/api/annotations").length);
+  const method: string = req.method ?? "GET";
+
+  if (method === "OPTIONS") {
+    res.writeHead(204, {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET,POST,PATCH,DELETE,OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+    });
+    res.end();
+    return;
+  }
+
+  // Collection: /api/annotations
+  if (after === "" || after === "/") {
+    if (method === "GET") {
+      const udid = pickAnnotationDevice(req, selectedDevice);
+      if (!udid) return jsonResponse(res, 200, []);
+      return jsonResponse(res, 200, listAnnotations(udid));
+    }
+    if (method === "POST") {
+      readJsonBody(req)
+        .then((body) => {
+          const udid = pickAnnotationDevice(req, selectedDevice);
+          const create = body as AnnotationCreateRequest;
+          if (udid && !create?.device?.udid) {
+            create.device = {
+              udid,
+              name: create.device?.name ?? "",
+            };
+          }
+          if (!create?.device?.udid) {
+            return jsonResponse(res, 400, { error: "no device available" });
+          }
+          const result = createAnnotation(create);
+          if ("error" in result) return jsonResponse(res, 400, result);
+          jsonResponse(res, 201, result.annotation);
+        })
+        .catch((err) => jsonResponse(res, 400, { error: String(err?.message ?? err) }));
+      return;
+    }
+    if (method === "DELETE") {
+      const udid = pickAnnotationDevice(req, selectedDevice);
+      if (!udid) return jsonResponse(res, 404, { error: "no device" });
+      const removed = deleteAllAnnotations(udid);
+      return jsonResponse(res, 200, { removed });
+    }
+    res.writeHead(405); res.end(); return;
+  }
+
+  // Item: /api/annotations/{id} or /api/annotations/{id}/crop|frame
+  const itemMatch = /^\/([A-Za-z0-9_-]+)(?:\/(crop|frame))?$/.exec(after);
+  if (!itemMatch) {
+    res.writeHead(404); res.end("Not found"); return;
+  }
+  const id = itemMatch[1]!;
+  const sub = itemMatch[2];
+  const udid = pickAnnotationDevice(req, selectedDevice);
+  if (!udid) return jsonResponse(res, 404, { error: "no device" });
+
+  if (sub === "crop" || sub === "frame") {
+    if (method !== "GET") { res.writeHead(405); res.end(); return; }
+    const annotation = getAnnotation(udid, id);
+    if (!annotation) return jsonResponse(res, 404, { error: "not found" });
+    const relPath = sub === "crop" ? annotation.screenshotPath : annotation.fullFramePath;
+    if (!relPath) return jsonResponse(res, 404, { error: "asset missing" });
+    const abs = resolveAnnotationAsset(udid, relPath);
+    if (!abs) return jsonResponse(res, 404, { error: "file gone" });
+    let size = 0;
+    try { size = statSync(abs).size; } catch {}
+    res.writeHead(200, {
+      "Content-Type": "image/jpeg",
+      "Content-Length": String(size),
+      "Cache-Control": "no-store",
+      "Access-Control-Allow-Origin": "*",
+    });
+    createReadStream(abs).pipe(res);
+    return;
+  }
+
+  if (method === "GET") {
+    const annotation = getAnnotation(udid, id);
+    if (!annotation) return jsonResponse(res, 404, { error: "not found" });
+    return jsonResponse(res, 200, annotation);
+  }
+  if (method === "PATCH") {
+    readJsonBody(req)
+      .then((body) => {
+        const updated = updateAnnotation(udid, id, body as AnnotationUpdateRequest);
+        if (!updated) return jsonResponse(res, 404, { error: "not found" });
+        jsonResponse(res, 200, updated);
+      })
+      .catch((err) => jsonResponse(res, 400, { error: String(err?.message ?? err) }));
+    return;
+  }
+  if (method === "DELETE") {
+    const ok = deleteAnnotation(udid, id);
+    if (!ok) return jsonResponse(res, 404, { error: "not found" });
+    return jsonResponse(res, 200, { id });
+  }
+  res.writeHead(405); res.end();
 }


### PR DESCRIPTION
## Summary

Adds an opt-in **Comment annotations** mode to the preview UI. Click the picker icon, tap an element on the simulator, write a comment, repeat. When you're done, copy a markdown bundle to the clipboard with one click and paste it into Claude Code, Cursor, Codex — any agent that lives next to your editor.

The feature is gated behind a new "Comments" entry in the Tools panel, so existing users see no UI change until they opt in.

- Picker uses the live AX snapshot to draw a bbox sized to the element you're hovering and to auto-fill `accessibilityLabel` / `role` / `type` on the saved annotation.
- Crops are JPEG-encoded client-side from the visible MJPEG `<img>`, served back over HTTP so any agent with access to the preview port can pull the exact pixels of what the user pointed at.
- Storage is JSONL append-only at `$TMPDIR/serve-sim/annotations/{udid}/`, cleared on demand from the dropdown.

## Demo

| | |
|---|---|
| **Default toolbar** — feature is off, nothing changes | **Tools panel** — opt-in via the `Comments / Enable` toggle |
| ![default toolbar](https://raw.githubusercontent.com/malopezr7/serve-sim/assets/comment-annotations-picker/docs/comment-annotations/01-toolbar-defaults.png) | ![tools panel](https://raw.githubusercontent.com/malopezr7/serve-sim/assets/comment-annotations-picker/docs/comment-annotations/02-tools-panel.png) |
| **Toolbar after Enable** — picker (crosshair) + comments (chat bubble) join the toolbar | **Picker hover** — bbox sized to the AX element, badge shows `<label> <role>` |
| ![toolbar with picker](https://raw.githubusercontent.com/malopezr7/serve-sim/assets/comment-annotations-picker/docs/comment-annotations/03-toolbar-with-picker.png) | ![hover bbox](https://raw.githubusercontent.com/malopezr7/serve-sim/assets/comment-annotations-picker/docs/comment-annotations/04-picker-hover-bbox.png) |
| **Composer** — inline input anchored to the click; `Enter` submits, `Esc` cancels | **Comments dropdown** — pending list with delete, clear-all, and `Copy` |
| ![composer](https://raw.githubusercontent.com/malopezr7/serve-sim/assets/comment-annotations-picker/docs/comment-annotations/06-composer-typed.png) | ![dropdown](https://raw.githubusercontent.com/malopezr7/serve-sim/assets/comment-annotations-picker/docs/comment-annotations/07-dropdown.png) |

The crop saved to disk for the example above (256 px on the long side, JPEG q70):

![stored crop](https://raw.githubusercontent.com/malopezr7/serve-sim/assets/comment-annotations-picker/docs/comment-annotations/08-stored-crop.jpg)

## Output for agents

`Copy` writes a single markdown document to the clipboard:

````md
# Feedback from simulator session
Device: iPhone 17 Pro (UDID: 8B3BDAE3-83C2-4BC2-B4D1-F5D72A41250B)
Captured: 1 annotation · 2026-05-05T22:55:39.026Z

## [1] make this CTA bigger and more contrasted
- Element: button "Personalizar la página principal"
- Location: (200, 352)
- Screenshot: http://localhost:3200/api/annotations/02cae5aaf6ec/crop?device=8B3BDAE3-83C2-4BC2-B4D1-F5D72A41250B
````

The screenshot URLs hit the new `/api/annotations/{id}/crop` endpoint. An agent that runs locally next to the dev server can fetch the JPEG directly — no need to put base64 image data in the prompt. When the agent doesn't have HTTP access, the same bytes are also on disk under the device's annotations dir.

The on-disk record (one line of `annotations.jsonl`) carries everything the picker captured:

```json
{
  "id": "02cae5aaf6ec",
  "createdAt": "2026-05-05T22:55:39.026Z",
  "device": { "udid": "8B3BDAE3-…", "name": "iPhone 17 Pro" },
  "point": { "x": 200, "y": 352 },
  "region": { "x": 36, "y": 334.33, "w": 330, "h": 34.33 },
  "screenshotPath": "crops/anno-02cae5aaf6ec.jpg",
  "context": {
    "accessibilityLabel": "Personalizar la página principal",
    "accessibilityRole": "button",
    "accessibilityType": "Button",
    "accessibilityId": "0.0.2"
  },
  "comment": "make this CTA bigger and more contrasted",
  "status": "pending"
}
```

## How it works

### Storage layer (`src/annotations.ts`, `src/annotations-shared.ts`)

- Append-only JSONL at `$TMPDIR/serve-sim/annotations/{udid}/annotations.jsonl`.
- Crops at `crops/anno-{id}.jpg`, optional full frames at `frames/`.
- Pure functions: `listAnnotations`, `createAnnotation`, `updateAnnotation`, `deleteAnnotation`, `deleteAllAnnotations`, `resolveAnnotationAsset`.
- Path-traversal guard on the asset resolver since IDs are reflected in HTTP responses.

### HTTP API (mounted by `middleware.ts` and `dev.ts`)

```
GET    /api/annotations           list (filter via ?device=)
POST   /api/annotations           create from { point, region?, comment, cropDataUri, context? }
DELETE /api/annotations           clear all for device
GET    /api/annotations/:id       fetch one
PATCH  /api/annotations/:id       update comment / status
DELETE /api/annotations/:id       delete one
GET    /api/annotations/:id/crop  serve the JPEG crop
GET    /api/annotations/:id/frame serve the full-frame JPEG (if captured)
```

The Connect-style middleware and the Bun dev server share the storage layer; only the request/response plumbing differs.

### Picker UI (`src/client/annotations/index.tsx`)

- **Opt-in via Tools panel.** Disabled by default; the topbar buttons, picker overlay, and dropdown only mount when `annotationsEnabled` is true. Toggling on auto-closes the panel so the toolbar change is visible. Toggling off resets all transient picker state.
- **Hover hit-test** runs against the existing AX SSE (`/ax`). The picker subscribes to that endpoint when active, regardless of whether the AX overlay is visible, so picking with the AX overlay off still gives you element-shaped bboxes.
- **Click capture** draws the visible MJPEG `<img>` onto a canvas, crops to the element bbox in physical pixels, scales the longest side down to 256 px, and posts a JPEG data URI to `POST /api/annotations`.
- **AXe missing** is a soft-degrade. Without `axe` on PATH (`brew install cameroncooke/axe/axe`) the picker still captures point + crop, just without an element-fitting bbox. The Tools panel surfaces an inline amber callout linking to the install command.
- **Keyboard fix**: serve-sim's HID-keyboard forwarder now bails when an `INPUT` / `TEXTAREA` / `contentEditable` is focused, so typing in the composer doesn't leak into iOS.

## Future work (not in this PR)

The picker is currently AX-driven (Tier 3 + Accessibility tree). The same overlay can be powered by richer sources without changing the wire format — `Annotation.context` was designed with `componentName`, `sourceFile`, `sourceLine`, etc. fields ready to fill:

- **React Native DevTools backend.** `react-devtools-core` is embedded in any RN dev build; we can act as the headless client (the same mechanism `react-native-debugger` and Flipper use) and resolve the Fiber under the cursor to component name + `file:line`. That's the next PR — same UX, richer context.
- **`react-native-grab` integration.** When the host app already runs grab (Fabric ShadowTree, native IDs), we can prefer its pipeline for native-side metadata. Optional.

This PR is intentionally agnostic — no DevTools wiring, no `react-native-grab` dependency — so it ships value for any sim, RN or not, today.

## Test plan

- [ ] `bun install --frozen-lockfile`
- [ ] `bun run --filter serve-sim build`
- [ ] `bun test ./packages/serve-sim/src/__tests__`
- [ ] `bun test ./packages/serve-sim-client/src/__tests__/`
- [ ] Open `serve-sim` against a booted iOS simulator → toolbar is unchanged.
- [ ] Open the Tools panel → see a new `COMMENTS / Enable` row.
- [ ] Click `Enable` → panel closes, picker (crosshair) and comments (chat bubble) appear in the toolbar.
- [ ] With `axe` on PATH: hover the simulator with picker active → bbox tracks the element under the cursor; badge shows `<label> <role>`.
- [ ] Without `axe`: open Tools while Comments is enabled → amber callout points at the install command.
- [ ] Click → composer appears, autofocused. Type, press Enter → annotation persists, badge counter increments, picker stays active for the next pick.
- [ ] Press `Esc` while typing → composer cancels.
- [ ] Open the Comments dropdown → list shows pending annotations with relative timestamps.
- [ ] Hover an item → delete chip appears.
- [ ] Click an item → bbox flashes over the simulator for ~1 s.
- [ ] `Copy` button → markdown bundle on the clipboard.
- [ ] Trash icon → first click confirms, second click clears.
- [ ] `curl http://localhost:3200/api/annotations` returns the persisted list.
- [ ] `curl http://localhost:3200/api/annotations/<id>/crop` returns a JPEG.
- [ ] Multiple devices: annotations are scoped per `udid` on disk and over the API.
