### PR TITLE
serve-sim ax: bootstrap /appstate with frontmost-app probe

### DIFF
--- a/packages/serve-sim/Sources/SimStreamHelper/AccessibilityBridge.swift
+++ b/packages/serve-sim/Sources/SimStreamHelper/AccessibilityBridge.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AppKit
+import Darwin
 import ObjectiveC.runtime
 
 // Accessibility tree fetcher for booted iOS Simulators.
@@ -185,6 +186,104 @@ final class AccessibilityBridge: NSObject {
 
         let json: [Any] = [root]
         return try JSONSerialization.data(withJSONObject: json)
+    }
+
+    /// Cheap point-query for the frontmost app on a simulator: returns
+    /// `{bundleId, pid}` without walking the AX tree. Used to bootstrap
+    /// `/appstate` SSE clients (the SpringBoard log stream is edge-triggered
+    /// so a fresh subscriber sees nothing until the user re-foregrounds an
+    /// app). Throws when SpringBoard hasn't surfaced an app yet.
+    func frontmostApp(udid: String) throws -> [String: Any] {
+        try ensureLoaded()
+
+        guard let device = FrameCapture.findSimDevice(udid: udid) else {
+            throw NSError(domain: "Accessibility", code: 1,
+                          userInfo: [NSLocalizedDescriptionKey: "Device \(udid) not found"])
+        }
+        guard let translator = translator else {
+            throw AccessibilityError.translatorUnavailable
+        }
+
+        let token = UUID().uuidString
+        registerToken(token, device: device)
+        defer { unregisterToken(token) }
+
+        let frontmostSel = NSSelectorFromString("frontmostApplicationWithDisplayId:bridgeDelegateToken:")
+        typealias FrontmostFunc = @convention(c) (AnyObject, Selector, UInt32, NSString) -> AnyObject?
+        guard let frontmostIMP = translator.method(for: frontmostSel) else {
+            throw AccessibilityError.translatorUnavailable
+        }
+        let frontmost = unsafeBitCast(frontmostIMP, to: FrontmostFunc.self)
+        guard let translation = frontmost(translator, frontmostSel, 0, token as NSString) as? NSObject else {
+            throw AccessibilityError.noFrontmostApplication
+        }
+        translation.setValue(token, forKey: "bridgeDelegateToken")
+
+        // AXPTranslationObject's accessors vary across simulator runtimes
+        // and throw NSUnknownKeyException for undefined keys, so probe via
+        // -respondsToSelector: before each KVC fetch.
+        func safeValue<T>(_ key: String, as: T.Type) -> T? {
+            guard translation.responds(to: NSSelectorFromString(key)) else { return nil }
+            return translation.value(forKey: key) as? T
+        }
+
+        var pid: Int32 = 0
+        for key in ["pid", "processIdentifier", "processID"] {
+            if let n = safeValue(key, as: NSNumber.self) {
+                pid = n.int32Value
+                if pid > 0 { break }
+            }
+        }
+
+        // Bundle identifier sometimes ships as a property on the translation
+        // (newer simulator runtimes) — try first, then fall back to walking
+        // the executable path up to the surrounding `.app/Info.plist`.
+        var bundleId: String? = nil
+        for key in ["bundleIdentifier", "processBundleIdentifier", "applicationIdentifier"] {
+            if let s = safeValue(key, as: String.self), !s.isEmpty {
+                bundleId = s
+                break
+            }
+        }
+        if bundleId == nil, pid > 0 {
+            bundleId = Self.bundleIdForPid(pid)
+        }
+
+        guard let bundleId else { throw AccessibilityError.noFrontmostApplication }
+        var result: [String: Any] = ["bundleId": bundleId]
+        if pid > 0 { result["pid"] = Int(pid) }
+        return result
+    }
+
+    /// Resolve a pid to its bundle identifier by reading
+    /// `<executable>.app/Info.plist`. Works for simulator app processes
+    /// because `proc_pidpath` returns the host-side path to the
+    /// `MyApp.app/MyApp` binary inside the simulator's runtime container.
+    private static func bundleIdForPid(_ pid: Int32) -> String? {
+        // PROC_PIDPATHINFO_MAXSIZE = 4 * MAXPATHLEN (4096) — not exported to
+        // Swift in some SDKs, so size the buffer explicitly.
+        var buffer = [CChar](repeating: 0, count: 4 * 1024)
+        let len = proc_pidpath(pid, &buffer, UInt32(buffer.count))
+        guard len > 0 else { return nil }
+        let path = String(cString: buffer)
+        var url = URL(fileURLWithPath: path)
+        // Walk up until we find the enclosing `.app` bundle. SpringBoard
+        // and most user apps land inside one within a few components.
+        for _ in 0..<8 {
+            url.deleteLastPathComponent()
+            if url.pathExtension == "app" {
+                let plist = url.appendingPathComponent("Info.plist")
+                if let data = try? Data(contentsOf: plist),
+                   let obj = try? PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any],
+                   let bundleId = obj["CFBundleIdentifier"] as? String,
+                   !bundleId.isEmpty {
+                    return bundleId
+                }
+                return nil
+            }
+            if url.path == "/" { break }
+        }
+        return nil
     }
 
     /// Sample a grid of screen points and ask the translator for the

--- a/packages/serve-sim/Sources/SimStreamHelper/HTTPServer.swift
+++ b/packages/serve-sim/Sources/SimStreamHelper/HTTPServer.swift
@@ -123,6 +123,38 @@ final class HTTPServer {
             }
         }
 
+        // Frontmost-app probe. Returns `{bundleId, pid}` for the visible
+        // app right now — used to bootstrap `/appstate` SSE clients after
+        // a page reload, since SpringBoard's foreground log is edge-only.
+        server["/foreground"] = { [weak self] _ in
+            guard let self else { return .internalServerError }
+            do {
+                let info = try AccessibilityBridge.shared.frontmostApp(udid: self.deviceUDID)
+                let data = try JSONSerialization.data(withJSONObject: info)
+                var headers = self.corsHeaders
+                headers["Content-Type"] = "application/json"
+                headers["Cache-Control"] = "no-cache, no-store"
+                headers["Content-Length"] = "\(data.count)"
+                return .raw(200, "OK", headers) { writer in
+                    try? writer.write(data)
+                }
+            } catch {
+                let payload: [String: Any] = [
+                    "error": "foreground_unavailable",
+                    "message": error.localizedDescription,
+                ]
+                guard let body = try? JSONSerialization.data(withJSONObject: payload) else {
+                    return .internalServerError
+                }
+                var headers = self.corsHeaders
+                headers["Content-Type"] = "application/json"
+                headers["Content-Length"] = "\(body.count)"
+                return .raw(503, "Service Unavailable", headers) { writer in
+                    try? writer.write(body)
+                }
+            }
+        }
+
         // CORS preflight
         server.middleware.append { request in
             if request.method == "OPTIONS" {

--- a/packages/serve-sim/src/middleware.ts
+++ b/packages/serve-sim/src/middleware.ts
@@ -1051,6 +1051,31 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
       });
       res.write(":\n\n");
 
+      // Bootstrap: SpringBoard's log feed is edge-triggered, so a fresh
+      // subscriber would otherwise see nothing until the user re-foregrounds
+      // an app (the bug: tools couldn't reconnect after a page reload). Ask
+      // the helper's AX bridge for the current frontmost app via
+      // `proc_pidpath`+Info.plist resolution and emit it before tailing.
+      let lastBundle = "";
+      void (async () => {
+        try {
+          const ctrl = new AbortController();
+          const timer = setTimeout(() => ctrl.abort(), 1500);
+          const r = await fetch(`http://127.0.0.1:${state.port}/foreground`, { signal: ctrl.signal });
+          clearTimeout(timer);
+          if (!r.ok) return;
+          const info = await r.json() as { bundleId?: string; pid?: number };
+          if (!info.bundleId || !isUserFacingBundle(info.bundleId)) return;
+          if (res.writableEnded) return;
+          lastBundle = info.bundleId;
+          const isReactNative = await detectReactNative(udid, info.bundleId);
+          if (res.writableEnded) return;
+          res.write("data: " + JSON.stringify({ bundleId: info.bundleId, pid: info.pid, isReactNative }) + "\n\n");
+        } catch {
+          // Helper may be coming up — log tail will fill in once anything moves.
+        }
+      })();
+
       const child: ChildProcess = spawn("xcrun", [
         "simctl", "spawn", udid, "log", "stream",
         "--style", "ndjson",
@@ -1059,28 +1084,17 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
         'process == "SpringBoard" AND eventMessage CONTAINS "Setting process visibility to: Foreground"',
       ], { stdio: ["ignore", "pipe", "ignore"] });
 
-      let lastBundle = "";
-      let hasEmitted = false;
       let closed = false;
       const emitApp = async (bundleId: string, pid?: number) => {
         if (!isUserFacingBundle(bundleId)) return;
         if (bundleId === lastBundle) return;
         lastBundle = bundleId;
-        hasEmitted = true;
         const isReactNative = await detectReactNative(udid, bundleId);
         if (!closed) {
           res.write("data: " + JSON.stringify({ bundleId, pid, isReactNative }) + "\n\n");
         }
       };
 
-      // The seed loses to any live log event — a SpringBoard log that fires
-      // while the AX call is in flight is fresher than the AX snapshot.
-      detectCurrentForegroundApp(udid, state.url).then((app) => {
-        if (!app || closed || hasEmitted) return;
-        lastBundle = app.bundleId;
-        hasEmitted = true;
-        res.write("data: " + JSON.stringify(app) + "\n\n");
-      });
 
       let buf = "";
       child.stdout!.on("data", (chunk: Buffer) => {


### PR DESCRIPTION
## Summary
- Add `/foreground` route to SimStreamHelper that returns `{bundleId, pid}` for the visible app via a cheap AX point-query (no tree walk).
- Seed `/appstate` SSE subscribers with the result so tools can reconnect after page reloads — SpringBoard's foreground log is edge-triggered, so fresh subscribers previously saw nothing until the user re-foregrounded an app.
- Resolve bundle id Swift-side by walking `proc_pidpath` up to the enclosing `.app/Info.plist`. Replaces the prior `/ax` + `simctl listapps` seed in middleware.ts.

Split out of #@evanbacon/camera-stream so the AX work can land independently of the camera/location tooling.

## Test plan
- [ ] Boot a sim, open the preview page, confirm tools attach without re-foregrounding the app.
- [ ] Reload the preview page; SSE bootstrap fires and emits the current bundle id within ~1.5s.
- [ ] `bun test` (middleware-selection, accessibility-endpoint) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)