### PR TITLE
chore: update README.md to use url

### DIFF
--- a/packages/serve-sim/README.md
+++ b/packages/serve-sim/README.md
@@ -85,7 +85,7 @@ Create a `.claude/launch.json` and define a server:
       "name": "ios",
       "runtimeExecutable": "npx",
       "runtimeArgs": ["serve-sim"],
-      "port": 3200,
+      "url": "http://localhost:8081/.sim"
     }
   ]
 }


### PR DESCRIPTION
**Why**

This would likely be clearer since it aligns with the section below which exposes the simulator over http://localhost:8081/.sim