### PR TITLE
docs: correct `.claude/launch.json` port config in README

### DIFF
--- a/packages/serve-sim/README.md
+++ b/packages/serve-sim/README.md
@@ -137,7 +137,7 @@ Create a `.claude/launch.json` and define a server:
       "name": "Apple",
       "runtimeExecutable": "npx",
       "runtimeArgs": ["serve-sim"],
-      "url": "http://localhost:3200"
+      "port": 3200
     }
   ]
 }


### PR DESCRIPTION
README.md referenced an invalid `url` property for Claude Code. The right property is `port`.