### PR TITLE
serve-sim android: add adb-backed device streaming

### DIFF
--- a/packages/serve-sim-client/package.json
+++ b/packages/serve-sim-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serve-sim-client",
-  "description": "Client library for serve-sim — iOS Simulator streaming and gateway protocol.",
+  "description": "Client library for serve-sim mobile streaming and gateway protocol.",
   "version": "0.1.15",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/serve-sim-client/src/__tests__/simulator-geometry.test.ts
+++ b/packages/serve-sim-client/src/__tests__/simulator-geometry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   fallbackScreenSize,
+  getDeviceType,
   screenBorderRadius,
   simulatorAspectRatio,
   simulatorMaxWidth,
@@ -58,6 +59,15 @@ describe("simulator geometry helpers", () => {
     expect(simulatorAspectRatio(null, fallbackScreenSize("iphone", "iPhone 16 Pro Max"))).toBe(
       "1320 / 2868",
     );
+  });
+
+  test("detects Android device names", () => {
+    expect(getDeviceType("sdk_gphone64_arm64")).toBe("android");
+    expect(getDeviceType("Pixel 9 Pro")).toBe("android");
+    expect(getDeviceType("SM-S918B")).toBe("android");
+    expect(getDeviceType("ONEPLUS A6013")).toBe("android");
+    expect(getDeviceType("moto g power")).toBe("android");
+    expect(getDeviceType("iPhone 16 Pro")).toBe("iphone");
   });
 
   test("uses wider max width for landscape phones and tablets", () => {

--- a/packages/serve-sim-client/src/__tests__/stream-frame-parser.test.ts
+++ b/packages/serve-sim-client/src/__tests__/stream-frame-parser.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { extractImageFrame } from "../simulator/streamFrames";
+
+const jpeg = new Uint8Array([0xff, 0xd8, 0x01, 0x02, 0xff, 0xd9]);
+const png = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  0x00, 0x00, 0x00, 0x00,
+  0x49, 0x45, 0x4e, 0x44,
+  0xae, 0x42, 0x60, 0x82,
+]);
+
+describe("extractImageFrame", () => {
+  test("extracts a JPEG frame from a multipart byte stream", () => {
+    const input = concat(ascii("--frame\r\nContent-Type: image/jpeg\r\n\r\n"), jpeg, ascii("\r\nnext"));
+    const extracted = extractImageFrame(input);
+
+    expect(extracted?.mimeType).toBe("image/jpeg");
+    expect([...extracted!.frame]).toEqual([...jpeg]);
+    expect(new TextDecoder().decode(extracted!.rest)).toBe("\r\nnext");
+  });
+
+  test("extracts a PNG frame from an Android screencap multipart stream", () => {
+    const input = concat(ascii("--frame\r\nContent-Type: image/png\r\n\r\n"), png, ascii("\r\n"));
+    const extracted = extractImageFrame(input);
+
+    expect(extracted?.mimeType).toBe("image/png");
+    expect([...extracted!.frame]).toEqual([...png]);
+    expect(new TextDecoder().decode(extracted!.rest)).toBe("\r\n");
+  });
+
+  test("waits for a complete PNG before returning a frame", () => {
+    expect(extractImageFrame(png.slice(0, png.length - 2))).toBeNull();
+  });
+
+  test("does not emit a false JPEG from inside an incomplete PNG", () => {
+    const incompletePngWithJpegMarkers = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+      0x00, 0x00, 0x00, 0x04,
+      0x49, 0x44, 0x41, 0x54,
+      0xff, 0xd8, 0x00, 0xff, 0xd9,
+      0x00, 0x00, 0x00, 0x00,
+    ]);
+
+    expect(extractImageFrame(incompletePngWithJpegMarkers)).toBeNull();
+  });
+});
+
+function ascii(value: string): Uint8Array {
+  return new TextEncoder().encode(value);
+}
+
+function concat(...parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((sum, part) => sum + part.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}

--- a/packages/serve-sim-client/src/simulator/SimulatorToolbar.tsx
+++ b/packages/serve-sim-client/src/simulator/SimulatorToolbar.tsx
@@ -81,7 +81,9 @@ function SimulatorToolbarRoot({
   style,
   ...rest
 }: SimulatorToolbarProps) {
-  const deviceType = getDeviceType(deviceName);
+  const deviceType = deviceRuntime?.toLowerCase().startsWith("android")
+    ? "android"
+    : getDeviceType(deviceName);
   const effectiveDisabled = disabled || !deviceUdid || !streaming;
   const value: ToolbarContextValue = {
     exec,

--- a/packages/serve-sim-client/src/simulator/SimulatorView.tsx
+++ b/packages/serve-sim-client/src/simulator/SimulatorView.tsx
@@ -20,6 +20,7 @@ const FINGER_CURSOR = `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2
 const WS_MSG_TOUCH = 0x03;
 const WS_MSG_BUTTON = 0x04;
 const WS_MSG_MULTI_TOUCH = 0x05;
+const RELAY_FRAME_DECODE_TIMEOUT_MS = 2000;
 
 export interface SimulatorViewProps {
   /** Base URL of the serve-sim server, e.g. "http://localhost:3100" */
@@ -36,6 +37,8 @@ export interface SimulatorViewProps {
   onStreamTouch?: (data: { type: "begin" | "move" | "end"; x: number; y: number; edge?: number }) => void;
   /** Relay mode: callback for multi-touch events */
   onStreamMultiTouch?: (data: { type: "begin" | "move" | "end"; x1: number; y1: number; x2: number; y2: number }) => void;
+  /** Enable two-finger gestures such as option-drag pinch/pan. */
+  multiTouchEnabled?: boolean;
   /** Relay mode: callback for button events */
   onStreamButton?: (button: string) => void;
   /** Relay mode: subscribe to frame updates (bypasses React state for performance).
@@ -73,6 +76,7 @@ export function SimulatorView({
   onHomePress,
   onStreamTouch,
   onStreamMultiTouch,
+  multiTouchEnabled = true,
   onStreamButton,
   subscribeFrame,
   streamFrame,
@@ -176,6 +180,11 @@ export function SimulatorView({
   const connectedRef = useRef(false);
   connectedRef.current = connected;
   const prevBlobUrlRef = useRef<string | null>(null);
+  const revokeAfterLoadRef = useRef<string[]>([]);
+  const pendingRelayImagesRef = useRef<Set<HTMLImageElement>>(new Set());
+  const pendingRelayDecodeTimersRef = useRef<Set<ReturnType<typeof setTimeout>>>(new Set());
+  const decodingRelayFrameRef = useRef(false);
+  const queuedRelayBlobUrlRef = useRef<string | null>(null);
   useEffect(() => {
     if (!relayMode || !subscribeFrame) return;
     // Startup watchdog: flag the stream as broken if no frame arrives within
@@ -188,27 +197,83 @@ export function SimulatorView({
         setError("Stream is not producing frames. The simulator may have stopped — try reconnecting.");
       }
     }, STARTUP_MS);
-    const unsubscribe = subscribeFrame((blobUrl) => {
+    const markFrameReceived = () => {
       frameCountRef.current++;
       lastFrameAtRef.current = Date.now();
-      const img = relayImgRef.current;
-      if (img) {
-        // Revoke the previous blob URL to avoid memory leaks
-        if (prevBlobUrlRef.current) {
-          URL.revokeObjectURL(prevBlobUrlRef.current);
-        }
-        prevBlobUrlRef.current = blobUrl;
-        img.src = blobUrl;
-      }
       if (!connectedRef.current) {
         clearTimeout(watchdog);
         setConnected(true);
         setError(null);
       }
+    };
+    const decodeFrame = (blobUrl: string) => {
+      decodingRelayFrameRef.current = true;
+      const nextImage = new Image();
+      pendingRelayImagesRef.current.add(nextImage);
+      let settled = false;
+      const finish = (loaded: boolean) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(decodeTimer);
+        pendingRelayDecodeTimersRef.current.delete(decodeTimer);
+        pendingRelayImagesRef.current.delete(nextImage);
+        nextImage.onload = null;
+        nextImage.onerror = null;
+        const img = relayImgRef.current;
+        if (!loaded || !img) {
+          URL.revokeObjectURL(blobUrl);
+        } else {
+          if (prevBlobUrlRef.current) {
+            revokeAfterLoadRef.current.push(prevBlobUrlRef.current);
+          }
+          prevBlobUrlRef.current = blobUrl;
+          img.src = blobUrl;
+        }
+        nextImage.src = "";
+        decodingRelayFrameRef.current = false;
+        const queued = queuedRelayBlobUrlRef.current;
+        queuedRelayBlobUrlRef.current = null;
+        if (queued) decodeFrame(queued);
+      };
+      const decodeTimer = setTimeout(() => finish(false), RELAY_FRAME_DECODE_TIMEOUT_MS);
+      pendingRelayDecodeTimersRef.current.add(decodeTimer);
+      nextImage.onload = () => finish(true);
+      nextImage.onerror = () => finish(false);
+      nextImage.src = blobUrl;
+    };
+    const unsubscribe = subscribeFrame((blobUrl) => {
+      markFrameReceived();
+      if (decodingRelayFrameRef.current) {
+        if (queuedRelayBlobUrlRef.current) {
+          URL.revokeObjectURL(queuedRelayBlobUrlRef.current);
+        }
+        queuedRelayBlobUrlRef.current = blobUrl;
+        return;
+      }
+      decodeFrame(blobUrl);
     });
     return () => {
       clearTimeout(watchdog);
       unsubscribe?.();
+      for (const pendingImage of pendingRelayImagesRef.current) {
+        pendingImage.onload = null;
+        pendingImage.onerror = null;
+        pendingImage.src = "";
+      }
+      pendingRelayImagesRef.current.clear();
+      for (const timer of pendingRelayDecodeTimersRef.current) {
+        clearTimeout(timer);
+      }
+      pendingRelayDecodeTimersRef.current.clear();
+      decodingRelayFrameRef.current = false;
+      if (queuedRelayBlobUrlRef.current) {
+        URL.revokeObjectURL(queuedRelayBlobUrlRef.current);
+        queuedRelayBlobUrlRef.current = null;
+      }
+      for (const staleUrl of revokeAfterLoadRef.current) {
+        URL.revokeObjectURL(staleUrl);
+      }
+      revokeAfterLoadRef.current = [];
       if (prevBlobUrlRef.current) {
         URL.revokeObjectURL(prevBlobUrlRef.current);
         prevBlobUrlRef.current = null;
@@ -269,6 +334,7 @@ export function SimulatorView({
       x2: number;
       y2: number;
     }) => {
+      if (!multiTouchEnabled) return;
       const orientation = streamDisplayGeometry(screenSizeRef.current).inputOrientation;
       const p1 = rawPointForDisplayPoint(orientation, touch.x1, touch.y1);
       const p2 = rawPointForDisplayPoint(orientation, touch.x2, touch.y2);
@@ -292,7 +358,7 @@ export function SimulatorView({
       msg.set(json, 1);
       ws.send(msg);
     },
-    [relayMode, onStreamMultiTouch],
+    [relayMode, onStreamMultiTouch, multiTouchEnabled],
   );
 
   useEffect(() => {
@@ -466,7 +532,7 @@ export function SimulatorView({
   // Track Alt key globally to show preview before click
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Alt") setAltHeld(true);
+      if (multiTouchEnabled && e.key === "Alt") setAltHeld(true);
     };
     const onKeyUp = (e: KeyboardEvent) => {
       if (e.key === "Alt") {
@@ -482,7 +548,7 @@ export function SimulatorView({
       window.removeEventListener("keydown", onKeyDown);
       window.removeEventListener("keyup", onKeyUp);
     };
-  }, []);
+  }, [multiTouchEnabled]);
 
   // Show preview indicators when Alt is held but no gesture is active
   useEffect(() => {
@@ -656,6 +722,11 @@ export function SimulatorView({
             ref={relayImgRef}
             draggable={false}
             onLoad={(e) => {
+              for (const staleUrl of revokeAfterLoadRef.current) {
+                URL.revokeObjectURL(staleUrl);
+              }
+              revokeAfterLoadRef.current = [];
+              if (streamConfig) return;
               const el = e.currentTarget;
               if (el.naturalWidth > 0 && el.naturalHeight > 0) {
                 updateScreenConfig({ width: el.naturalWidth, height: el.naturalHeight });
@@ -679,7 +750,7 @@ export function SimulatorView({
             const x = (e.clientX - rect.left) / rect.width;
             const y = (e.clientY - rect.top) / rect.height;
 
-            if (e.altKey) {
+            if (multiTouchEnabled && e.altKey) {
               // Multi-touch mode: begin gesture
               multiTouchActiveRef.current = true;
               multiTouchShiftRef.current = e.shiftKey;
@@ -709,7 +780,7 @@ export function SimulatorView({
 
             // Alt-hover preview (no buttons pressed)
             if (e.buttons === 0) {
-              if (e.altKey) {
+              if (multiTouchEnabled && e.altKey) {
                 setFingerIndicators({
                   x1: x,
                   y1: y,
@@ -815,7 +886,7 @@ export function SimulatorView({
             const rect = getInputRect();
             if (!rect) return;
 
-            if (e.touches.length >= 2) {
+            if (multiTouchEnabled && e.touches.length >= 2) {
               // Two fingers down — start multi-touch
               hideTouchIndicator();
               const t1 = e.touches[0];

--- a/packages/serve-sim-client/src/simulator/deviceFrames.tsx
+++ b/packages/serve-sim-client/src/simulator/deviceFrames.tsx
@@ -9,11 +9,15 @@ import {
   isLandscapeConfig,
 } from "./orientation.js";
 
-export type DeviceType = "iphone" | "ipad" | "watch" | "vision";
+export type DeviceType = "iphone" | "ipad" | "watch" | "vision" | "android";
+
+const ANDROID_DEVICE_NAME_RE =
+  /(android|pixel|sdk_gphone|gphone|emulator|galaxy|samsung|oneplus|moto|motorola|nexus|xiaomi|redmi|poco|oppo|vivo|huawei|honor|realme|nothing|xperia|sony|fairphone|^sm[-_\s])/;
 
 export function getDeviceType(name?: string | null): DeviceType {
   if (!name) return "iphone";
   const lower = name.toLowerCase();
+  if (ANDROID_DEVICE_NAME_RE.test(lower)) return "android";
   if (lower.includes("ipad")) return "ipad";
   if (lower.includes("watch")) return "watch";
   if (lower.includes("vision")) return "vision";
@@ -23,6 +27,7 @@ export function getDeviceType(name?: string | null): DeviceType {
 /** Frame geometry for each device type. */
 export const DEVICE_FRAMES = {
   iphone: { width: 427, height: 881, bezelX: 18, bezelY: 18, innerRadius: 55 },
+  android: { width: 427, height: 881, bezelX: 14, bezelY: 14, innerRadius: 36 },
   ipad: { width: 430, height: 605, bezelX: 16, bezelY: 16, innerRadius: 12 },
   watch: { width: 274, height: 322, bezelX: 12, bezelY: 12, innerRadius: 79 },
   vision: { width: 640, height: 400, bezelX: 12, bezelY: 12, innerRadius: 32 },
@@ -117,6 +122,7 @@ export function simulatorMaxWidth(
         return 580;
       case "watch":
         return 200;
+      case "android":
       default:
         return 620;
     }
@@ -128,6 +134,7 @@ export function simulatorMaxWidth(
       return 200;
     case "vision":
       return 580;
+    case "android":
     default:
       return 320;
   }
@@ -161,6 +168,8 @@ export function screenBorderRadius(
 /** Renders the correct frame chrome for the given device type. */
 export function DeviceFrameChrome({ type = "iphone", streaming = false }: { type?: DeviceType; streaming?: boolean }) {
   switch (type) {
+    case "android":
+      return <AndroidPhoneFrameChrome streaming={streaming} />;
     case "ipad":
       return <IPadFrameChrome streaming={streaming} />;
     case "watch":
@@ -170,6 +179,45 @@ export function DeviceFrameChrome({ type = "iphone", streaming = false }: { type
     default:
       return <PhoneFrameChrome streaming={streaming} />;
   }
+}
+
+export function AndroidPhoneFrameChrome({ streaming = false }: { streaming?: boolean }) {
+  return (
+    <svg viewBox="0 0 427 881" style={{ width: "100%", height: "100%" }} fill="none" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <linearGradient id="android-frame-edge" x1="0" y1="0" x2="427" y2="881" gradientUnits="userSpaceOnUse">
+          <stop stopColor="#4b5563" />
+          <stop offset="0.42" stopColor="#111827" />
+          <stop offset="1" stopColor="#374151" />
+        </linearGradient>
+        <filter id="android-frame-shadow" x="-20" y="-20" width="467" height="921" filterUnits="userSpaceOnUse" colorInterpolationFilters="sRGB">
+          <feDropShadow dx="0" dy="18" stdDeviation="18" floodColor="#000" floodOpacity="0.35" />
+        </filter>
+      </defs>
+      <rect
+        x="1"
+        y="1"
+        width="425"
+        height="879"
+        rx="48"
+        fill="url(#android-frame-edge)"
+        stroke={streaming ? "#34d399" : "#4b5563"}
+        strokeWidth="2"
+        filter="url(#android-frame-shadow)"
+      />
+      <rect x="8" y="8" width="411" height="865" rx="42" fill="#06070a" />
+      <rect x="188" y="17" width="51" height="5" rx="2.5" fill="#374151" />
+      <circle cx="254" cy="19.5" r="3.5" fill="#1f2937" />
+      <rect
+        x="13.5"
+        y="13.5"
+        width="400"
+        height="854"
+        rx="36"
+        stroke="rgba(255,255,255,0.08)"
+      />
+    </svg>
+  );
 }
 
 export function PhoneFrameChrome({ streaming = false }: { streaming?: boolean }) {

--- a/packages/serve-sim-client/src/simulator/index.ts
+++ b/packages/serve-sim-client/src/simulator/index.ts
@@ -26,6 +26,8 @@ export {
   rotationDegreesForOrientation,
   streamDisplayGeometry,
 } from "./orientation.js";
+export { extractImageFrame } from "./streamFrames.js";
+export type { ExtractedImageFrame } from "./streamFrames.js";
 export type { StreamDisplayGeometry } from "./orientation.js";
 export type { DeviceType } from "./deviceFrames.js";
 export type { SimulatorOrientation, StreamConfig } from "../types.js";

--- a/packages/serve-sim-client/src/simulator/streamFrames.ts
+++ b/packages/serve-sim-client/src/simulator/streamFrames.ts
@@ -1,0 +1,89 @@
+export interface ExtractedImageFrame {
+  frame: Uint8Array;
+  rest: Uint8Array;
+  mimeType: "image/jpeg" | "image/png";
+}
+
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+export function extractImageFrame(buffer: Uint8Array): ExtractedImageFrame | null {
+  const jpegStart = findJpegStart(buffer);
+  const pngStart = findPngSignature(buffer);
+  if (jpegStart === -1 && pngStart === -1) return null;
+  if (pngStart !== -1 && (jpegStart === -1 || pngStart < jpegStart)) {
+    return extractPngFrame(buffer, pngStart);
+  }
+  return extractJpegFrame(buffer, jpegStart);
+}
+
+function findJpegStart(buffer: Uint8Array): number {
+  for (let i = 0; i < buffer.length - 1; i++) {
+    if (buffer[i] === 0xff && buffer[i + 1] === 0xd8) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+function extractJpegFrame(buffer: Uint8Array, start: number): ExtractedImageFrame | null {
+  if (start === -1) return null;
+  for (let i = start + 2; i < buffer.length - 1; i++) {
+    if (buffer[i] === 0xff && buffer[i + 1] === 0xd9) {
+      const end = i + 2;
+      return {
+        frame: buffer.slice(start, end),
+        rest: buffer.slice(end),
+        mimeType: "image/jpeg",
+      };
+    }
+  }
+  return null;
+}
+
+function extractPngFrame(buffer: Uint8Array, start: number): ExtractedImageFrame | null {
+  if (start === -1) return null;
+
+  let offset = start + PNG_SIGNATURE.length;
+  while (offset + 8 <= buffer.length) {
+    const length = readUInt32BE(buffer, offset);
+    const typeOffset = offset + 4;
+    const dataOffset = offset + 8;
+    const chunkEnd = dataOffset + length + 4;
+    if (chunkEnd > buffer.length) return null;
+    const type =
+      String.fromCharCode(buffer[typeOffset] ?? 0) +
+      String.fromCharCode(buffer[typeOffset + 1] ?? 0) +
+      String.fromCharCode(buffer[typeOffset + 2] ?? 0) +
+      String.fromCharCode(buffer[typeOffset + 3] ?? 0);
+    if (type === "IEND") {
+      return {
+        frame: buffer.slice(start, chunkEnd),
+        rest: buffer.slice(chunkEnd),
+        mimeType: "image/png",
+      };
+    }
+    offset = chunkEnd;
+  }
+
+  return null;
+}
+
+function findPngSignature(buffer: Uint8Array): number {
+  outer:
+  for (let i = 0; i <= buffer.length - PNG_SIGNATURE.length; i++) {
+    for (let j = 0; j < PNG_SIGNATURE.length; j++) {
+      if (buffer[i + j] !== PNG_SIGNATURE[j]) continue outer;
+    }
+    return i;
+  }
+  return -1;
+}
+
+function readUInt32BE(buffer: Uint8Array, offset: number): number {
+  return (
+    ((buffer[offset] ?? 0) * 0x1000000) +
+    ((buffer[offset + 1] ?? 0) << 16) +
+    ((buffer[offset + 2] ?? 0) << 8) +
+    (buffer[offset + 3] ?? 0)
+  );
+}

--- a/packages/serve-sim-client/src/simulator/useSimStream.ts
+++ b/packages/serve-sim-client/src/simulator/useSimStream.ts
@@ -7,6 +7,7 @@ export interface SimStreamInfo {
   wsUrl: string;
   port: number;
   device: string;
+  platform?: "ios" | "android";
 }
 
 export interface UseSimStreamOptions {

--- a/packages/serve-sim/README.md
+++ b/packages/serve-sim/README.md
@@ -1,8 +1,8 @@
 # serve-sim
 
-The `npx serve` of Apple Simulators. 
+The `npx serve` of mobile simulators and emulators.
 
-Host your simulator for use with Agent tools like Codex, Cursor, or Claude Desktop — locally, over your LAN, or host on a remote mac and tunnel anywhere. 
+Host your simulator or emulator for use with Agent tools like Codex, Cursor, or Claude Desktop — locally, over your LAN, or host on a remote machine and tunnel anywhere.
 
 ```sh
 npx serve-sim
@@ -11,33 +11,34 @@ npx serve-sim
 
 https://github.com/user-attachments/assets/fbf890f4-c8c7-4684-82be-d677b8a188f8
 
-`serve-sim` spawns a small Swift helper that captures the simulator's framebuffer via `simctl io`, exposes it as an MJPEG stream + WebSocket control channel, and serves a React preview UI on top. It works with any booted iOS Simulator — no Xcode plugin, no instrumentation in your app.
+`serve-sim` spawns a small platform helper that captures the device framebuffer, exposes it as a browser stream + WebSocket control channel, and serves a React preview UI on top. It works with booted iOS Simulators and connected Android devices or emulators — no app instrumentation required.
 
 ## Features 
 
-- Full 60 FPS video stream in the browser.
+- Full 60 FPS video stream in the browser on iOS; Android streams through adb screencap.
 - Swipe from the bottom to go home.
-- gestures like pinch to zoom by holding the option key.
-- Simulator logs are forwarded to the browser for browser-use MCP tools to read from.
-- Drag and drop videos and images to add them to the simulator device. 
+- Pinch/zoom gestures on iOS by holding the option key.
+- Simulator logs are forwarded to the browser for browser-use MCP tools to read from on iOS.
+- Drag and drop videos and images to add them to the simulator device on iOS.
 - Keyboard commands and hot keys are forwarded to the simulator, including CMD+SHIFT+H to go home.
-- Apple Watch, iPad, and iOS support.
+- Apple Watch, iPad, iOS, and Android support.
 
 ## Why?
 
-Hosted simulators can be hard to test, `serve-sim` enables you to test the hosted infra locally first for faster iteration. When you're ready to host a simulator remotely, simply tunnel the served URL and users can interact with the simulator as if it were running locally on their device.
+Hosted simulators and emulators can be hard to test, `serve-sim` enables you to test the hosted infra locally first for faster iteration. When you're ready to host a device remotely, simply tunnel the served URL and users can interact with the simulator or emulator as if it were running locally on their device.
 
-I develop the Expo framework, but this tool is completely agnostic to React Native and can be used for any iOS interaction you need.
+I develop the Expo framework, but this tool is completely agnostic to React Native and can be used for mobile interaction testing.
 
 ## Install
 
-Requires macOS with Xcode command line tools (`xcrun simctl`) and Node.js 18+. `bun` is **not** required to run the CLI.
+Requires Node.js 18+. iOS support requires macOS with Xcode command line tools (`xcrun simctl`). Android support requires Android platform tools (`adb`) and a connected device or running emulator. `bun` is **not** required to run the CLI.
 
 ## CLI
 
 ```
 serve-sim [device...]                 Start preview server (default: localhost:3200)
 serve-sim --no-preview [device...]    Stream in foreground without a preview server
+serve-sim --platform android [serial] Stream a connected Android device/emulator
 serve-sim gesture '<json>' [-d udid]  Send a touch gesture
 serve-sim button [name] [-d udid]     Send a button press (default: home)
 serve-sim rotate <orientation> [-d udid]
@@ -52,6 +53,9 @@ Options:
   -p, --port <port>   Starting port (preview default: 3200, stream default: 3100)
   -d, --detach        Spawn helper and exit (daemon mode)
   -q, --quiet         JSON-only output
+      --platform <p>  Device platform: ios (default) or android
+      --ios           Alias for --platform ios
+      --android       Alias for --platform android
       --no-preview    Skip the web UI; stream in foreground only
       --list [device] List running streams
       --kill [device] Kill running stream(s)
@@ -62,12 +66,13 @@ Options:
 ```sh
 serve-sim                              # auto-detect booted sim, open preview
 serve-sim "iPhone 16 Pro"              # target a specific device
+serve-sim --android emulator-5554      # target a connected Android emulator
 serve-sim --detach                     # start a background helper, return JSON
 serve-sim --list                       # show running streams
 serve-sim --kill                       # stop all helpers
 ```
 
-Multiple booted simulators are supported — pass several device names, or leave it empty to attach to all of them.
+Multiple booted iOS simulators or connected Android devices are supported — pass several device names/serials, or leave it empty to attach to the default device for the selected platform.
 
 ## Connectors
 
@@ -139,10 +144,10 @@ The middleware reads the helper's state from `$TMPDIR/serve-sim/` and forwards t
 ## How it works
 
 ```
-┌──────────────┐   simctl io   ┌─────────────────┐  MJPEG / WS  ┌─────────┐
-│ iOS Simulator│ ────────────► │ serve-sim-bin   │ ───────────► │ Browser │
-└──────────────┘   (Swift)     │ (per-device)    │              └─────────┘
-                               └─────────────────┘
+┌──────────────┐   simctl/adb   ┌─────────────────┐  Stream / WS ┌─────────┐
+│ iOS/Android  │ ─────────────► │ serve-sim helper│ ───────────► │ Browser │
+└──────────────┘                │ (per-device)    │              └─────────┘
+                                └─────────────────┘
                                        ▲
                                   state file in
                                 $TMPDIR/serve-sim/
@@ -153,7 +158,7 @@ The middleware reads the helper's state from `$TMPDIR/serve-sim/` and forwards t
                                └──────────────────┘
 ```
 
-The Swift helper (`bin/serve-sim-bin`) is a tiny standalone binary — no Xcode dependency at runtime. The CLI embeds it via `bun build --compile`, so installing the npm package is enough.
+The iOS Swift helper (`bin/serve-sim-bin`) is a tiny standalone binary — no Xcode dependency at runtime beyond the local simulator stack. Android uses the local `adb` binary for screencap and input. The CLI embeds the iOS helper via `bun build --compile`, so installing the npm package is enough.
 
 ## Development
 

--- a/packages/serve-sim/src/__tests__/android.test.ts
+++ b/packages/serve-sim/src/__tests__/android.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { androidKeyCodeForHidUsage, parseAdbDevices, parseAndroidDisplayConfig, parsePngSize } from "../android";
+
+describe("Android helpers", () => {
+  test("parses adb device listings", () => {
+    const devices = parseAdbDevices(`
+List of devices attached
+emulator-5554 device product:sdk_gphone64_arm64 model:sdk_gphone64_arm64 device:emu64a transport_id:1
+0123456789ABCDEF unauthorized usb:336592896X transport_id:2
+`);
+
+    expect(devices).toEqual([
+      {
+        serial: "emulator-5554",
+        state: "device",
+        product: "sdk_gphone64_arm64",
+        model: "sdk_gphone64_arm64",
+        name: "sdk_gphone64_arm64",
+      },
+      {
+        serial: "0123456789ABCDEF",
+        state: "unauthorized",
+        product: undefined,
+        model: undefined,
+        name: "0123456789ABCDEF",
+      },
+    ]);
+  });
+
+  test("reads dimensions from adb screencap PNG data", () => {
+    const png = new Uint8Array(24);
+    png.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+    const view = new DataView(png.buffer);
+    view.setUint32(16, 1080, false);
+    view.setUint32(20, 2400, false);
+
+    expect(parsePngSize(png)).toEqual({ width: 1080, height: 2400 });
+  });
+
+  test("rejects non-PNG screencap data", () => {
+    expect(parsePngSize(new Uint8Array([0, 1, 2, 3]))).toBeNull();
+  });
+
+  test("reads dimensions and orientation from Android display dumps", () => {
+    expect(parseAndroidDisplayConfig(`
+DisplayPolicy
+  DisplayFrames w=2340 h=1080 r=1
+    `)).toEqual({
+      width: 2340,
+      height: 1080,
+      orientation: "landscape_left",
+    });
+  });
+
+  test("maps HID keyboard usage codes to Android keycodes", () => {
+    expect(androidKeyCodeForHidUsage(0x04)).toBe("29");
+    expect(androidKeyCodeForHidUsage(0x1e)).toBe("8");
+    expect(androidKeyCodeForHidUsage(0x28)).toBe("KEYCODE_ENTER");
+    expect(androidKeyCodeForHidUsage(0x52)).toBe("KEYCODE_DPAD_UP");
+    expect(androidKeyCodeForHidUsage(0xe3)).toBeNull();
+  });
+});

--- a/packages/serve-sim/src/__tests__/android.test.ts
+++ b/packages/serve-sim/src/__tests__/android.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { androidKeyCodeForHidUsage, parseAdbDevices, parseAndroidDisplayConfig, parsePngSize } from "../android";
+import {
+  androidKeyCodeForHidUsage,
+  parseAdbDevices,
+  parseAndroidAccessibilityTree,
+  parseAndroidDisplayConfig,
+  parsePngSize,
+} from "../android";
 
 describe("Android helpers", () => {
   test("parses adb device listings", () => {
@@ -50,6 +56,71 @@ DisplayPolicy
       height: 1080,
       orientation: "landscape_left",
     });
+  });
+
+  test("maps uiautomator XML to the existing accessibility tree shape", () => {
+    const nodes = parseAndroidAccessibilityTree(`
+<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+<hierarchy rotation="0">
+  <node index="0" text="" resource-id="" class="android.widget.FrameLayout" content-desc="" enabled="true" bounds="[0,0][1080,2340]">
+    <node index="0" text="Search &amp; Maps" resource-id="com.example:id/search" class="android.widget.EditText" content-desc="Search field" enabled="true" bounds="[24,100][1056,180]" />
+    <node index="1" text="" resource-id="com.example:id/submit" class="android.widget.Button" content-desc="Submit" enabled="false" bounds="[800,200][1056,320]" />
+  </node>
+</hierarchy>UI hierchary dumped to: /dev/tty
+`, { width: 1080, height: 2340, orientation: "portrait" });
+
+    expect(nodes).toEqual([{
+      AXUniqueId: null,
+      AXLabel: null,
+      AXValue: null,
+      enabled: true,
+      frame: { x: 0, y: 0, width: 1080, height: 2340 },
+      role_description: "FrameLayout",
+      type: "FrameLayout",
+      children: [
+        {
+          AXUniqueId: "com.example:id/search@[24,100][1056,180]",
+          AXLabel: "Search field",
+          AXValue: "Search & Maps",
+          enabled: true,
+          frame: { x: 24, y: 100, width: 1032, height: 80 },
+          role_description: "Text Field",
+          type: "EditText",
+          children: [],
+        },
+        {
+          AXUniqueId: "com.example:id/submit@[800,200][1056,320]",
+          AXLabel: "Submit",
+          AXValue: null,
+          enabled: false,
+          frame: { x: 800, y: 200, width: 256, height: 120 },
+          role_description: "Button",
+          type: "Button",
+          children: [],
+        },
+      ],
+    }]);
+  });
+
+  test("keeps text-only Android node values", () => {
+    const nodes = parseAndroidAccessibilityTree(`
+<hierarchy rotation="0">
+  <node text="Typed value" resource-id="com.example:id/input" class="android.widget.EditText" content-desc="" enabled="true" bounds="[0,0][100,40]" />
+</hierarchy>
+`, { width: 100, height: 40, orientation: "portrait" });
+
+    expect(nodes[0]?.AXLabel).toBe("Typed value");
+    expect(nodes[0]?.AXValue).toBe("Typed value");
+  });
+
+  test("rejects malformed uiautomator output", () => {
+    expect(() =>
+      parseAndroidAccessibilityTree("UI hierchary dumped to: /dev/tty", {
+        width: 1080,
+        height: 2340,
+        orientation: "portrait",
+      })
+    ).toThrow("uiautomator dump did not contain hierarchy XML");
   });
 
   test("maps HID keyboard usage codes to Android keycodes", () => {

--- a/packages/serve-sim/src/__tests__/multi-device.test.ts
+++ b/packages/serve-sim/src/__tests__/multi-device.test.ts
@@ -34,6 +34,11 @@ describe("multi-device state", () => {
     expect(file.startsWith(STATE_DIR)).toBe(true);
   });
 
+  it("stateFileForDevice escapes Android network serials for file paths", () => {
+    const file = stateFileForDevice("127.0.0.1:5555");
+    expect(file).toContain("server-127.0.0.1%3A5555.json");
+  });
+
   it("multiple state files can coexist", () => {
     // Write state files directly to the real state dir for listStateFiles
     mkdirSync(STATE_DIR, { recursive: true });
@@ -83,4 +88,3 @@ describe("multi-device state", () => {
     }
   });
 });
-

--- a/packages/serve-sim/src/android.ts
+++ b/packages/serve-sim/src/android.ts
@@ -1,0 +1,649 @@
+import { createServer, type ServerResponse } from "http";
+import { createHash } from "crypto";
+import { execFile, execFileSync } from "child_process";
+
+import type { SimulatorOrientation } from "serve-sim-client";
+
+export interface AndroidDevice {
+  serial: string;
+  state: string;
+  name: string;
+  model?: string;
+  product?: string;
+}
+
+interface TouchPayload {
+  type: "begin" | "move" | "end";
+  x: number;
+  y: number;
+  edge?: number;
+}
+
+interface ButtonPayload {
+  button: string;
+}
+
+interface KeyPayload {
+  type: "down" | "up";
+  usage: number;
+}
+
+interface OrientationPayload {
+  orientation: SimulatorOrientation;
+}
+
+interface ScreenConfig {
+  width: number;
+  height: number;
+  orientation: SimulatorOrientation;
+}
+
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+const DEFAULT_ANDROID_FPS = 8;
+
+export function parseAdbDevices(output: string): AndroidDevice[] {
+  const devices: AndroidDevice[] = [];
+  for (const rawLine of output.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || /^List of devices attached/i.test(line)) continue;
+    const parts = line.split(/\s+/);
+    const serial = parts[0];
+    const state = parts[1];
+    if (!serial || !state) continue;
+    const attrs = new Map<string, string>();
+    for (const part of parts.slice(2)) {
+      const index = part.indexOf(":");
+      if (index <= 0) continue;
+      attrs.set(part.slice(0, index), part.slice(index + 1));
+    }
+    const model = attrs.get("model");
+    const product = attrs.get("product");
+    devices.push({
+      serial,
+      state,
+      model,
+      product,
+      name: model || product || serial,
+    });
+  }
+  return devices;
+}
+
+export function listAndroidDevices(): AndroidDevice[] {
+  const output = execFileSync("adb", ["devices", "-l"], {
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 5_000,
+  });
+  return parseAdbDevices(output);
+}
+
+export function getConnectedAndroidSerials(): Set<string> | null {
+  try {
+    return new Set(
+      listAndroidDevices()
+        .filter((device) => device.state === "device")
+        .map((device) => device.serial),
+    );
+  } catch {
+    return null;
+  }
+}
+
+export function findConnectedAndroidDevice(): string | null {
+  try {
+    return listAndroidDevices().find((device) => device.state === "device")?.serial ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function resolveAndroidDevice(nameOrSerial: string): string {
+  let devices: AndroidDevice[] = [];
+  try {
+    devices = listAndroidDevices();
+  } catch (err) {
+    console.error(`Could not list Android devices with adb: ${(err as Error).message}`);
+    process.exit(1);
+  }
+
+  const exact = devices.find((device) => device.serial === nameOrSerial);
+  if (exact) return exact.serial;
+
+  const lower = nameOrSerial.toLowerCase();
+  const byName = devices.find((device) =>
+    device.name.toLowerCase() === lower ||
+    device.model?.toLowerCase() === lower ||
+    device.product?.toLowerCase() === lower
+  );
+  if (byName) return byName.serial;
+
+  console.error(`Could not resolve Android device: ${nameOrSerial}`);
+  if (devices.length > 0) {
+    console.error("Connected Android devices:");
+    for (const device of devices) {
+      console.error(`  ${device.serial}\t${device.state}\t${device.name}`);
+    }
+  }
+  process.exit(1);
+}
+
+export function getAndroidDeviceName(serial: string): string | null {
+  try {
+    const match = listAndroidDevices().find((device) => device.serial === serial);
+    if (match) return match.name;
+  } catch {}
+  try {
+    const model = adbSync(serial, ["shell", "getprop", "ro.product.model"]).trim();
+    return model || null;
+  } catch {
+    return null;
+  }
+}
+
+export function parsePngSize(data: Uint8Array): { width: number; height: number } | null {
+  if (data.length < 24) return null;
+  for (let i = 0; i < PNG_SIGNATURE.length; i++) {
+    if (data[i] !== PNG_SIGNATURE[i]) return null;
+  }
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  return {
+    width: view.getUint32(16, false),
+    height: view.getUint32(20, false),
+  };
+}
+
+function adbSync(serial: string, args: string[]): string {
+  return execFileSync("adb", ["-s", serial, ...args], {
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 5_000,
+  });
+}
+
+function adb(serial: string, args: string[], timeout = 10_000): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    execFile("adb", ["-s", serial, ...args], {
+      encoding: "buffer",
+      maxBuffer: 32 * 1024 * 1024,
+      timeout,
+    }, (err, stdout, stderr) => {
+      if (err) {
+        const message = Buffer.isBuffer(stderr) ? stderr.toString("utf-8") : String(stderr);
+        reject(new Error(message || err.message));
+        return;
+      }
+      resolve(Buffer.isBuffer(stdout) ? stdout : Buffer.from(stdout));
+    });
+  });
+}
+
+function adbShell(serial: string, args: string[], timeout = 5_000): Promise<void> {
+  return adb(serial, ["shell", ...args], timeout).then(() => {});
+}
+
+function parseWmSize(output: string): { width: number; height: number } | null {
+  const match = output.match(/(?:Physical|Override) size:\s*(\d+)x(\d+)/i);
+  if (!match) return null;
+  return {
+    width: Number(match[1]),
+    height: Number(match[2]),
+  };
+}
+
+function orientationForRotation(rotation: string | number): SimulatorOrientation {
+  switch (String(rotation)) {
+    case "1":
+      return "landscape_left";
+    case "2":
+      return "portrait_upside_down";
+    case "3":
+      return "landscape_right";
+    case "0":
+    default:
+      return "portrait";
+  }
+}
+
+function orientationForSize({ width, height }: { width: number; height: number }): SimulatorOrientation {
+  return width > height ? "landscape_left" : "portrait";
+}
+
+export function parseAndroidDisplayConfig(output: string): ScreenConfig | null {
+  const match = output.match(/DisplayFrames\s+w=(\d+)\s+h=(\d+)\s+r=(\d+)/);
+  if (!match) return null;
+  return {
+    width: Number(match[1]),
+    height: Number(match[2]),
+    orientation: orientationForRotation(match[3]!),
+  };
+}
+
+function clampCoordinate(value: number, max: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(max - 1, Math.round(value * max)));
+}
+
+export function androidKeyCodeForHidUsage(usage: number): string | null {
+  if (usage >= 0x04 && usage <= 0x1d) {
+    return String(29 + usage - 0x04);
+  }
+  if (usage >= 0x1e && usage <= 0x26) {
+    return String(8 + usage - 0x1e);
+  }
+  if (usage === 0x27) return "7";
+  const map: Record<number, string> = {
+    0x28: "KEYCODE_ENTER",
+    0x29: "KEYCODE_ESCAPE",
+    0x2a: "KEYCODE_DEL",
+    0x2b: "KEYCODE_TAB",
+    0x2c: "KEYCODE_SPACE",
+    0x2d: "KEYCODE_MINUS",
+    0x2e: "KEYCODE_EQUALS",
+    0x4f: "KEYCODE_DPAD_RIGHT",
+    0x50: "KEYCODE_DPAD_LEFT",
+    0x51: "KEYCODE_DPAD_DOWN",
+    0x52: "KEYCODE_DPAD_UP",
+  };
+  return map[usage] ?? null;
+}
+
+function rotationForOrientation(orientation: SimulatorOrientation): string {
+  switch (orientation) {
+    case "landscape_left":
+      return "1";
+    case "portrait_upside_down":
+      return "2";
+    case "landscape_right":
+      return "3";
+    case "portrait":
+    default:
+      return "0";
+  }
+}
+
+async function androidScreenConfig(serial: string): Promise<ScreenConfig> {
+  try {
+    const display = parseAndroidDisplayConfig(adbSync(serial, ["shell", "dumpsys", "window", "displays"]));
+    if (display) return display;
+  } catch {}
+  try {
+    const frame = await adb(serial, ["exec-out", "screencap", "-p"], 8_000);
+    const size = parsePngSize(frame);
+    if (size) return { ...size, orientation: orientationForSize(size) };
+  } catch {}
+  try {
+    const size = parseWmSize(adbSync(serial, ["shell", "wm", "size"]));
+    if (size) return { ...size, orientation: orientationForSize(size) };
+  } catch {}
+  return { width: 1, height: 1, orientation: "portrait" };
+}
+
+export async function sendAndroidButton(serial: string, button: string): Promise<void> {
+  const map: Record<string, string> = {
+    home: "KEYCODE_HOME",
+    app_switcher: "KEYCODE_APP_SWITCH",
+    back: "KEYCODE_BACK",
+    lock: "KEYCODE_POWER",
+    power: "KEYCODE_POWER",
+  };
+  const fallback = button.toUpperCase();
+  const key = map[button] ?? (fallback.startsWith("KEYCODE_") ? fallback : `KEYCODE_${fallback}`);
+  await adbShell(serial, ["input", "keyevent", key]);
+}
+
+export async function setAndroidOrientation(serial: string, orientation: SimulatorOrientation): Promise<void> {
+  const rotation = rotationForOrientation(orientation);
+  await Promise.allSettled([
+    adbShell(serial, ["settings", "put", "system", "accelerometer_rotation", "0"]),
+    adbShell(serial, ["settings", "put", "system", "user_rotation", rotation]),
+    adbShell(serial, ["cmd", "window", "fixed-to-user-rotation", "enabled"]),
+    adbShell(serial, ["cmd", "window", "set-ignore-orientation-request", "true"]),
+    adbShell(serial, ["cmd", "window", "user-rotation", "lock", rotation]),
+  ]);
+}
+
+class AndroidStreamServer {
+  private mjpegClients = new Map<ServerResponse, { raw: boolean }>();
+  private wsSockets = new Set<any>();
+  private latestFrame: Buffer | null = null;
+  private captureTimer: ReturnType<typeof setTimeout> | null = null;
+  private firstFrameLogged = false;
+  private multiTouchWarningLogged = false;
+  private lastScreenConfigAt = 0;
+  private activeTouch: { x: number; y: number; lastX: number; lastY: number; startedAt: number } | null = null;
+  private screen: ScreenConfig = { width: 0, height: 0, orientation: "portrait" };
+
+  constructor(private serial: string, private port: number) {}
+
+  async start(): Promise<void> {
+    await this.initScreenConfig();
+    const server = createServer((req, res) => {
+      const rawUrl = req.url ?? "/";
+      const url = rawUrl.split("?")[0];
+
+      if (req.method === "OPTIONS") {
+        res.writeHead(204, corsHeaders());
+        res.end();
+        return;
+      }
+
+      if (url === "/health") {
+        writeJson(res, { status: "ok", platform: "android" });
+        return;
+      }
+
+      if (url === "/config") {
+        void this.writeConfig(res);
+        return;
+      }
+
+      if (url === "/ax") {
+        writeJson(res, {
+          error: "ax_unavailable",
+          message: "Android accessibility snapshots are not available through adb.",
+        }, 503);
+        return;
+      }
+
+      if (url === "/stream.mjpeg") {
+        const raw = new URL(rawUrl, `http://127.0.0.1:${this.port}`).searchParams.get("raw") === "1";
+        res.writeHead(200, {
+          ...corsHeaders(),
+          "Content-Type": raw ? "application/octet-stream" : "multipart/x-mixed-replace; boundary=frame",
+          "Cache-Control": "no-cache, no-store",
+          Connection: "keep-alive",
+        });
+        this.mjpegClients.set(res, { raw });
+        if (this.latestFrame) writeStreamFrame(res, this.latestFrame, raw);
+        req.on("close", () => this.mjpegClients.delete(res));
+        return;
+      }
+
+      res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+      res.end("Not found");
+    });
+
+    server.on("upgrade", (req, socket) => {
+      if ((req.url ?? "").split("?")[0] !== "/ws") {
+        socket.destroy();
+        return;
+      }
+      this.acceptWebSocket(req.headers["sec-websocket-key"], socket);
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.once("listening", () => resolve());
+      server.listen(this.port, "0.0.0.0");
+    });
+
+    console.log(`[server] Listening on http://0.0.0.0:${this.port}`);
+    this.scheduleCapture(0);
+
+    const stop = () => {
+      if (this.captureTimer) clearTimeout(this.captureTimer);
+      for (const client of this.mjpegClients.keys()) client.end();
+      for (const socket of this.wsSockets) socket.destroy();
+      server.close(() => process.exit(0));
+    };
+    process.on("SIGINT", stop);
+    process.on("SIGTERM", stop);
+  }
+
+  private async initScreenConfig(): Promise<void> {
+    await this.refreshScreenConfig(true);
+  }
+
+  private async writeConfig(res: ServerResponse): Promise<void> {
+    await this.refreshScreenConfig(true);
+    writeJson(res, this.screen);
+  }
+
+  private async refreshScreenConfig(force = false): Promise<void> {
+    const now = Date.now();
+    if (!force && now - this.lastScreenConfigAt < 1000) return;
+    this.lastScreenConfigAt = now;
+    try {
+      const next = await androidScreenConfig(this.serial);
+      if (
+        next.width !== this.screen.width ||
+        next.height !== this.screen.height ||
+        next.orientation !== this.screen.orientation
+      ) {
+        this.screen = next;
+      }
+    } catch {}
+  }
+
+  private scheduleCapture(delayMs: number): void {
+    this.captureTimer = setTimeout(() => void this.captureOnce(), delayMs);
+  }
+
+  private async captureOnce(): Promise<void> {
+    const started = Date.now();
+    try {
+      const frame = await adb(this.serial, ["exec-out", "screencap", "-p"], 8_000);
+      if (frame.length > 0) {
+        await this.refreshScreenConfig();
+        this.latestFrame = frame;
+        const size = parsePngSize(frame);
+        if (size && (size.width !== this.screen.width || size.height !== this.screen.height)) {
+          this.screen = { ...this.screen, ...size, orientation: orientationForSize(size) };
+        }
+        if (!this.firstFrameLogged) {
+          this.firstFrameLogged = true;
+          console.log("Capture started");
+        }
+        for (const [client, options] of this.mjpegClients) {
+          writeStreamFrame(client, frame, options.raw);
+        }
+      }
+    } catch (err) {
+      console.error(`[android] screencap failed: ${(err as Error).message}`);
+    } finally {
+      const frameInterval = Math.round(1000 / DEFAULT_ANDROID_FPS);
+      this.scheduleCapture(Math.max(50, frameInterval - (Date.now() - started)));
+    }
+  }
+
+  private acceptWebSocket(key: string | string[] | undefined, socket: any): void {
+    const wsKey = Array.isArray(key) ? key[0] : key;
+    if (!wsKey) {
+      socket.destroy();
+      return;
+    }
+    const accept = createHash("sha1")
+      .update(`${wsKey}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
+      .digest("base64");
+    socket.write(
+      "HTTP/1.1 101 Switching Protocols\r\n" +
+      "Upgrade: websocket\r\n" +
+      "Connection: Upgrade\r\n" +
+      `Sec-WebSocket-Accept: ${accept}\r\n\r\n`,
+    );
+    this.wsSockets.add(socket);
+    let buffer = Buffer.alloc(0);
+    socket.on("data", (chunk: Buffer) => {
+      buffer = Buffer.concat([buffer, chunk]);
+      const result = parseWebSocketFrames(buffer);
+      buffer = result.remaining;
+      for (const frame of result.frames) {
+        if (frame.opcode === 0x8) {
+          socket.end();
+          return;
+        }
+        if (frame.opcode === 0x2) this.handleInputMessage(frame.payload);
+      }
+    });
+    socket.on("close", () => this.wsSockets.delete(socket));
+    socket.on("error", () => this.wsSockets.delete(socket));
+  }
+
+  private handleInputMessage(payload: Buffer): void {
+    if (payload.length < 1) return;
+    const tag = payload[0];
+    const body = payload.subarray(1).toString("utf-8");
+    try {
+      if (tag === 0x03) this.handleTouch(JSON.parse(body) as TouchPayload);
+      else if (tag === 0x04) this.handleButton(JSON.parse(body) as ButtonPayload);
+      else if (tag === 0x05) this.handleUnsupportedMultiTouch();
+      else if (tag === 0x06) this.handleKey(JSON.parse(body) as KeyPayload);
+      else if (tag === 0x07) this.handleOrientation(JSON.parse(body) as OrientationPayload);
+    } catch (err) {
+      console.error(`[android] failed to handle input: ${(err as Error).message}`);
+    }
+  }
+
+  private handleTouch(touch: TouchPayload): void {
+    const width = this.screen.width || 1;
+    const height = this.screen.height || 1;
+    const x = clampCoordinate(touch.x, width);
+    const y = clampCoordinate(touch.y, height);
+    if (touch.type === "begin") {
+      this.activeTouch = { x, y, lastX: x, lastY: y, startedAt: Date.now() };
+      return;
+    }
+    if (touch.type === "move") {
+      if (this.activeTouch) {
+        this.activeTouch.lastX = x;
+        this.activeTouch.lastY = y;
+      }
+      return;
+    }
+
+    const start = this.activeTouch ?? { x, y, lastX: x, lastY: y, startedAt: Date.now() };
+    this.activeTouch = null;
+    const endX = x;
+    const endY = y;
+    const distance = Math.hypot(endX - start.x, endY - start.y);
+    if (distance < 12) {
+      void adbShell(this.serial, ["input", "tap", String(endX), String(endY)]).catch(console.error);
+      return;
+    }
+    const duration = Math.max(80, Math.min(1500, Date.now() - start.startedAt));
+    void adbShell(this.serial, [
+      "input",
+      "touchscreen",
+      "swipe",
+      String(start.x),
+      String(start.y),
+      String(endX),
+      String(endY),
+      String(duration),
+    ]).catch(console.error);
+  }
+
+  private handleUnsupportedMultiTouch(): void {
+    if (this.multiTouchWarningLogged) return;
+    this.multiTouchWarningLogged = true;
+    console.warn("[android] Multi-touch gestures are not supported by adb input.");
+  }
+
+  private handleButton({ button }: ButtonPayload): void {
+    void sendAndroidButton(this.serial, button).catch(console.error);
+  }
+
+  private handleKey({ type, usage }: KeyPayload): void {
+    if (type !== "down") return;
+    const key = androidKeyCodeForHidUsage(usage);
+    if (!key) return;
+    void adbShell(this.serial, ["input", "keyevent", key]).catch(console.error);
+  }
+
+  private handleOrientation({ orientation }: OrientationPayload): void {
+    this.screen = { ...this.screen, orientation };
+    void setAndroidOrientation(this.serial, orientation).catch(() => {});
+  }
+}
+
+function corsHeaders(): Record<string, string> {
+  return {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+  };
+}
+
+function writeJson(res: ServerResponse, value: unknown, status = 200): void {
+  const body = JSON.stringify(value);
+  res.writeHead(status, {
+    ...corsHeaders(),
+    "Content-Type": "application/json",
+    "Cache-Control": "no-cache, no-store",
+    "Content-Length": Buffer.byteLength(body),
+  });
+  res.end(body);
+}
+
+function writeMultipartFrame(res: ServerResponse, frame: Buffer): void {
+  const header =
+    `--frame\r\nContent-Type: image/png\r\nContent-Length: ${frame.length}\r\n\r\n`;
+  res.write(header);
+  res.write(frame);
+  res.write("\r\n");
+}
+
+function writeStreamFrame(res: ServerResponse, frame: Buffer, raw: boolean): void {
+  if (raw) {
+    res.write(frame);
+    return;
+  }
+  writeMultipartFrame(res, frame);
+}
+
+function parseWebSocketFrames(buffer: Buffer): {
+  frames: Array<{ opcode: number; payload: Buffer }>;
+  remaining: Buffer;
+} {
+  const frames: Array<{ opcode: number; payload: Buffer }> = [];
+  let offset = 0;
+
+  while (buffer.length - offset >= 2) {
+    const first = buffer[offset]!;
+    const second = buffer[offset + 1]!;
+    const opcode = first & 0x0f;
+    const masked = (second & 0x80) !== 0;
+    let length = second & 0x7f;
+    let headerLength = 2;
+
+    if (length === 126) {
+      if (buffer.length - offset < 4) break;
+      length = buffer.readUInt16BE(offset + 2);
+      headerLength = 4;
+    } else if (length === 127) {
+      if (buffer.length - offset < 10) break;
+      const bigLength = buffer.readBigUInt64BE(offset + 2);
+      if (bigLength > BigInt(Number.MAX_SAFE_INTEGER)) {
+        return { frames, remaining: Buffer.alloc(0) };
+      }
+      length = Number(bigLength);
+      headerLength = 10;
+    }
+
+    const maskLength = masked ? 4 : 0;
+    const frameLength = headerLength + maskLength + length;
+    if (buffer.length - offset < frameLength) break;
+
+    const payloadStart = offset + headerLength + maskLength;
+    const payload = Buffer.from(buffer.subarray(payloadStart, payloadStart + length));
+    if (masked) {
+      const mask = buffer.subarray(offset + headerLength, offset + headerLength + 4);
+      for (let i = 0; i < payload.length; i++) {
+        payload[i] = payload[i]! ^ mask[i % 4]!;
+      }
+    }
+    frames.push({ opcode, payload });
+    offset += frameLength;
+  }
+
+  return { frames, remaining: buffer.subarray(offset) };
+}
+
+export async function runAndroidHelper(serial: string, port: number): Promise<void> {
+  const state = await adb(serial, ["get-state"], 5_000).then((out) => out.toString("utf-8").trim());
+  if (state !== "device") {
+    throw new Error(`Android device ${serial} is not ready (adb state: ${state || "unknown"})`);
+  }
+  await new AndroidStreamServer(serial, port).start();
+}

--- a/packages/serve-sim/src/android.ts
+++ b/packages/serve-sim/src/android.ts
@@ -38,6 +38,17 @@ interface ScreenConfig {
   orientation: SimulatorOrientation;
 }
 
+interface AndroidAxNode {
+  AXUniqueId: string | null;
+  AXLabel: string | null;
+  AXValue: string | null;
+  enabled: boolean;
+  frame: { x: number; y: number; width: number; height: number };
+  role_description: string;
+  type: string;
+  children: AndroidAxNode[];
+}
+
 const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
 const DEFAULT_ANDROID_FPS = 8;
 
@@ -219,6 +230,121 @@ export function parseAndroidDisplayConfig(output: string): ScreenConfig | null {
   };
 }
 
+function decodeXmlAttribute(value: string): string {
+  return value.replace(/&(#x[0-9a-f]+|#\d+|amp|lt|gt|quot|apos);/gi, (match, entity: string) => {
+    switch (entity) {
+      case "amp":
+        return "&";
+      case "lt":
+        return "<";
+      case "gt":
+        return ">";
+      case "quot":
+        return "\"";
+      case "apos":
+        return "'";
+      default: {
+        const numeric = entity.startsWith("#x")
+          ? Number.parseInt(entity.slice(2), 16)
+          : Number.parseInt(entity.slice(1), 10);
+        return Number.isFinite(numeric) && numeric >= 0 && numeric <= 0x10ffff
+          ? String.fromCodePoint(numeric)
+          : match;
+      }
+    }
+  });
+}
+
+function parseXmlAttributes(source: string): Map<string, string> {
+  const attrs = new Map<string, string>();
+  for (const match of source.matchAll(/([A-Za-z0-9:_-]+)="([^"]*)"/g)) {
+    attrs.set(match[1]!, decodeXmlAttribute(match[2]!));
+  }
+  return attrs;
+}
+
+function parseAndroidBounds(value: string | undefined): AndroidAxNode["frame"] {
+  const match = value?.match(/\[(-?\d+),(-?\d+)\]\[(-?\d+),(-?\d+)\]/);
+  if (!match) return { x: 0, y: 0, width: 0, height: 0 };
+  const left = Number(match[1]);
+  const top = Number(match[2]);
+  const right = Number(match[3]);
+  const bottom = Number(match[4]);
+  return {
+    x: left,
+    y: top,
+    width: Math.max(0, right - left),
+    height: Math.max(0, bottom - top),
+  };
+}
+
+function androidRoleForClass(className: string): string {
+  const simple = className.split(".").pop() || className || "View";
+  if (/button/i.test(simple)) return "Button";
+  if (/edittext/i.test(simple)) return "Text Field";
+  if (/checkbox/i.test(simple)) return "Checkbox";
+  if (/switch/i.test(simple)) return "Switch";
+  if (/radiobutton/i.test(simple)) return "Radio Button";
+  if (/image/i.test(simple)) return "Image";
+  if (/textview/i.test(simple)) return "Text";
+  if (/list|recycler/i.test(simple)) return "List";
+  if (/scroll/i.test(simple)) return "Scroll View";
+  if (/progress/i.test(simple)) return "Progress Indicator";
+  return simple;
+}
+
+function androidAxNodeFromAttributes(attrs: Map<string, string>): AndroidAxNode {
+  const className = attrs.get("class") || "android.view.View";
+  const contentDescription = attrs.get("content-desc") || "";
+  const text = attrs.get("text") || "";
+  const resourceId = attrs.get("resource-id") || "";
+  const bounds = attrs.get("bounds") || "";
+  const label = contentDescription || text || null;
+  const value = text || null;
+  return {
+    AXUniqueId: resourceId ? `${resourceId}@${bounds}` : null,
+    AXLabel: label,
+    AXValue: value,
+    enabled: attrs.get("enabled") !== "false",
+    frame: parseAndroidBounds(bounds),
+    role_description: androidRoleForClass(className),
+    type: className.split(".").pop() || className,
+    children: [],
+  };
+}
+
+export function parseAndroidAccessibilityTree(xml: string, screen: ScreenConfig): AndroidAxNode[] {
+  const start = xml.indexOf("<hierarchy");
+  const end = xml.lastIndexOf("</hierarchy>");
+  if (start < 0 || end < start) {
+    throw new Error("uiautomator dump did not contain hierarchy XML");
+  }
+  const body = xml.slice(start, end + "</hierarchy>".length);
+  const roots: AndroidAxNode[] = [];
+  const stack: AndroidAxNode[] = [];
+
+  for (const match of body.matchAll(/<\/node\s*>|<node\b[^>]*>/g)) {
+    const token = match[0];
+    if (/^<\/node\s*>$/.test(token)) {
+      stack.pop();
+      continue;
+    }
+
+    const isSelfClosing = /\/\s*>$/.test(token);
+    const node = androidAxNodeFromAttributes(parseXmlAttributes(token));
+    const parent = stack.at(-1);
+    if (parent) parent.children.push(node);
+    else roots.push(node);
+
+    if (!isSelfClosing) stack.push(node);
+  }
+
+  if (roots.length === 0) {
+    throw new Error(`uiautomator hierarchy did not contain nodes for ${screen.width}x${screen.height}`);
+  }
+  return roots;
+}
+
 function clampCoordinate(value: number, max: number): number {
   if (!Number.isFinite(value)) return 0;
   return Math.max(0, Math.min(max - 1, Math.round(value * max)));
@@ -277,6 +403,12 @@ async function androidScreenConfig(serial: string): Promise<ScreenConfig> {
     if (size) return { ...size, orientation: orientationForSize(size) };
   } catch {}
   return { width: 1, height: 1, orientation: "portrait" };
+}
+
+async function androidAccessibilityTree(serial: string, screen: ScreenConfig): Promise<AndroidAxNode[]> {
+  const xml = await adb(serial, ["exec-out", "uiautomator", "dump", "/dev/tty"], 8_000)
+    .then((out) => out.toString("utf-8"));
+  return parseAndroidAccessibilityTree(xml, screen);
 }
 
 export async function sendAndroidButton(serial: string, button: string): Promise<void> {
@@ -339,10 +471,7 @@ class AndroidStreamServer {
       }
 
       if (url === "/ax") {
-        writeJson(res, {
-          error: "ax_unavailable",
-          message: "Android accessibility snapshots are not available through adb.",
-        }, 503);
+        void this.writeAccessibilityTree(res);
         return;
       }
 
@@ -398,6 +527,18 @@ class AndroidStreamServer {
   private async writeConfig(res: ServerResponse): Promise<void> {
     await this.refreshScreenConfig(true);
     writeJson(res, this.screen);
+  }
+
+  private async writeAccessibilityTree(res: ServerResponse): Promise<void> {
+    try {
+      await this.refreshScreenConfig(true);
+      writeJson(res, await androidAccessibilityTree(this.serial, this.screen));
+    } catch (err) {
+      writeJson(res, {
+        error: "ax_unavailable",
+        message: (err as Error).message || "Android accessibility snapshot failed.",
+      }, 503);
+    }
   }
 
   private async refreshScreenConfig(force = false): Promise<void> {

--- a/packages/serve-sim/src/client/client.tsx
+++ b/packages/serve-sim/src/client/client.tsx
@@ -23,6 +23,7 @@ import {
   fallbackScreenSize,
   screenBorderRadius,
   SimulatorToolbar,
+  extractImageFrame,
   getDeviceType,
   simulatorAspectRatio,
   simulatorMaxWidth,
@@ -113,34 +114,12 @@ function useMjpegStream(streamUrl: string | null) {
           newBuf.set(value, buffer.length);
           buffer = newBuf;
 
-          // Look for JPEG frames: find Content-Length or JPEG markers (FFD8...FFD9)
-          // Simpler approach: split on boundary markers and extract JPEG data
           while (true) {
-            // Find first JPEG start (FF D8)
-            let jpegStart = -1;
-            for (let i = 0; i < buffer.length - 1; i++) {
-              if (buffer[i] === 0xff && buffer[i + 1] === 0xd8) {
-                jpegStart = i;
-                break;
-              }
-            }
-            if (jpegStart === -1) break;
+            const extracted = extractImageFrame(buffer);
+            if (!extracted) break;
+            buffer = extracted.rest;
 
-            // Find JPEG end (FF D9) after the start
-            let jpegEnd = -1;
-            for (let i = jpegStart + 2; i < buffer.length - 1; i++) {
-              if (buffer[i] === 0xff && buffer[i + 1] === 0xd9) {
-                jpegEnd = i + 2;
-                break;
-              }
-            }
-            if (jpegEnd === -1) break;
-
-            // Extract the JPEG frame
-            const jpeg = buffer.slice(jpegStart, jpegEnd);
-            buffer = buffer.slice(jpegEnd);
-
-            const blob = new Blob([jpeg], { type: "image/jpeg" });
+            const blob = new Blob([extracted.frame], { type: extracted.mimeType });
             const blobUrl = URL.createObjectURL(blob);
             if (subscribersRef.current.size === 0) {
               URL.revokeObjectURL(blobUrl);
@@ -216,6 +195,7 @@ declare global {
       wsUrl: string;
       port: number;
       device: string;
+      platform?: "ios" | "android";
       basePath: string;
       logsEndpoint?: string;
       axEndpoint?: string;
@@ -260,6 +240,43 @@ function ReloadIcon({ size = 18, strokeWidth = 2 }: { size?: number; strokeWidth
     >
       <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
       <path d="M3 3v5h5" />
+    </svg>
+  );
+}
+
+function BackIcon({ size = 18, strokeWidth = 2 }: { size?: number; strokeWidth?: number }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="m15 18-6-6 6-6" />
+    </svg>
+  );
+}
+
+function AppSwitcherIcon({ size = 18, strokeWidth = 2 }: { size?: number; strokeWidth?: number }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="8" y="8" width="10" height="10" rx="2" />
+      <path d="M6 14H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h7a2 2 0 0 1 2 2v1" />
     </svg>
   );
 }
@@ -710,6 +727,7 @@ interface SimDevice {
   name: string;
   state: string;
   runtime: string;
+  platform: "ios" | "android";
 }
 
 function parseSimctlList(stdout: string): SimDevice[] {
@@ -722,7 +740,7 @@ function parseSimctlList(stdout: string): SimDevice[] {
         .replace(/-/g, ".");
       for (const d of devs) {
         if (d.isAvailable) {
-          out.push({ udid: d.udid, name: d.name, state: d.state, runtime: runtimeName });
+          out.push({ udid: d.udid, name: d.name, state: d.state, runtime: runtimeName, platform: "ios" });
         }
       }
     }
@@ -732,8 +750,36 @@ function parseSimctlList(stdout: string): SimDevice[] {
   }
 }
 
+function parseAdbList(stdout: string): SimDevice[] {
+  const out: SimDevice[] = [];
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || /^List of devices attached/i.test(line)) continue;
+    const parts = line.split(/\s+/);
+    const serial = parts[0];
+    const state = parts[1];
+    if (!serial || !state) continue;
+    const attrs = new Map<string, string>();
+    for (const part of parts.slice(2)) {
+      const index = part.indexOf(":");
+      if (index <= 0) continue;
+      attrs.set(part.slice(0, index), part.slice(index + 1));
+    }
+    const name = attrs.get("model") || attrs.get("product") || serial;
+    out.push({
+      udid: serial,
+      name,
+      state,
+      runtime: "Android",
+      platform: "android",
+    });
+  }
+  return out;
+}
+
 function deviceKind(name: string): number {
   const n = name.toLowerCase();
+  if (n.includes("android") || n.includes("pixel") || n.includes("sdk_gphone")) return 0;
   if (n.includes("iphone")) return 0;
   if (n.includes("ipad")) return 1;
   if (n.includes("watch")) return 2;
@@ -743,11 +789,16 @@ function deviceKind(name: string): number {
 
 function runtimeOrder(runtime: string): number {
   const r = runtime.toLowerCase();
+  if (r.startsWith("android")) return 0;
   if (r.startsWith("ios")) return 0;
   if (r.startsWith("ipados")) return 1;
   if (r.startsWith("watchos")) return 2;
   if (r.startsWith("visionos") || r.startsWith("xros")) return 3;
   return 4;
+}
+
+function isDeviceReadyForStream(device: Pick<SimDevice, "platform" | "state">): boolean {
+  return device.platform === "android" ? device.state === "device" : device.state === "Booted";
 }
 
 // ─── Device picker ───
@@ -816,7 +867,7 @@ function DevicePicker({
       {open && (
         <div style={pickerMenuStyle}>
           <div style={pickerHeaderStyle}>
-            <span style={{ fontWeight: 600 }}>Simulators</span>
+            <span style={{ fontWeight: 600 }}>Devices</span>
             <button
               onClick={(e) => { e.stopPropagation(); onRefresh(); }}
               disabled={loading}
@@ -829,21 +880,21 @@ function DevicePicker({
           {selected && (
             <>
               <div style={{ ...pickerItemStyle, color: "#a5b4fc" }}>
-                <span style={dotStyle(selected.state === "Booted" ? "#4ade80" : "#444")} />
+                <span style={dotStyle(isDeviceReadyForStream(selected) ? "#4ade80" : "#444")} />
                 <span style={{ flex: 1 }}>{selected.name}</span>
               </div>
               <div style={pickerSeparatorStyle} />
             </>
           )}
           {devices.length === 0 && !loading && !error && (
-            <div style={pickerEmptyStyle}>No available simulators found</div>
+            <div style={pickerEmptyStyle}>No available devices found</div>
           )}
           {sortedGroups.map(([runtime, devs]) => (
             <div key={runtime}>
               <div style={pickerGroupHeaderStyle}>{runtime}</div>
               {devs.map((d) => {
                 const isStopping = stoppingUdids.has(d.udid);
-                const isBooted = d.state === "Booted";
+                const isReady = isDeviceReadyForStream(d);
                 return (
                   <div
                     key={d.udid}
@@ -852,9 +903,9 @@ function DevicePicker({
                     onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
                     onClick={() => { onSelect(d); setOpen(false); }}
                   >
-                    <span style={dotStyle(isBooted ? "#4ade80" : "#444")} />
+                    <span style={dotStyle(isReady ? "#4ade80" : "#444")} />
                     <span style={{ flex: 1 }}>{d.name}</span>
-                    {isBooted && (
+                    {isReady && d.platform === "ios" && (
                       <span
                         role="button"
                         onClick={(e) => { e.stopPropagation(); if (!isStopping) onStop(d.udid); }}
@@ -1491,11 +1542,11 @@ function AppPermissionsTool({
   );
 }
 
-// ─── Empty state: pick a simulator to boot ───
+// ─── Empty state: pick a device to stream ───
 //
 // When no serve-sim helper is running, the middleware has no state file to
 // inject and `window.__SIM_PREVIEW__` is undefined. Instead of telling the
-// user to drop into a terminal, list available simulators inline and let
+// user to drop into a terminal, list available devices inline and let
 // them boot one + start `serve-sim --detach` from the browser.
 
 function BootEmptyState({
@@ -1519,11 +1570,15 @@ function BootEmptyState({
     try {
       // Single round-trip: the middleware's grid/start endpoint resolves the
       // serve-sim binary itself (no `bunx` lookup) and `serve-sim --detach`
-      // already boots the device + waits for readiness, so the prior
-      // explicit `xcrun simctl boot` was redundant and just added latency.
+      // already boots iOS devices + waits for readiness. Android devices must
+      // already be in adb's `device` state, which keeps emulator booting under
+      // the user's Android tooling instead of guessing here.
       // We also poll the API in parallel with the start request so as soon
       // as the helper writes its state file we can navigate — no need to
       // wait for the start request to fully return.
+      if (d.platform === "android" && d.state !== "device") {
+        throw new Error(`Android device is not ready (adb state: ${d.state})`);
+      }
       const apiUrl = `${simEndpoint("api")}?device=${encodeURIComponent(d.udid)}`;
       const navigateWhenReady = (async () => {
         // Generous deadline: a cold simulator can take 30-60s to reach
@@ -1548,7 +1603,7 @@ function BootEmptyState({
       const startReq = fetch(startUrl, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ udid: d.udid }),
+        body: JSON.stringify({ udid: d.udid, platform: d.platform }),
       })
         .then(async (res) => {
           const json = await res.json().catch(() => ({} as any));
@@ -1585,9 +1640,9 @@ function BootEmptyState({
   }
   for (const list of grouped.values()) {
     list.sort((a, b) => {
-      // Booted first, then by device kind, then by name.
-      const ab = a.state === "Booted" ? 0 : 1;
-      const bb = b.state === "Booted" ? 0 : 1;
+      // Ready first, then by device kind, then by name.
+      const ab = isDeviceReadyForStream(a) ? 0 : 1;
+      const bb = isDeviceReadyForStream(b) ? 0 : 1;
       if (ab !== bb) return ab - bb;
       return deviceKind(a.name) - deviceKind(b.name) || a.name.localeCompare(b.name);
     });
@@ -1601,12 +1656,12 @@ function BootEmptyState({
       <div style={s.empty}>
         <h1 style={s.emptyTitle}>No serve-sim stream running</h1>
         <p style={s.emptyHint}>
-          Pick a simulator to boot, or start one yourself with{" "}
+          Pick a device to stream, or start one yourself with{" "}
           <code style={s.code}>bunx serve-sim --detach</code>.
         </p>
         <div style={bootListStyle}>
           <div style={pickerHeaderStyle}>
-            <span style={{ fontWeight: 600 }}>Simulators</span>
+            <span style={{ fontWeight: 600 }}>Devices</span>
             <button onClick={onRefresh} disabled={loading} style={pickerRefreshStyle}>
               {loading ? "..." : "Refresh"}
             </button>
@@ -1614,15 +1669,16 @@ function BootEmptyState({
           {error && <div style={pickerErrorStyle}>{error}</div>}
           {startError && <div style={pickerErrorStyle}>{startError}</div>}
           {!loading && !error && devices.length === 0 && (
-            <div style={pickerEmptyStyle}>No available simulators found</div>
+            <div style={pickerEmptyStyle}>No available devices found</div>
           )}
           {sortedGroups.map(([runtime, devs]) => (
             <div key={runtime}>
               <div style={pickerGroupHeaderStyle}>{runtime}</div>
               {devs.map((d) => {
                 const isStarting = startingUdid === d.udid;
-                const disabled = startingUdid !== null && !isStarting;
-                const isBooted = d.state === "Booted";
+                const isReady = isDeviceReadyForStream(d);
+                const cannotStart = d.platform === "android" && !isReady;
+                const disabled = (startingUdid !== null && !isStarting) || cannotStart;
                 return (
                   <div
                     key={d.udid}
@@ -1637,12 +1693,12 @@ function BootEmptyState({
                     onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
                     onClick={() => { if (!disabled) start(d); }}
                   >
-                    <span style={dotStyle(isBooted ? "#4ade80" : "#444")} />
+                    <span style={dotStyle(isReady ? "#4ade80" : "#444")} />
                     <span style={{ flex: 1, textAlign: "left" }}>{d.name}</span>
                     <span style={{ fontSize: 10, color: isStarting ? "#a5b4fc" : "#888" }}>
                       {isStarting
-                        ? (isBooted ? "Starting..." : "Booting...")
-                        : (isBooted ? "Start stream" : "Boot & stream")}
+                        ? (isReady ? "Starting..." : "Booting...")
+                        : (isReady ? "Start stream" : d.platform === "ios" ? "Boot & stream" : d.state)}
                     </span>
                   </div>
                 );
@@ -2008,6 +2064,7 @@ interface GridDevice {
   name: string;
   runtime: string;
   state: string;
+  platform: "ios" | "android";
   helper: { port: number; url: string; streamUrl: string; wsUrl: string } | null;
 }
 
@@ -2271,14 +2328,15 @@ function GridTile({
   onShutdown: () => void;
 }) {
   const helper = device.helper;
-  const isBooted = device.state === "Booted";
+  const isReady = device.platform === "android" ? device.state === "device" : device.state === "Booted";
+  const isIOS = device.platform === "ios";
   const status = helper
     ? "● live"
     : starting
-    ? (isBooted ? "starting helper…" : "booting & starting…")
+    ? (isReady ? "starting helper…" : "booting & starting…")
     : shuttingDown
-    ? "shutting down…"
-    : isBooted ? "booted (no stream)" : device.state.toLowerCase();
+    ? (isIOS ? "shutting down…" : "stopping stream…")
+    : isReady ? (isIOS ? "booted (no stream)" : "connected (no stream)") : device.state.toLowerCase();
   const statusColor = helper ? "#3b3" : "#888";
   const ringColor = active ? "rgba(10,132,255,0.55)" : "transparent";
 
@@ -2296,11 +2354,11 @@ function GridTile({
         outline: `1px solid ${ringColor}`,
       }}
     >
-      {(helper || isBooted) && (
+      {(helper || (isIOS && isReady)) && (
         <button
           type="button"
-          title={shuttingDown ? "Shutting down…" : "Shutdown simulator"}
-          aria-label="Shutdown simulator"
+          title={shuttingDown ? (isIOS ? "Shutting down…" : "Stopping stream…") : isIOS ? "Shutdown simulator" : "Stop stream"}
+          aria-label={isIOS ? "Shutdown simulator" : "Stop stream"}
           onClick={(e) => {
             e.preventDefault();
             e.stopPropagation();
@@ -2337,21 +2395,21 @@ function GridTile({
               }}
             />
           ) : (
-            <div style={{ fontSize: 28, opacity: 0.5 }}>{isBooted ? "▣" : "▢"}</div>
+            <div style={{ fontSize: 28, opacity: 0.5 }}>{isReady ? "▣" : "▢"}</div>
           )}
           {error ? <div style={gridStyles.tileError}>{error}</div> : null}
           <button
             type="button"
             onClick={(e) => { e.preventDefault(); e.stopPropagation(); onStart(); }}
-            disabled={starting}
+            disabled={starting || (!isReady && !isIOS)}
             style={{
               ...gridStyles.tileStartBtn,
-              background: starting ? "#1a1a1a" : "#1d2a1d",
-              color: starting ? "#888" : "#9c9",
-              cursor: starting ? "default" : "pointer",
+              background: starting || (!isReady && !isIOS) ? "#1a1a1a" : "#1d2a1d",
+              color: starting || (!isReady && !isIOS) ? "#888" : "#9c9",
+              cursor: starting || (!isReady && !isIOS) ? "default" : "pointer",
             }}
           >
-            {starting ? (isBooted ? "Starting…" : "Booting…") : (isBooted ? "Start stream" : "Boot & start")}
+            {starting ? (isReady ? "Starting…" : "Booting…") : (isReady ? "Start stream" : isIOS ? "Boot & start" : device.state)}
           </button>
         </div>
       )}
@@ -2413,7 +2471,7 @@ function GridPanel({
   );
 
   const start = useCallback(
-    async (udid: string) => {
+    async (udid: string, platform: "ios" | "android") => {
       if (!startEndpoint) return;
       setPending((p) => ({ ...p, [udid]: true }));
       setErrors((e) => ({ ...e, [udid]: null }));
@@ -2421,7 +2479,7 @@ function GridPanel({
         const res = await fetch(startEndpoint, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ udid }),
+          body: JSON.stringify({ udid, platform }),
         });
         const json = await res.json().catch(() => ({}));
         if (!res.ok || !json.ok) {
@@ -2465,7 +2523,7 @@ function GridPanel({
   }, [devices, currentUdid, previewEndpoint]);
 
   const shutdown = useCallback(
-    async (udid: string) => {
+    async (udid: string, platform: "ios" | "android") => {
       if (!shutdownEndpoint) return;
       setShuttingDown((s) => ({ ...s, [udid]: true }));
       setErrors((e) => ({ ...e, [udid]: null }));
@@ -2473,7 +2531,7 @@ function GridPanel({
         const res = await fetch(shutdownEndpoint, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ udid }),
+          body: JSON.stringify({ udid, platform }),
         });
         const json = await res.json().catch(() => ({}));
         if (!res.ok || !json.ok) {
@@ -2493,7 +2551,7 @@ function GridPanel({
     <Panel open={open} width={width}>
       <style>{GRID_HOVER_CSS}</style>
       <PanelHeader>
-        <PanelTitle>Simulators</PanelTitle>
+        <PanelTitle>Devices</PanelTitle>
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
           <GridCapacityBanner report={memory} />
           <PanelCloseButton onClick={onClose} />
@@ -2501,7 +2559,7 @@ function GridPanel({
       </PanelHeader>
       <div style={gridStyles.body}>
         {devices === null ? null : devices.length === 0 ? (
-          <div style={gridStyles.empty}>No iOS simulators available.</div>
+          <div style={gridStyles.empty}>No streamable devices available.</div>
         ) : (
           devices.map((d) => (
             <GridTile
@@ -2512,8 +2570,8 @@ function GridPanel({
               starting={!!pending[d.device]}
               shuttingDown={!!shuttingDown[d.device]}
               error={errors[d.device] ?? null}
-              onStart={() => start(d.device)}
-              onShutdown={() => shutdown(d.device)}
+              onStart={() => start(d.device, d.platform)}
+              onShutdown={() => shutdown(d.device, d.platform)}
             />
           ))
         )}
@@ -2683,9 +2741,33 @@ function App() {
     setDevicesLoading(true);
     setDevicesError(null);
     try {
-      const res = await execOnHost("xcrun simctl list devices available -j");
-      if (res.exitCode !== 0) throw new Error(res.stderr || "simctl list failed");
-      setDevices(parseSimctlList(res.stdout));
+      try {
+        const gridRes = await fetch(simEndpoint("grid/api"), { cache: "no-store" });
+        if (gridRes.ok) {
+          const grid = await gridRes.json() as { devices?: GridDevice[] };
+          setDevices((grid.devices ?? []).map((d) => ({
+            udid: d.device,
+            name: d.name,
+            state: d.state,
+            runtime: d.runtime,
+            platform: d.platform,
+          })));
+          return;
+        }
+      } catch {}
+
+      const [simctl, adb] = await Promise.all([
+        execOnHost("xcrun simctl list devices available -j"),
+        execOnHost("adb devices -l"),
+      ]);
+      const nextDevices: SimDevice[] = [];
+      const errors: string[] = [];
+      if (simctl.exitCode === 0) nextDevices.push(...parseSimctlList(simctl.stdout));
+      else errors.push(simctl.stderr || "simctl list failed");
+      if (adb.exitCode === 0) nextDevices.push(...parseAdbList(adb.stdout));
+      else errors.push(adb.stderr || "adb devices failed");
+      setDevices(nextDevices);
+      if (nextDevices.length === 0 && errors.length > 0) throw new Error(errors.join("\n"));
     } catch (err) {
       setDevicesError(err instanceof Error ? err.message : "Failed to list devices");
     } finally {
@@ -2780,12 +2862,16 @@ function App() {
 
   useEffect(() => {
     document.title = selectedDevice?.name
-      ? `Simulator - ${selectedDevice.name}`
-      : "Simulator Preview";
-  }, [selectedDevice?.name]);
+      ? `${selectedDevice.platform === "android" ? "Android" : "Simulator"} - ${selectedDevice.name}`
+      : "Device Preview";
+  }, [selectedDevice?.name, selectedDevice?.platform]);
 
-  const deviceType: DeviceType = getDeviceType(selectedDevice?.name);
-  const devtools = useWebKitDevtools(config.devtoolsEndpoint ?? simEndpoint("devtools"), devtoolsOpen);
+  const isIOSPreview = (config.platform ?? "ios") === "ios";
+  const deviceType: DeviceType = isIOSPreview ? getDeviceType(selectedDevice?.name) : "android";
+  const devtools = useWebKitDevtools(isIOSPreview ? (config.devtoolsEndpoint ?? simEndpoint("devtools")) : undefined, devtoolsOpen && isIOSPreview);
+  useEffect(() => {
+    if (!isIOSPreview) setDevtoolsOpen(false);
+  }, [isIOSPreview]);
 
   useEffect(() => {
     if (!devtoolsOpen) return;
@@ -2939,7 +3025,12 @@ function App() {
     return () => window.removeEventListener("resize", onResize);
   }, []);
   useEffect(() => {
-    const es = new EventSource(config.appStateEndpoint ?? simEndpoint("appstate"));
+    const endpoint = isIOSPreview ? (config.appStateEndpoint ?? simEndpoint("appstate")) : undefined;
+    if (!endpoint) {
+      setCurrentApp(null);
+      return;
+    }
+    const es = new EventSource(endpoint);
     let timer: ReturnType<typeof setTimeout> | null = null;
     es.onmessage = (e) => {
       try {
@@ -2952,7 +3043,7 @@ function App() {
       } catch {}
     };
     return () => { if (timer) clearTimeout(timer); es.close(); };
-  }, [config.appStateEndpoint]);
+  }, [config.appStateEndpoint, isIOSPreview]);
 
   // Cmd+R to reload the RN/Expo bundle. RCTKeyCommands on iOS listens for
   // this combo and triggers DevSupport reload. We hold Meta, tap R, release.
@@ -3027,7 +3118,7 @@ function App() {
         return;
       }
       // Cmd+Shift+A → toggle appearance (Simulator.app's shortcut).
-      if (e.code === "KeyA" && e.metaKey && e.shiftKey) {
+      if (isIOSPreview && e.code === "KeyA" && e.metaKey && e.shiftKey) {
         e.preventDefault();
         if (type === "down" && !e.repeat) {
           // simctl has no toggle; query current, invert, set.
@@ -3055,27 +3146,32 @@ function App() {
       window.removeEventListener("keydown", down);
       window.removeEventListener("keyup", up);
     };
-  }, [sendWs, config.device]);
+  }, [sendWs, config.device, isIOSPreview]);
 
   const switchToDevice = useCallback(async (d: SimDevice) => {
     if (switching || d.udid === config.device) return;
     setSwitching(true);
-    // Ensure the target simulator is booted (serve-sim boots on --detach but
-    // this keeps the flow snappy) and spin up a helper bound to it. Do not
-    // kill the current helper here; another preview window may be using it.
+    // Spin up a helper bound to the target. Do not kill the current helper
+    // here; another preview window may be using it.
     try {
-      if (d.state !== "Booted") {
-        await execOnHost(`xcrun simctl boot ${d.udid}`);
+      if (d.platform === "android" && d.state !== "device") {
+        throw new Error(`Android device is not ready (adb state: ${d.state})`);
       }
-      const detach = await execOnHost(`bunx serve-sim --detach ${d.udid}`);
-      if (detach.exitCode !== 0) throw new Error(detach.stderr || "Failed to start serve-sim");
+      const startEndpoint = config.gridStartEndpoint ?? simEndpoint("grid/api/start");
+      const res = await fetch(startEndpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ udid: d.udid, platform: d.platform }),
+      });
+      const json = await res.json().catch(() => ({} as any));
+      if (!res.ok || !json.ok) throw new Error(json.error ?? `HTTP ${res.status}`);
       const nextUrl = new URL(window.location.href);
       nextUrl.searchParams.set("device", d.udid);
       window.location.assign(nextUrl.toString());
     } catch {
       setSwitching(false);
     }
-  }, [switching, config.device]);
+  }, [switching, config.device, config.gridStartEndpoint]);
 
   // Drag/drop images, videos, or .ipa files onto the simulator.
   // Media → Photos (addmedia); .ipa → install.
@@ -3083,7 +3179,7 @@ function App() {
   const mediaDrop = useMediaDrop({
     exec: execOnHost,
     udid: config.device,
-    enabled: streaming,
+    enabled: streaming && isIOSPreview,
     onUploadStart: uploads.add,
     onUploadEnd: (id, ok, message) =>
       uploads.update(id, { status: ok ? "success" : "error", message }),
@@ -3099,7 +3195,10 @@ function App() {
   const stopDevice = useCallback(async (udid: string) => {
     setStoppingUdids((prev) => new Set(prev).add(udid));
     try {
-      await execOnHost(`xcrun simctl shutdown ${udid}`);
+      const device = devices.find((d) => d.udid === udid);
+      if (device?.platform === "ios") {
+        await execOnHost(`xcrun simctl shutdown ${udid}`);
+      }
       await fetchDevices();
     } finally {
       setStoppingUdids((prev) => {
@@ -3108,7 +3207,7 @@ function App() {
         return next;
       });
     }
-  }, [fetchDevices]);
+  }, [devices, fetchDevices]);
 
   const simulatorResize = useSimulatorResize({
     defaultWidth: frameMaxWidth,
@@ -3197,14 +3296,34 @@ function App() {
                 <ReloadIcon />
               </SimulatorToolbar.Button>
             )}
+            {!isIOSPreview && (
+              <SimulatorToolbar.Button
+                aria-label="Back"
+                title="Back"
+                onClick={() => onStreamButton("back")}
+              >
+                <BackIcon />
+              </SimulatorToolbar.Button>
+            )}
             <SimulatorToolbar.HomeButton
               onClick={(e) => { e.preventDefault(); onStreamButton("home"); }}
             />
-            <AxToolbarButton
-              overlayEnabled={axOverlayEnabled}
-              streaming={streaming}
-              onToggleOverlay={() => setAxOverlayEnabled((enabled) => !enabled)}
-            />
+            {!isIOSPreview && (
+              <SimulatorToolbar.Button
+                aria-label="App switcher"
+                title="App switcher"
+                onClick={() => onStreamButton("app_switcher")}
+              >
+                <AppSwitcherIcon />
+              </SimulatorToolbar.Button>
+            )}
+            {isIOSPreview && (
+              <AxToolbarButton
+                overlayEnabled={axOverlayEnabled}
+                streaming={streaming}
+                onToggleOverlay={() => setAxOverlayEnabled((enabled) => !enabled)}
+              />
+            )}
             <SimulatorToolbar.RotateButton title="Rotate device" />
           </SimulatorToolbar.Actions>
         </SimulatorToolbar>
@@ -3238,6 +3357,7 @@ function App() {
             onStreamingChange={setStreaming}
             onStreamTouch={onStreamTouch}
             onStreamMultiTouch={onStreamMultiTouch}
+            multiTouchEnabled={isIOSPreview}
             onStreamButton={onStreamButton}
             subscribeFrame={mjpeg.subscribeFrame}
             streamFrame={mjpeg.frame}
@@ -3331,23 +3451,25 @@ function App() {
             <line x1="15" y1="4" x2="15" y2="20" />
           </svg>
         </button>
-        <button
-          onClick={() => {
-            setPanelOpen(false);
-            setGridOpen(false);
-            setDevtoolsOpen((o) => !o);
-          }}
-          style={sidebarRailStyles.button}
-          aria-label="Open WebKit DevTools"
-          aria-pressed={devtoolsOpen}
-          title="WebKit DevTools"
-        >
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
-            <circle cx="12" cy="12" r="10" />
-            <path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20" />
-            <path d="M2 12h20" />
-          </svg>
-        </button>
+        {isIOSPreview && (
+          <button
+            onClick={() => {
+              setPanelOpen(false);
+              setGridOpen(false);
+              setDevtoolsOpen((o) => !o);
+            }}
+            style={sidebarRailStyles.button}
+            aria-label="Open WebKit DevTools"
+            aria-pressed={devtoolsOpen}
+            title="WebKit DevTools"
+          >
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="10" />
+              <path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20" />
+              <path d="M2 12h20" />
+            </svg>
+          </button>
+        )}
         <button
           onClick={() => {
             setPanelOpen(false);
@@ -3355,9 +3477,9 @@ function App() {
             setGridOpen((o) => !o);
           }}
           style={sidebarRailStyles.button}
-          aria-label="Open simulator grid"
+          aria-label="Open device grid"
           aria-pressed={gridOpen}
-          title="Simulators"
+          title="Devices"
         >
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
             <rect x="3" y="3" width="7" height="7" rx="1.5" />
@@ -3397,24 +3519,28 @@ function App() {
         ariaLabel="Resize simulators panel"
       />
 
-      <WebKitDevtoolsPanel
-        open={devtoolsOpen}
-        onClose={() => setDevtoolsOpen(false)}
-        udid={config.device}
-        targets={devtools.targets}
-        selectedTargetId={selectedDevtoolsTargetId}
-        onSelectTarget={setSelectedDevtoolsTargetId}
-        loading={devtools.loading}
-        error={devtools.error}
-        onRefresh={() => void devtools.refresh()}
-        width={devtoolsPanelWidth}
-      />
-      <ResizeHandle
-        panelWidth={devtoolsPanelWidth}
-        visible={devtoolsOpen}
-        onPointerDown={onDevtoolsResize}
-        ariaLabel="Resize WebKit DevTools panel"
-      />
+      {isIOSPreview && (
+        <>
+          <WebKitDevtoolsPanel
+            open={devtoolsOpen}
+            onClose={() => setDevtoolsOpen(false)}
+            udid={config.device}
+            targets={devtools.targets}
+            selectedTargetId={selectedDevtoolsTargetId}
+            onSelectTarget={setSelectedDevtoolsTargetId}
+            loading={devtools.loading}
+            error={devtools.error}
+            onRefresh={() => void devtools.refresh()}
+            width={devtoolsPanelWidth}
+          />
+          <ResizeHandle
+            panelWidth={devtoolsPanelWidth}
+            visible={devtoolsOpen}
+            onPointerDown={onDevtoolsResize}
+            ariaLabel="Resize WebKit DevTools panel"
+          />
+        </>
+      )}
 
       {/* Status bar */}
       <div style={s.bar}>

--- a/packages/serve-sim/src/index.ts
+++ b/packages/serve-sim/src/index.ts
@@ -4,8 +4,17 @@ import { chmodSync, existsSync, mkdirSync, openSync, closeSync, readFileSync, un
 import { createHash } from "crypto";
 import { homedir, networkInterfaces } from "os";
 import { join, resolve } from "path";
-import { STATE_DIR, stateFileForDevice, listStateFiles } from "./state";
+import { STATE_DIR, stateFileForDevice, listStateFiles, type DevicePlatform, type ServerState } from "./state";
 import { dirnameOf, sleepSync, isPortFree, servePreview } from "./runtime";
+import {
+  findConnectedAndroidDevice,
+  getAndroidDeviceName,
+  getConnectedAndroidSerials,
+  resolveAndroidDevice,
+  runAndroidHelper,
+  sendAndroidButton,
+  setAndroidOrientation,
+} from "./android";
 
 // `import.meta.dir` is Bun-only; resolve once via fileURLToPath so the bundled
 // CLI works under plain `node` too.
@@ -16,15 +25,6 @@ const __dirname = dirnameOf(import.meta.url);
 // real file on disk; inside a compiled binary it points at bun's virtual FS
 // and we extract the bytes to a cached location on first use.
 import swiftHelperEmbeddedPath from "../bin/serve-sim-bin" with { type: "file" };
-
-interface ServerState {
-  pid: number;
-  port: number;
-  device: string;
-  url: string;
-  streamUrl: string;
-  wsUrl: string;
-}
 
 function ensureStateDir() {
   if (!existsSync(STATE_DIR)) {
@@ -81,10 +81,22 @@ function getBootedUdids(): Set<string> | null {
   }
 }
 
+let androidSnapshot: { at: number; connected: Set<string> | null } = { at: 0, connected: null };
+function getConnectedAndroidDeviceIds(): Set<string> | null {
+  const now = Date.now();
+  if (androidSnapshot.connected && now - androidSnapshot.at < 1000) {
+    return androidSnapshot.connected;
+  }
+  const connected = getConnectedAndroidSerials();
+  if (connected) androidSnapshot = { at: now, connected };
+  return connected;
+}
+
 function readStateFile(file: string): ServerState | null {
   try {
     if (!existsSync(file)) return null;
     const state = JSON.parse(readFileSync(file, "utf-8")) as ServerState;
+    const platform = state.platform ?? "ios";
     try {
       process.kill(state.pid, 0);
     } catch {
@@ -97,16 +109,18 @@ function readStateFile(file: string): ServerState | null {
     // When that happens the helper keeps accepting /stream.mjpeg connections
     // but never emits frames, so clients hang on "Connecting...". Detect and
     // recycle here so --detach / --list always return a working stream.
-    const booted = getBootedUdids();
-    if (booted && !booted.has(state.device)) {
+    const liveDevices = platform === "android"
+      ? getConnectedAndroidDeviceIds()
+      : getBootedUdids();
+    if (liveDevices && !liveDevices.has(state.device)) {
       console.error(
-        `[serve-sim] Helper pid ${state.pid} is bound to device ${state.device} which is no longer booted — killing stale helper.`,
+        `[serve-sim] Helper pid ${state.pid} is bound to ${platform} device ${state.device} which is no longer available — killing stale helper.`,
       );
       try { process.kill(state.pid, "SIGTERM"); } catch {}
       try { unlinkSync(file); } catch {}
       return null;
     }
-    return state;
+    return { ...state, platform };
   } catch {
     return null;
   }
@@ -267,6 +281,14 @@ function resolveDevice(nameOrUDID: string): string {
   process.exit(1);
 }
 
+function resolveDeviceForPlatform(nameOrUDID: string, platform: DevicePlatform): string {
+  return platform === "android" ? resolveAndroidDevice(nameOrUDID) : resolveDevice(nameOrUDID);
+}
+
+function stateDeviceForPlatform(nameOrUDID: string, platform: DevicePlatform): string {
+  return platform === "android" ? nameOrUDID : resolveDevice(nameOrUDID);
+}
+
 function isDeviceBooted(udid: string): boolean {
   try {
     const output = execSync("xcrun simctl list devices -j", { encoding: "utf-8" });
@@ -367,6 +389,31 @@ function getLocalNetworkIP(): string | null {
   return null;
 }
 
+function findDefaultDevice(platform: DevicePlatform, quiet = false): string[] {
+  if (platform === "android") {
+    const connected = findConnectedAndroidDevice();
+    if (connected) return [connected];
+    console.error("No Android device specified and no connected Android device/emulator found. Start an emulator or connect a device, then rerun with --platform android.");
+    process.exit(1);
+  }
+
+  const booted = findBootedDevice();
+  if (booted) return [booted];
+  const fallback = pickDefaultDevice();
+  if (!fallback) {
+    console.error("No device specified and no available iOS simulator found.");
+    process.exit(1);
+  }
+  if (!quiet) {
+    console.log(`No booted simulator — booting ${fallback.name}...`);
+  }
+  return [fallback.udid];
+}
+
+function getDisplayName(udid: string, platform: DevicePlatform): string | null {
+  return platform === "android" ? getAndroidDeviceName(udid) : getDeviceName(udid);
+}
+
 async function findAvailablePort(start: number): Promise<number> {
   const usedPorts = new Set(readAllStates().map((s) => s.port));
   for (let port = start; port < start + 100; port++) {
@@ -402,6 +449,21 @@ interface SpawnHelperOptions {
   port: number;
   host: string;
   logFile: string;
+}
+
+interface SpawnAndroidHelperOptions {
+  serial: string;
+  port: number;
+  host: string;
+  logFile: string;
+}
+
+function selfCommandArgs(args: string[]): { command: string; args: string[] } {
+  const entry = process.argv[1];
+  if (entry && entry !== process.execPath && !entry.startsWith("/$bunfs/") && existsSync(entry)) {
+    return { command: process.execPath, args: [entry, ...args] };
+  }
+  return { command: process.execPath, args };
 }
 
 /** Wait for the helper to become ready (health check + capture started). */
@@ -510,8 +572,59 @@ async function spawnHelperAttached(opts: SpawnHelperOptions): Promise<{
   return { ready, child, log };
 }
 
+async function spawnAndroidHelper(opts: SpawnAndroidHelperOptions, detachMode: boolean): Promise<{
+  ready: boolean;
+  pid: number;
+  child?: ChildProcess;
+  log: string;
+}> {
+  const { serial, port, host, logFile } = opts;
+  const url = `http://${host}:${port}`;
+
+  ensureStateDir();
+  const logFd = openSync(logFile, "w");
+  const command = selfCommandArgs(["__android-helper", serial, "--port", String(port)]);
+  const child = nodeSpawn(command.command, command.args, {
+    detached: detachMode,
+    stdio: ["ignore", logFd, logFd],
+  });
+  if (detachMode) child.unref();
+  closeSync(logFd);
+
+  const childPid = child.pid!;
+  let childExited = false;
+  child.once("exit", () => { childExited = true; });
+
+  const { ready, log } = await waitForHelperReady(
+    childPid,
+    url,
+    logFile,
+    () => !childExited && isProcessAlive(childPid),
+  );
+
+  return {
+    ready,
+    pid: childPid,
+    child: detachMode ? undefined : child,
+    log,
+  };
+}
+
+function makeState(platform: DevicePlatform, device: string, pid: number, port: number): ServerState {
+  const host = "127.0.0.1";
+  return {
+    pid,
+    port,
+    device,
+    platform,
+    url: `http://${host}:${port}`,
+    streamUrl: `http://${host}:${port}/stream.mjpeg`,
+    wsUrl: `ws://${host}:${port}/ws`,
+  };
+}
+
 /** Boot + spawn helper with retry logic. Returns pid on success, exits on failure. */
-async function startHelper(
+async function startIOSHelper(
   udid: string,
   port: number,
   opts: { detach: boolean },
@@ -532,15 +645,7 @@ async function startHelper(
     if (opts.detach) {
       const result = await spawnHelperDetached(spawnOpts);
       if (result.ready) {
-        const state: ServerState = {
-          pid: result.pid,
-          port,
-          device: udid,
-          url: `http://${host}:${port}`,
-          streamUrl: `http://${host}:${port}/stream.mjpeg`,
-          wsUrl: `ws://${host}:${port}/ws`,
-        };
-        writeState(state);
+        writeState(makeState("ios", udid, result.pid, port));
         return { pid: result.pid };
       }
       stopProcess(result.pid);
@@ -548,15 +653,7 @@ async function startHelper(
     } else {
       const result = await spawnHelperAttached(spawnOpts);
       if (result.ready) {
-        const state: ServerState = {
-          pid: result.child.pid!,
-          port,
-          device: udid,
-          url: `http://${host}:${port}`,
-          streamUrl: `http://${host}:${port}/stream.mjpeg`,
-          wsUrl: `ws://${host}:${port}/ws`,
-        };
-        writeState(state);
+        writeState(makeState("ios", udid, result.child.pid!, port));
         return { pid: result.child.pid!, child: result.child };
       }
       stopProcess(result.child.pid!);
@@ -573,25 +670,63 @@ async function startHelper(
   process.exit(1);
 }
 
+async function startAndroidHelper(
+  serial: string,
+  port: number,
+  opts: { detach: boolean },
+): Promise<{ pid: number; child?: ChildProcess }> {
+  const connected = getConnectedAndroidDeviceIds();
+  if (connected && !connected.has(serial)) {
+    console.error(`Android device ${serial} is not connected or ready.`);
+    process.exit(1);
+  }
+
+  const host = "127.0.0.1";
+  const logFile = join(STATE_DIR, `server-${serial}.log`);
+  const spawnOpts: SpawnAndroidHelperOptions = { serial, port, host, logFile };
+
+  let lastLog = "";
+  const MAX_ATTEMPTS = 2;
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    killPortHolder(port);
+
+    const result = await spawnAndroidHelper(spawnOpts, opts.detach);
+    if (result.ready) {
+      writeState(makeState("android", serial, result.pid, port));
+      return { pid: result.pid, child: result.child };
+    }
+    stopProcess(result.pid);
+    lastLog = result.log;
+
+    if (attempt < MAX_ATTEMPTS) {
+      await new Promise((r) => setTimeout(r, 500));
+    }
+  }
+
+  const reason = lastLog ? `Android helper failed:\n${lastLog}` : "Android helper process failed to start";
+  console.error(reason);
+  process.exit(1);
+}
+
+async function startHelper(
+  platform: DevicePlatform,
+  device: string,
+  port: number,
+  opts: { detach: boolean },
+): Promise<{ pid: number; child?: ChildProcess }> {
+  return platform === "android"
+    ? startAndroidHelper(device, port, opts)
+    : startIOSHelper(device, port, opts);
+}
+
 // ─── Commands ───
 
 /** Foreground follow mode (default). Stays attached, cleans up on Ctrl+C. */
-async function follow(devices: string[], startPort: number, quiet: boolean) {
+async function follow(platform: DevicePlatform, devices: string[], startPort: number, quiet: boolean) {
   const udids = devices.length > 0
-    ? devices.map(resolveDevice)
-    : (() => {
-        const booted = findBootedDevice();
-        if (booted) return [booted];
-        const fallback = pickDefaultDevice();
-        if (!fallback) {
-          console.error("No device specified and no available iOS simulator found.");
-          process.exit(1);
-        }
-        if (!quiet) {
-          console.log(`No booted simulator — booting ${fallback.name}...`);
-        }
-        return [fallback.udid];
-      })();
+    ? devices.map((device) => resolveDeviceForPlatform(device, platform))
+    : findDefaultDevice(platform, quiet);
 
   const children = new Map<string, ChildProcess>();
   const states: ServerState[] = [];
@@ -602,7 +737,7 @@ async function follow(devices: string[], startPort: number, quiet: boolean) {
     const existing = readState(udid);
     if (existing) {
       if (!quiet) {
-        const name = getDeviceName(udid) ?? udid;
+        const name = getDisplayName(udid, platform) ?? udid;
         if (udids.length > 1) console.log(`\n==> ${name} (${udid}) <==`);
         console.log(`  Already running on port ${existing.port}`);
         console.log(`  Stream:    ${existing.streamUrl}`);
@@ -613,25 +748,17 @@ async function follow(devices: string[], startPort: number, quiet: boolean) {
     }
 
     port = await findAvailablePort(port);
-    const { pid, child } = await startHelper(udid, port, { detach: false });
+    const { pid, child } = await startHelper(platform, udid, port, { detach: false });
 
     if (child) {
       children.set(udid, child);
     }
 
-    const host = "127.0.0.1";
-    const state: ServerState = {
-      pid,
-      port,
-      device: udid,
-      url: `http://${host}:${port}`,
-      streamUrl: `http://${host}:${port}/stream.mjpeg`,
-      wsUrl: `ws://${host}:${port}/ws`,
-    };
+    const state = makeState(platform, udid, pid, port);
     states.push(state);
 
     if (!quiet) {
-      const name = getDeviceName(udid) ?? udid;
+      const name = getDisplayName(udid, platform) ?? udid;
       if (udids.length > 1) console.log(`\n==> ${name} (${udid}) <==`);
       console.log(`  Stream:    ${state.streamUrl}`);
       console.log(`  WebSocket: ${state.wsUrl}`);
@@ -646,11 +773,13 @@ async function follow(devices: string[], startPort: number, quiet: boolean) {
     const s = states[0]!;
     console.log(JSON.stringify({
       url: s.url, streamUrl: s.streamUrl, wsUrl: s.wsUrl, port: s.port, device: s.device,
+      platform: s.platform ?? "ios",
     }));
   } else {
     console.log(JSON.stringify({
       devices: states.map((s) => ({
         url: s.url, streamUrl: s.streamUrl, wsUrl: s.wsUrl, port: s.port, device: s.device,
+        platform: s.platform ?? "ios",
       })),
     }));
   }
@@ -702,19 +831,10 @@ async function follow(devices: string[], startPort: number, quiet: boolean) {
 }
 
 /** Detach mode (--detach). Spawns helpers and returns their states. */
-async function detach(devices: string[], startPort: number): Promise<ServerState[]> {
+async function detach(platform: DevicePlatform, devices: string[], startPort: number): Promise<ServerState[]> {
   const udids = devices.length > 0
-    ? devices.map(resolveDevice)
-    : (() => {
-        const booted = findBootedDevice();
-        if (booted) return [booted];
-        const fallback = pickDefaultDevice();
-        if (!fallback) {
-          console.error("No device specified and no available iOS simulator found.");
-          process.exit(1);
-        }
-        return [fallback.udid];
-      })();
+    ? devices.map((device) => resolveDeviceForPlatform(device, platform))
+    : findDefaultDevice(platform, true);
 
   const states: ServerState[] = [];
   let port = startPort;
@@ -727,17 +847,9 @@ async function detach(devices: string[], startPort: number): Promise<ServerState
     }
 
     port = await findAvailablePort(port);
-    await startHelper(udid, port, { detach: true });
+    await startHelper(platform, udid, port, { detach: true });
 
-    const host = "127.0.0.1";
-    states.push({
-      pid: readState(udid)!.pid,
-      port,
-      device: udid,
-      url: `http://${host}:${port}`,
-      streamUrl: `http://${host}:${port}/stream.mjpeg`,
-      wsUrl: `ws://${host}:${port}/ws`,
-    });
+    states.push(readState(udid)!);
 
     port++;
   }
@@ -750,34 +862,38 @@ function printStatesJSON(states: ServerState[]) {
     const s = states[0]!;
     console.log(JSON.stringify({
       url: s.url, streamUrl: s.streamUrl, wsUrl: s.wsUrl, port: s.port, device: s.device,
+      platform: s.platform ?? "ios",
     }));
   } else {
     console.log(JSON.stringify({
       devices: states.map((s) => ({
         url: s.url, streamUrl: s.streamUrl, wsUrl: s.wsUrl, port: s.port, device: s.device,
+        platform: s.platform ?? "ios",
       })),
     }));
   }
 }
 
 /** List running streams (--list). */
-function listStreams(deviceArg?: string) {
+function listStreams(deviceArg: string | undefined, platform: DevicePlatform, platformExplicit: boolean) {
   if (deviceArg) {
-    const udid = resolveDevice(deviceArg);
+    const udid = stateDeviceForPlatform(deviceArg, platform);
     const state = readState(udid);
     if (!state) {
-      console.log(JSON.stringify({ running: false, device: udid }));
+      console.log(JSON.stringify({ running: false, device: udid, platform }));
     } else {
       console.log(JSON.stringify({
         running: true,
         url: state.url, streamUrl: state.streamUrl, wsUrl: state.wsUrl,
-        port: state.port, device: state.device, pid: state.pid,
+        port: state.port, device: state.device, platform: state.platform ?? "ios", pid: state.pid,
       }));
     }
     return;
   }
 
-  const states = readAllStates();
+  const states = readAllStates().filter(
+    (state) => !platformExplicit || (state.platform ?? "ios") === platform,
+  );
   if (states.length === 0) {
     console.log(JSON.stringify({ running: false }));
   } else if (states.length === 1) {
@@ -785,33 +901,35 @@ function listStreams(deviceArg?: string) {
     console.log(JSON.stringify({
       running: true,
       url: s.url, streamUrl: s.streamUrl, wsUrl: s.wsUrl,
-      port: s.port, device: s.device, pid: s.pid,
+      port: s.port, device: s.device, platform: s.platform ?? "ios", pid: s.pid,
     }));
   } else {
     console.log(JSON.stringify({
       running: true,
       streams: states.map((s) => ({
         url: s.url, streamUrl: s.streamUrl, wsUrl: s.wsUrl,
-        port: s.port, device: s.device, pid: s.pid,
+        port: s.port, device: s.device, platform: s.platform ?? "ios", pid: s.pid,
       })),
     }));
   }
 }
 
 /** Kill running streams (--kill). */
-function killStreams(deviceArg?: string) {
+function killStreams(deviceArg: string | undefined, platform: DevicePlatform, platformExplicit: boolean) {
   if (deviceArg) {
-    const udid = resolveDevice(deviceArg);
+    const udid = stateDeviceForPlatform(deviceArg, platform);
     const state = readState(udid);
     if (!state) {
-      console.log(JSON.stringify({ disconnected: true, device: udid }));
+      console.log(JSON.stringify({ disconnected: true, device: udid, platform }));
       return;
     }
     try { process.kill(state.pid, "SIGTERM"); } catch {}
     clearState(udid);
     console.log(JSON.stringify({ disconnected: true, device: state.device }));
   } else {
-    const states = readAllStates();
+    const states = readAllStates().filter(
+      (state) => !platformExplicit || (state.platform ?? "ios") === platform,
+    );
     if (states.length === 0) {
       console.log(JSON.stringify({ disconnected: true, devices: [] }));
       return;
@@ -821,7 +939,11 @@ function killStreams(deviceArg?: string) {
       try { process.kill(state.pid, "SIGTERM"); } catch {}
       devices.push(state.device);
     }
-    clearState();
+    if (platformExplicit) {
+      for (const device of devices) clearState(device);
+    } else {
+      clearState();
+    }
     console.log(JSON.stringify({ disconnected: true, devices }));
   }
 }
@@ -907,6 +1029,11 @@ async function rotate(args: string[]) {
     process.exit(1);
   }
 
+  if ((state.platform ?? "ios") === "android") {
+    await setAndroidOrientation(state.device, orientation as Parameters<typeof setAndroidOrientation>[1]);
+    return;
+  }
+
   return new Promise<void>((resolve, reject) => {
     const ws = new WebSocket(state.wsUrl);
     ws.binaryType = "arraybuffer";
@@ -944,6 +1071,11 @@ async function button(args: string[]) {
   }
 
   const buttonName = filteredArgs[0] ?? "home";
+
+  if ((state.platform ?? "ios") === "android") {
+    await sendAndroidButton(state.device, buttonName);
+    return;
+  }
 
   return new Promise<void>((resolve, reject) => {
     const ws = new WebSocket(state.wsUrl);
@@ -1049,20 +1181,20 @@ async function memoryWarning(args: string[]) {
 
 // ─── Serve preview ───
 
-async function serve(servePort: number, devices: string[], portExplicit: boolean) {
+async function serve(servePort: number, devices: string[], portExplicit: boolean, platform: DevicePlatform) {
   let targetDevice: string | undefined;
 
   if (devices.length > 0) {
-    const states = await detach(devices, 3100);
+    const states = await detach(platform, devices, 3100);
     targetDevice = states[0]?.device;
   } else {
     // Ensure a serve-sim stream is running (start one if not)
-    const existing = readAllStates();
+    const existing = readAllStates().filter((state) => (state.platform ?? "ios") === platform);
     if (existing.length > 0) {
       targetDevice = existing[0]?.device;
     } else {
-      console.log("Starting simulator stream...");
-      const states = await detach(devices, 3100);
+      console.log(platform === "android" ? "Starting Android stream..." : "Starting simulator stream...");
+      const states = await detach(platform, devices, 3100);
       targetDevice = states[0]?.device;
     }
   }
@@ -1118,11 +1250,12 @@ function bindPreviewServer(port: number, middleware: ReturnType<typeof import(".
 
 function printHelp() {
   console.log(`
-serve-sim - Stream iOS Simulator to the browser
+serve-sim - Stream iOS Simulator or Android emulator to the browser
 
 Usage:
   serve-sim [device...]                 Start preview server (default: localhost:3200)
   serve-sim --no-preview [device...]    Stream in foreground without a preview server
+  serve-sim --platform android [serial] Stream a connected Android device/emulator
   serve-sim gesture '<json>' [-d udid]  Send a touch gesture
   serve-sim button [name] [-d udid]     Send a button press (default: home)
   serve-sim rotate <orientation> [-d udid]
@@ -1137,6 +1270,9 @@ Options:
   -p, --port <port>   Starting port (preview default: 3200, stream default: 3100)
   -d, --detach        Spawn helper and exit (daemon mode)
   -q, --quiet         Suppress human-readable output, JSON only
+      --platform <p>  Device platform: ios (default) or android
+      --ios           Alias for --platform ios
+      --android       Alias for --platform android
       --no-preview    Skip the web preview server; stream in foreground only
       --list [device] List running streams
       --kill [device] Kill running stream(s)
@@ -1147,6 +1283,7 @@ Examples:
   serve-sim -p 8080                     Preview on a custom port
   serve-sim --no-preview                Auto-detect booted sim, stream in foreground
   serve-sim --no-preview "iPhone 16 Pro" Stream a specific device (no preview)
+  serve-sim --android emulator-5554     Stream a connected Android emulator
   serve-sim --detach                    Start streaming in background (daemon)
   serve-sim --list                      Show all running streams
   serve-sim --kill                      Stop all streams
@@ -1156,6 +1293,28 @@ Examples:
 // ─── Main ───
 
 const argv = process.argv.slice(2);
+
+function parsePlatform(value: string | undefined): DevicePlatform {
+  if (value === "ios" || value === "android") return value;
+  console.error(`Invalid platform: ${value ?? ""}. Expected "ios" or "android".`);
+  process.exit(1);
+}
+
+if (argv[0] === "__android-helper") {
+  const serial = argv[1];
+  let port = 3100;
+  for (let i = 2; i < argv.length; i++) {
+    if (argv[i] === "--port" || argv[i] === "-p") {
+      port = parseInt(argv[++i] ?? "3100", 10);
+    }
+  }
+  if (!serial) {
+    console.error("Missing Android device serial.");
+    process.exit(1);
+  }
+  await runAndroidHelper(serial, port);
+  await new Promise(() => {});
+}
 
 // Subcommands: gesture and button
 if (argv[0] === "gesture") {
@@ -1186,6 +1345,8 @@ let list = false;
 let kill = false;
 let help = false;
 let noPreview = false;
+let platform: DevicePlatform = "ios";
+let platformExplicit = false;
 const positionalDevices: string[] = [];
 let listDevice: string | undefined;
 let killDevice: string | undefined;
@@ -1204,6 +1365,18 @@ for (let i = 0; i < argv.length; i++) {
       break;
     case "--no-preview":
       noPreview = true;
+      break;
+    case "--platform":
+      platform = parsePlatform(argv[++i]);
+      platformExplicit = true;
+      break;
+    case "--ios":
+      platform = "ios";
+      platformExplicit = true;
+      break;
+    case "--android":
+      platform = "android";
+      platformExplicit = true;
       break;
     case "--list": case "-l":
       list = true;
@@ -1239,20 +1412,20 @@ if (help) {
 }
 
 if (list) {
-  listStreams(listDevice);
+  listStreams(listDevice, platform, platformExplicit);
   process.exit(0);
 }
 
 if (kill) {
-  killStreams(killDevice);
+  killStreams(killDevice, platform, platformExplicit);
   process.exit(0);
 }
 
 if (detachMode) {
-  const states = await detach(positionalDevices, startPort ?? 3100);
+  const states = await detach(platform, positionalDevices, startPort ?? 3100);
   printStatesJSON(states);
 } else if (noPreview) {
-  await follow(positionalDevices, startPort ?? 3100, quiet);
+  await follow(platform, positionalDevices, startPort ?? 3100, quiet);
 } else {
-  await serve(startPort ?? 3200, positionalDevices, startPort !== undefined);
+  await serve(startPort ?? 3200, positionalDevices, startPort !== undefined, platform);
 }

--- a/packages/serve-sim/src/middleware.ts
+++ b/packages/serve-sim/src/middleware.ts
@@ -4,6 +4,8 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { createServer as createNetServer } from "net";
 import { createAxStreamerCache } from "./ax";
+import type { DevicePlatform, ServerState as BaseServerState } from "./state";
+import { getConnectedAndroidSerials, listAndroidDevices } from "./android";
 
 // Injected at build time as a base64-encoded string via `define`
 declare const __PREVIEW_HTML_B64__: string;
@@ -31,13 +33,8 @@ type WebKitBridge = {
   releaseHighlight?(targetId?: string): void;
 };
 
-export interface ServeSimState {
-  pid: number;
-  port: number;
-  device: string;
-  url: string;
-  streamUrl: string;
-  wsUrl: string;
+export interface ServeSimState extends BaseServerState {
+  platform?: DevicePlatform;
 }
 
 const axStreamerCache = createAxStreamerCache();
@@ -201,6 +198,17 @@ function getBootedUdids(): Set<string> | null {
   }
 }
 
+let androidSnapshot: { at: number; connected: Set<string> | null } = { at: 0, connected: null };
+function getConnectedAndroidDeviceIds(): Set<string> | null {
+  const now = Date.now();
+  if (androidSnapshot.connected && now - androidSnapshot.at < 1500) {
+    return androidSnapshot.connected;
+  }
+  const connected = getConnectedAndroidSerials();
+  if (connected) androidSnapshot = { at: now, connected };
+  return connected;
+}
+
 function readServeSimStates(): ServeSimState[] {
   let files: string[];
   try {
@@ -211,11 +219,13 @@ function readServeSimStates(): ServeSimState[] {
     return [];
   }
   const booted = getBootedUdids();
+  const connectedAndroid = getConnectedAndroidDeviceIds();
   const states: ServeSimState[] = [];
   for (const f of files) {
     const path = join(STATE_DIR, f);
     try {
       const state: ServeSimState = JSON.parse(readFileSync(path, "utf-8"));
+      const platform = state.platform ?? "ios";
       try {
         process.kill(state.pid, 0);
       } catch {
@@ -226,12 +236,13 @@ function readServeSimStates(): ServeSimState[] {
       // would accept connections yet never produce frames, leaving the
       // preview stuck on "Connecting...". Recycle the stale state so the
       // caller can spawn a fresh helper bound to whatever is booted.
-      if (booted && !booted.has(state.device)) {
+      const liveDevices = platform === "android" ? connectedAndroid : booted;
+      if (liveDevices && !liveDevices.has(state.device)) {
         try { process.kill(state.pid, "SIGTERM"); } catch {}
         try { unlinkSync(path); } catch {}
         continue;
       }
-      states.push(state);
+      states.push({ ...state, platform });
     } catch {}
   }
   return states;
@@ -407,6 +418,20 @@ interface SimctlDevice {
   runtime: string;
 }
 
+interface GridDevice {
+  device: string;
+  name: string;
+  runtime: string;
+  state: string;
+  platform: DevicePlatform;
+  helper: {
+    port: number;
+    url: string;
+    streamUrl: string;
+    wsUrl: string;
+  } | null;
+}
+
 function listAllSimulators(): SimctlDevice[] {
   try {
     const output = execSync("xcrun simctl list devices -j", {
@@ -433,8 +458,26 @@ function listAllSimulators(): SimctlDevice[] {
   }
 }
 
+function listAllAndroidGridDevices(): Array<Omit<GridDevice, "helper">> {
+  try {
+    return listAndroidDevices().map((device) => ({
+      device: device.serial,
+      name: device.name,
+      runtime: "Android",
+      state: device.state,
+      platform: "android",
+    }));
+  } catch {
+    return [];
+  }
+}
+
 function deviceNameFor(udid: string): string | null {
   return listAllSimulators().find((d) => d.udid === udid)?.name ?? null;
+}
+
+function statePathForDevice(device: string): string {
+  return join(STATE_DIR, `server-${encodeURIComponent(device)}.json`);
 }
 
 // Default per-simulator footprint when we have no running sim to measure
@@ -650,18 +693,19 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
         // stream via fetch() (CORS is fine — serve-sim sends Access-Control-Allow-Origin: *)
         // and connects to the WS directly (WS has no CORS).
         const gridApiBase = (base === "" ? "" : base) + "/grid/api";
+        const isIOS = (state.platform ?? "ios") === "ios";
         const config = JSON.stringify({
           ...state,
           basePath: base,
-          logsEndpoint: endpoint(base, "/logs", state.device),
-          appStateEndpoint: endpoint(base, "/appstate", state.device),
+          logsEndpoint: isIOS ? endpoint(base, "/logs", state.device) : undefined,
+          appStateEndpoint: isIOS ? endpoint(base, "/appstate", state.device) : undefined,
           axEndpoint: endpoint(base, "/ax", state.device),
-          devtoolsEndpoint: endpoint(base, "/devtools", state.device),
           gridApiEndpoint: gridApiBase,
           gridStartEndpoint: gridApiBase + "/start",
           gridShutdownEndpoint: gridApiBase + "/shutdown",
           gridMemoryEndpoint: gridApiBase + "/memory",
           previewEndpoint: base === "" ? "/" : base,
+          devtoolsEndpoint: isIOS ? endpoint(base, "/devtools", state.device) : undefined,
         });
         const configScript = `<script>window.__SIM_PREVIEW__=${config}</script>`;
         html = html.replace("<!--__SIM_PREVIEW_CONFIG__-->", configScript);
@@ -685,18 +729,26 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
       return;
     }
 
-    // Grid JSON: every iOS simulator, annotated with running helper info if any.
+    // Grid JSON: every streamable iOS simulator and connected Android device,
+    // annotated with running helper info if any.
     if (url === base + "/grid/api") {
       const states = readServeSimStates();
       const helperByUdid = new Map(states.map((s) => [s.device, s] as const));
-      const sims = listAllSimulators();
-      const devices = sims.map((d) => {
-        const helper = helperByUdid.get(d.udid);
+      const iosDevices = listAllSimulators().map((d): Omit<GridDevice, "helper"> => ({
+        device: d.udid,
+        name: d.name,
+        runtime: d.runtime,
+        state: d.state,
+        platform: "ios",
+      }));
+      const devices = [...iosDevices, ...listAllAndroidGridDevices()].map((d): GridDevice => {
+        const helper = helperByUdid.get(d.device);
         return {
-          device: d.udid,
+          device: d.device,
           name: d.name,
           runtime: d.runtime,
           state: d.state,
+          platform: d.platform,
           helper: helper
             ? {
                 port: helper.port,
@@ -707,10 +759,10 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
             : null,
         };
       });
-      // Stable order: family (iPhone, iPad, Watch, TV, Vision, other) →
-      // state (helper > booted > shutdown) → alpha. Keeps the most
-      // commonly used devices visible without scrolling.
+      // Stable order: platform → family → state (helper > ready > stopped) →
+      // alpha. Keeps the most commonly used devices visible without scrolling.
       const familyRank = (name: string): number => {
+        if (/android|pixel|sdk_gphone/i.test(name)) return 0;
         if (/iphone/i.test(name)) return 0;
         if (/ipad/i.test(name)) return 1;
         if (/watch/i.test(name)) return 2;
@@ -719,8 +771,11 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
         return 5;
       };
       const stateRank = (x: typeof devices[number]) =>
-        x.helper ? 0 : x.state === "Booted" ? 1 : 2;
+        x.helper ? 0 : x.platform === "android"
+          ? x.state === "device" ? 1 : 2
+          : x.state === "Booted" ? 1 : 2;
       devices.sort((a, b) =>
+        (a.platform === "ios" ? 0 : 1) - (b.platform === "ios" ? 0 : 1) ||
         familyRank(a.name) - familyRank(b.name) ||
         stateRank(a) - stateRank(b) ||
         a.name.localeCompare(b.name),
@@ -733,18 +788,39 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
       return;
     }
 
-    // Shutdown a booted simulator. Any running helper for the device is reaped
-    // by readServeSimStates() on the next /grid/api poll (it kills helpers
-    // whose backing simulator is no longer in the booted set).
+    // Stop a device from the grid. iOS gets a real simulator shutdown; Android
+    // only stops the serve-sim helper, never the user's emulator/device.
     if (url === base + "/grid/api/shutdown" && req.method === "POST") {
       let body = "";
       req.on("data", (chunk: Buffer | string) => {
         body += typeof chunk === "string" ? chunk : chunk.toString();
       });
       req.on("end", () => {
-        let udid = "";
-        try { udid = JSON.parse(body).udid ?? ""; } catch {}
-        if (!/^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i.test(udid)) {
+        let device = "";
+        let platform: DevicePlatform | undefined;
+        try {
+          const parsed = JSON.parse(body);
+          device = parsed.udid ?? parsed.device ?? "";
+          platform = parsed.platform === "android" ? "android" : parsed.platform === "ios" ? "ios" : undefined;
+        } catch {}
+        const state = readServeSimStates().find((s) => s.device === device);
+        platform ??= state?.platform ?? (/^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i.test(device) ? "ios" : "android");
+        if (!device) {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: false, error: "Invalid or missing device" }));
+          return;
+        }
+        if (platform === "android") {
+          if (state) {
+            try { process.kill(state.pid, "SIGTERM"); } catch {}
+            try { unlinkSync(statePathForDevice(device)); } catch {}
+          }
+          androidSnapshot = { at: 0, connected: null };
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: true }));
+          return;
+        }
+        if (!/^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i.test(device)) {
           res.writeHead(400, { "Content-Type": "application/json" });
           res.end(JSON.stringify({ ok: false, error: "Invalid or missing udid" }));
           return;
@@ -752,7 +828,7 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
         // Drop the snapshot so the next /grid/api call re-queries simctl
         // and prunes any helper bound to this now-shutdown device.
         bootedSnapshot = { at: 0, booted: null };
-        execFile("xcrun", ["simctl", "shutdown", udid], { timeout: 30_000 }, (err, _stdout, stderr) => {
+        execFile("xcrun", ["simctl", "shutdown", device], { timeout: 30_000 }, (err, _stdout, stderr) => {
           if (err) {
             res.writeHead(500, { "Content-Type": "application/json" });
             res.end(JSON.stringify({
@@ -768,18 +844,23 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
       return;
     }
 
-    // Spawn a serve-sim helper (auto-boots if needed).
+    // Spawn a serve-sim helper (auto-boots iOS if needed).
     if (url === base + "/grid/api/start" && req.method === "POST") {
       let body = "";
       req.on("data", (chunk: Buffer | string) => {
         body += typeof chunk === "string" ? chunk : chunk.toString();
       });
       req.on("end", () => {
-        let udid = "";
-        try { udid = JSON.parse(body).udid ?? ""; } catch {}
-        if (!/^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i.test(udid)) {
+        let device = "";
+        let platform: DevicePlatform = "ios";
+        try {
+          const parsed = JSON.parse(body);
+          device = parsed.udid ?? parsed.device ?? "";
+          platform = parsed.platform === "android" ? "android" : "ios";
+        } catch {}
+        if (!device || (platform === "ios" && !/^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i.test(device))) {
           res.writeHead(400, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ ok: false, error: "Invalid or missing udid" }));
+          res.end(JSON.stringify({ ok: false, error: "Invalid or missing device" }));
           return;
         }
         const resolved = resolveServeSimCommand();
@@ -793,7 +874,7 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
         }
         const child = spawn(
           resolved.command,
-          [...resolved.baseArgs, "--detach", udid],
+          [...resolved.baseArgs, "--detach", "--platform", platform, device],
           { stdio: ["ignore", "pipe", "pipe"], detached: false },
         );
         let stdout = "";

--- a/packages/serve-sim/src/state.ts
+++ b/packages/serve-sim/src/state.ts
@@ -2,6 +2,18 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { readdirSync } from "fs";
 
+export type DevicePlatform = "ios" | "android";
+
+export interface ServerState {
+  pid: number;
+  port: number;
+  device: string;
+  platform?: DevicePlatform;
+  url: string;
+  streamUrl: string;
+  wsUrl: string;
+}
+
 /** Directory where serve-sim stores runtime state. */
 export const STATE_DIR = join(tmpdir(), "serve-sim");
 
@@ -11,7 +23,7 @@ export const STATE_FILE = join(STATE_DIR, "server.json");
 
 /** Per-device state file: `/tmp/serve-sim/server-{udid}.json` */
 export function stateFileForDevice(udid: string): string {
-  return join(STATE_DIR, `server-${udid}.json`);
+  return join(STATE_DIR, `server-${encodeURIComponent(udid)}.json`);
 }
 
 /** List all per-device state files in the state directory. */


### PR DESCRIPTION
## Summary

Adds explicit Android support alongside the existing iOS simulator path, including live browser preview, Android device discovery, streaming, input controls, and adb-backed accessibility snapshots for the existing AX overlay.

## What changed

- Adds `--platform android` / `--android` device selection and adb-backed Android device discovery.
- Adds an Android stream helper that serves screencap PNG frames, WebSocket input, button events, keyboard events, orientation changes, and `/ax` snapshots from `uiautomator dump`.
- Updates the preview UI to list Android devices, use Android-specific chrome/geometry, hide iOS-only tooling for Android streams, and expose Android Back/Home/Recents/Rotate controls.
- Maps Android accessibility XML into the existing AX tree shape so the shared tools panel can show labels, roles, bounds, enabled state, and overlay rectangles for Android streams.
- Updates runtime state, middleware stale-device checks, README usage, and focused tests for Android helpers, stream frame parsing, Android device detection, key mapping, and AX parsing.

## Scope

Existing iOS behavior remains the default. Android multi-touch gestures are not exposed because adb input does not provide a portable multi-pointer primitive.

## Validation

- `bun test packages/serve-sim/src/__tests__/`
- `bun test packages/serve-sim-client/src/__tests__/`
- `bun run build`
- `git diff --check`
- Verified a local Android emulator preview rendered live in the in-app browser with Android toolbar controls, AX tree rows, green AX overlay bounds, and no page console warnings.
