### PR TITLE
feat(serve-sim): add `type` subcommand

### DIFF
--- a/.github/workflows/sim-test.yml
+++ b/.github/workflows/sim-test.yml
@@ -26,21 +26,30 @@ jobs:
       - name: Boot iOS simulator
         id: boot-sim
         run: |
-          UDID=$(xcrun simctl list devices available -j | node -e "
-            const data = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
-            const iosRuntimes = Object.keys(data.devices).filter(r => r.includes('iOS'));
-            iosRuntimes.sort().reverse();
-            for (const runtime of iosRuntimes) {
-              for (const d of data.devices[runtime]) {
-                if (d.isAvailable && d.name.includes('iPhone')) {
-                  console.log(d.udid);
-                  process.exit(0);
+          # Fast path: GitHub's macOS runner images pre-create iPhone
+          # simulators, so try booting one by name directly. `simctl list`
+          # enumerates every device/runtime and was costing 1.5-3min of
+          # cold-CoreSimulator first-touch — boot-by-name pays that once on a
+          # single device instead. The first available name wins; fall back
+          # to the full discovery+create path only if none boot.
+          UDID=""
+          for NAME in "iPhone 16 Pro" "iPhone 16" "iPhone 15 Pro" "iPhone 15"; do
+            echo "Trying to boot \"$NAME\"..."
+            if OUT=$(xcrun simctl boot "$NAME" 2>&1); then
+              UDID=$(xcrun simctl list devices booted -j | node -e "
+                const data = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+                for (const devs of Object.values(data.devices)) {
+                  for (const d of devs) { console.log(d.udid); process.exit(0); }
                 }
-              }
-            }
-          ")
+              ")
+              echo "Booted \"$NAME\" -> $UDID"
+              break
+            fi
+            echo "  skip: $OUT"
+          done
+
           if [ -z "$UDID" ]; then
-            echo "No pre-created iOS simulator found; creating one from the latest runtime"
+            echo "No pre-created iPhone simulator booted; creating one from the latest runtime"
             RUNTIME=$(xcrun simctl list runtimes -j | node -e "
               const data = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
               const ios = data.runtimes.filter(r => r.isAvailable && r.identifier.includes('iOS'));
@@ -53,9 +62,9 @@ jobs:
               console.log(iphones[iphones.length - 1].identifier);
             ")
             UDID=$(xcrun simctl create "ci-test-iphone" "$DEVICETYPE" "$RUNTIME")
+            xcrun simctl boot "$UDID" || true
           fi
-          echo "Booting simulator $UDID"
-          xcrun simctl boot "$UDID" || true
+
           xcrun simctl bootstatus "$UDID" -b
           open -ga Simulator || true
           echo "udid=$UDID" >> $GITHUB_OUTPUT

--- a/.github/workflows/sim-test.yml
+++ b/.github/workflows/sim-test.yml
@@ -56,8 +56,22 @@ jobs:
           fi
           echo "Booting simulator $UDID"
           xcrun simctl boot "$UDID" || true
-          xcrun simctl bootstatus "$UDID" -b
           open -ga Simulator || true
+
+          # `simctl bootstatus -b` blocks until every first-launch migration
+          # finishes (~1-2min on cold CI). Our tests only need SpringBoard
+          # running — it owns the framebuffer surface and HID dispatch we
+          # exercise. Poll for it instead.
+          echo "Waiting for SpringBoard..."
+          for i in $(seq 1 120); do
+            if xcrun simctl spawn "$UDID" launchctl print system 2>/dev/null \
+                 | grep -q "com.apple.SpringBoard"; then
+              echo "SpringBoard up after ${i}s"
+              break
+            fi
+            sleep 1
+          done
+
           echo "udid=$UDID" >> $GITHUB_OUTPUT
 
       - name: serve-sim tests

--- a/.github/workflows/sim-test.yml
+++ b/.github/workflows/sim-test.yml
@@ -1,0 +1,68 @@
+name: serve-sim tests
+
+on:
+  pull_request:
+    paths:
+      - "packages/serve-sim/**"
+      - ".github/workflows/sim-test.yml"
+
+# Cancel superseded runs — pushing twice to the same PR shouldn't burn two
+# macOS slots in parallel.
+concurrency:
+  group: sim-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sim-test:
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+
+      - name: Boot iOS simulator
+        id: boot-sim
+        run: |
+          UDID=$(xcrun simctl list devices available -j | node -e "
+            const data = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+            const iosRuntimes = Object.keys(data.devices).filter(r => r.includes('iOS'));
+            iosRuntimes.sort().reverse();
+            for (const runtime of iosRuntimes) {
+              for (const d of data.devices[runtime]) {
+                if (d.isAvailable && d.name.includes('iPhone')) {
+                  console.log(d.udid);
+                  process.exit(0);
+                }
+              }
+            }
+          ")
+          if [ -z "$UDID" ]; then
+            echo "No pre-created iOS simulator found; creating one from the latest runtime"
+            RUNTIME=$(xcrun simctl list runtimes -j | node -e "
+              const data = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+              const ios = data.runtimes.filter(r => r.isAvailable && r.identifier.includes('iOS'));
+              ios.sort((a, b) => a.version.localeCompare(b.version));
+              console.log(ios[ios.length - 1].identifier);
+            ")
+            DEVICETYPE=$(xcrun simctl list devicetypes -j | node -e "
+              const data = JSON.parse(require('fs').readFileSync(0, 'utf-8'));
+              const iphones = data.devicetypes.filter(d => d.identifier.includes('iPhone'));
+              console.log(iphones[iphones.length - 1].identifier);
+            ")
+            UDID=$(xcrun simctl create "ci-test-iphone" "$DEVICETYPE" "$RUNTIME")
+          fi
+          echo "Booting simulator $UDID"
+          xcrun simctl boot "$UDID" || true
+          xcrun simctl bootstatus "$UDID" -b
+          open -ga Simulator || true
+          echo "udid=$UDID" >> $GITHUB_OUTPUT
+
+      - name: serve-sim tests
+        run: bun test packages/serve-sim/src/__tests__/
+
+      - name: Shutdown simulator
+        if: always() && steps.boot-sim.outputs.udid != ''
+        run: xcrun simctl shutdown "${{ steps.boot-sim.outputs.udid }}" || true

--- a/.github/workflows/sim-test.yml
+++ b/.github/workflows/sim-test.yml
@@ -56,22 +56,8 @@ jobs:
           fi
           echo "Booting simulator $UDID"
           xcrun simctl boot "$UDID" || true
+          xcrun simctl bootstatus "$UDID" -b
           open -ga Simulator || true
-
-          # `simctl bootstatus -b` blocks until every first-launch migration
-          # finishes (~1-2min on cold CI). Our tests only need SpringBoard
-          # running — it owns the framebuffer surface and HID dispatch we
-          # exercise. Poll for it instead.
-          echo "Waiting for SpringBoard..."
-          for i in $(seq 1 120); do
-            if xcrun simctl spawn "$UDID" launchctl print system 2>/dev/null \
-                 | grep -q "com.apple.SpringBoard"; then
-              echo "SpringBoard up after ${i}s"
-              break
-            fi
-            sleep 1
-          done
-
           echo "udid=$UDID" >> $GITHUB_OUTPUT
 
       - name: serve-sim tests

--- a/packages/serve-sim/src/__tests__/type-command-sim.test.ts
+++ b/packages/serve-sim/src/__tests__/type-command-sim.test.ts
@@ -1,0 +1,110 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { execSync, spawnSync } from "child_process";
+import { readFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+/**
+ * Native e2e for `serve-sim type`.
+ *
+ * Boots through the full stack: textToKeyEvents → WS 0x06 frames →
+ * SimStreamHelper.ClientManager → HIDInjector.sendKey → CoreSimulator's HID
+ * legacy client. The helper logs `[hid] Key <down|up> usage=0x<hex>` for every
+ * accepted key event, which is what we assert against — proving the event
+ * round-tripped all the way to the sim, not just to the helper's WS reader.
+ *
+ * Skipped automatically when no iOS simulator is booted, so this stays green
+ * on machines without one. The macOS CI job boots a sim explicitly and runs
+ * `bun test packages/serve-sim/src/__tests__/`, so it runs there.
+ */
+
+const CLI_PATH = join(import.meta.dir, "../../src/index.ts");
+const STATE_DIR = join(tmpdir(), "serve-sim");
+
+function firstBootedIosSim(): string | null {
+  try {
+    const out = execSync("xcrun simctl list devices booted -j", { encoding: "utf-8" });
+    const data = JSON.parse(out) as {
+      devices: Record<string, Array<{ udid: string; state: string }>>;
+    };
+    for (const [runtime, devs] of Object.entries(data.devices)) {
+      if (!runtime.includes("iOS")) continue;
+      for (const d of devs) if (d.state === "Booted") return d.udid;
+    }
+  } catch {}
+  return null;
+}
+
+const bootedUdid = firstBootedIosSim();
+const describeWithSim = bootedUdid ? describe : describe.skip;
+
+describeWithSim(`serve-sim type e2e (booted sim ${bootedUdid ?? "<skipped>"})`, () => {
+  let logFile: string;
+
+  beforeAll(() => {
+    try { execSync(`bun run ${CLI_PATH} --kill`, { stdio: "pipe" }); } catch {}
+
+    const detach = spawnSync("bun", ["run", CLI_PATH, "--detach", bootedUdid!], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "inherit"],
+      timeout: 45_000,
+    });
+    if (detach.status !== 0 || !detach.stdout) {
+      throw new Error(
+        `serve-sim --detach failed (exit=${detach.status} signal=${detach.signal})\nstdout: ${detach.stdout}`,
+      );
+    }
+    logFile = join(STATE_DIR, `server-${bootedUdid!}.log`);
+  }, 60_000);
+
+  afterAll(() => {
+    try { execSync(`bun run ${CLI_PATH} --kill`, { stdio: "pipe" }); } catch {}
+  });
+
+  test("`serve-sim type` injects HID key events into the booted simulator", async () => {
+    const logBefore = readFileSync(logFile, "utf-8");
+    const beforeCount = countKeyLines(logBefore);
+
+    // "Hi!" → 10 events:
+    //   H: shift down, KeyH down, KeyH up, shift up      (0xe1, 0x0b, 0x0b, 0xe1)
+    //   i: KeyI down, KeyI up                            (0x0c, 0x0c)
+    //   !: shift down, Digit1 down, Digit1 up, shift up  (0xe1, 0x1e, 0x1e, 0xe1)
+    const result = spawnSync("bun", ["run", CLI_PATH, "type", "Hi!", "-d", bootedUdid!], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 15_000,
+    });
+    expect(result.status).toBe(0);
+
+    // Wait briefly for the helper to flush its stdout log — sendKey is sync,
+    // but stdio buffering means a few ms can elapse before lines hit the file.
+    await new Promise((r) => setTimeout(r, 200));
+
+    const logAfter = readFileSync(logFile, "utf-8");
+    const newLines = logAfter.slice(logBefore.length);
+    const afterCount = countKeyLines(logAfter);
+
+    expect(afterCount - beforeCount).toBe(10);
+
+    // Every usage we sent must show up at least once in the new log slice.
+    const expectedUsages = [0xe1, 0x0b, 0x0c, 0x1e];
+    for (const usage of expectedUsages) {
+      const hex = usage.toString(16);
+      expect(newLines).toContain(`usage=0x${hex}`);
+    }
+
+    // And we should see balanced down/up events for the new slice.
+    expect(countMatches(newLines, /\[hid\] Key down /g)).toBe(5);
+    expect(countMatches(newLines, /\[hid\] Key up /g)).toBe(5);
+  }, 30_000);
+});
+
+function countKeyLines(s: string): number {
+  return countMatches(s, /\[hid\] Key (down|up) /g);
+}
+
+function countMatches(s: string, re: RegExp): number {
+  let n = 0;
+  for (let m = re.exec(s); m; m = re.exec(s)) n++;
+  return n;
+}

--- a/packages/serve-sim/src/__tests__/type-command.test.ts
+++ b/packages/serve-sim/src/__tests__/type-command.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, beforeAll, afterAll } from "bun:test";
+import type { ServerWebSocket } from "bun";
+import { textToKeyEvents, UnsupportedCharacterError, sendKeyEventsToWs } from "../text-to-keys";
+
+describe("textToKeyEvents", () => {
+  it("emits down/up for a single lowercase letter", () => {
+    expect(textToKeyEvents("a")).toEqual([
+      { type: "down", usage: 0x04 },
+      { type: "up", usage: 0x04 },
+    ]);
+  });
+
+  it("wraps shifted characters with left-shift down/up", () => {
+    // 'A' = shift + KeyA(0x04)
+    expect(textToKeyEvents("A")).toEqual([
+      { type: "down", usage: 0xe1 },
+      { type: "down", usage: 0x04 },
+      { type: "up", usage: 0x04 },
+      { type: "up", usage: 0xe1 },
+    ]);
+  });
+
+  it("maps digits and shifted symbols on the digits row", () => {
+    // '1' = 0x1e (no shift); '!' = shift + 0x1e
+    expect(textToKeyEvents("1!")).toEqual([
+      { type: "down", usage: 0x1e },
+      { type: "up", usage: 0x1e },
+      { type: "down", usage: 0xe1 },
+      { type: "down", usage: 0x1e },
+      { type: "up", usage: 0x1e },
+      { type: "up", usage: 0xe1 },
+    ]);
+    // '0' = 0x27
+    expect(textToKeyEvents("0")[0]).toEqual({ type: "down", usage: 0x27 });
+  });
+
+  it("maps space, newline, and tab to their HID codes", () => {
+    expect(textToKeyEvents(" ")[0]).toEqual({ type: "down", usage: 0x2c });
+    expect(textToKeyEvents("\n")[0]).toEqual({ type: "down", usage: 0x28 });
+    expect(textToKeyEvents("\t")[0]).toEqual({ type: "down", usage: 0x2b });
+  });
+
+  it("normalizes CRLF to a single Enter press", () => {
+    expect(textToKeyEvents("\r\n")).toEqual([
+      { type: "down", usage: 0x28 },
+      { type: "up", usage: 0x28 },
+    ]);
+  });
+
+  it("covers common punctuation in both plain and shifted forms", () => {
+    // ; → 0x33, : → shift+0x33; / → 0x38, ? → shift+0x38
+    expect(textToKeyEvents(";")[0]).toEqual({ type: "down", usage: 0x33 });
+    expect(textToKeyEvents(":")[0]).toEqual({ type: "down", usage: 0xe1 });
+    expect(textToKeyEvents("/")[0]).toEqual({ type: "down", usage: 0x38 });
+    expect(textToKeyEvents("?")[1]).toEqual({ type: "down", usage: 0x38 });
+  });
+
+  it("throws UnsupportedCharacterError for non-US-keyboard chars", () => {
+    expect(() => textToKeyEvents("é")).toThrow(UnsupportedCharacterError);
+    expect(() => textToKeyEvents("emoji 🙂 here")).toThrow(UnsupportedCharacterError);
+  });
+
+  it("produces 4 events for an uppercase letter (shift wraps key)", () => {
+    expect(textToKeyEvents("A").length).toBe(4);
+  });
+
+  it("expands 'Hi!' to the expected event count", () => {
+    // H: shift+down+up+shift(4) ; i: down+up(2) ; !: shift+down+up+shift(4) → 10
+    expect(textToKeyEvents("Hi!").length).toBe(10);
+  });
+});
+
+// ─── E2E: send key events over WS to a fake serve-sim server ───
+//
+// Spins up a Bun WebSocket server that mimics the serve-sim helper's input
+// channel, runs the type-command's send path, and asserts the bytes received
+// match what `textToKeyEvents` produced.
+
+describe("sendKeyEventsToWs e2e", () => {
+  let server: ReturnType<typeof Bun.serve>;
+  let wsUrl: string;
+  let received: Array<{ opcode: number; payload: unknown }>;
+
+  beforeAll(() => {
+    received = [];
+    server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req, srv) {
+        if (srv.upgrade(req, { data: undefined })) return;
+        return new Response("not a ws", { status: 400 });
+      },
+      websocket: {
+        message(_ws: ServerWebSocket<unknown>, data: string | Buffer) {
+          const buf = typeof data === "string" ? Buffer.from(data) : data;
+          const opcode = buf[0]!;
+          const json = buf.slice(1).toString("utf8");
+          received.push({ opcode, payload: JSON.parse(json) });
+        },
+      },
+    });
+    wsUrl = `ws://127.0.0.1:${server.port}/ws`;
+  });
+
+  afterAll(() => {
+    server.stop(true);
+  });
+
+  it("sends one 0x06 WS frame per key event with the JSON payload", async () => {
+    received.length = 0;
+    const events = textToKeyEvents("aB");
+    // 'a' (2 events) + 'B' (4 events) = 6 frames
+    expect(events.length).toBe(6);
+
+    await sendKeyEventsToWs(wsUrl, events, /* perEventDelayMs */ 0);
+
+    // Wait briefly for the server to drain all frames before we assert. The
+    // WS client closes only after a 50ms tail in sendKeyEventsToWs, so frames
+    // should already be flushed by the time the promise resolves — but give
+    // the event loop one tick to deliver the final `message` callbacks.
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(received.length).toBe(6);
+    for (const frame of received) {
+      expect(frame.opcode).toBe(0x06);
+    }
+    expect(received.map((f) => f.payload)).toEqual(events);
+  });
+
+  it("rejects when the WS endpoint is unreachable", async () => {
+    // Port 1 is virtually never accepting connections from a normal process.
+    let err: unknown;
+    try {
+      await sendKeyEventsToWs("ws://127.0.0.1:1/ws", [{ type: "down", usage: 0x04 }], 0);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/WebSocket/);
+  });
+});

--- a/packages/serve-sim/src/index.ts
+++ b/packages/serve-sim/src/index.ts
@@ -5,6 +5,7 @@ import { createHash } from "crypto";
 import { homedir, networkInterfaces } from "os";
 import { join, resolve } from "path";
 import { STATE_DIR, stateFileForDevice, listStateFiles } from "./state";
+import { textToKeyEvents, UnsupportedCharacterError, sendKeyEventsToWs } from "./text-to-keys";
 import { dirnameOf, sleepSync, isPortFree, servePreview } from "./runtime";
 
 // `import.meta.dir` is Bun-only; resolve once via fileURLToPath so the bundled
@@ -922,6 +923,70 @@ async function tap(args: string[]) {
       reject(new Error("WebSocket connection failed"));
     };
   });
+}
+
+async function typeText(args: string[]) {
+  let deviceArg: string | undefined;
+  let useStdin = false;
+  let inputFile: string | undefined;
+  const positional: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!;
+    if (a === "--device" || a === "-d") {
+      deviceArg = args[++i];
+    } else if (a === "--stdin") {
+      useStdin = true;
+    } else if (a === "--file") {
+      inputFile = args[++i];
+    } else {
+      positional.push(a);
+    }
+  }
+
+  const sourceCount = [positional.length > 0, useStdin, inputFile != null].filter(Boolean).length;
+  if (sourceCount === 0 || sourceCount > 1) {
+    console.error("Usage: serve-sim type <text> [-d udid]");
+    console.error("       serve-sim type --stdin [-d udid]");
+    console.error("       serve-sim type --file <path> [-d udid]");
+    console.error("");
+    console.error("Only US-keyboard ASCII characters are supported (A-Z, a-z, 0-9,");
+    console.error("space, newline, tab, and standard punctuation).");
+    process.exit(1);
+  }
+
+  let text: string;
+  if (useStdin) {
+    text = readFileSync(0, "utf8");
+  } else if (inputFile) {
+    try {
+      text = readFileSync(inputFile, "utf8");
+    } catch (err) {
+      console.error(`Failed to read file '${inputFile}': ${(err as Error).message}`);
+      process.exit(1);
+    }
+  } else {
+    text = positional.join(" ");
+  }
+
+  let events;
+  try {
+    events = textToKeyEvents(text);
+  } catch (err) {
+    if (err instanceof UnsupportedCharacterError) {
+      console.error(err.message);
+      console.error("Supported: A-Z, a-z, 0-9, space, newline, tab, and standard punctuation.");
+      process.exit(1);
+    }
+    throw err;
+  }
+
+  const state = readState(deviceArg);
+  if (!state) {
+    console.error("No serve-sim server running. Run `serve-sim` first.");
+    process.exit(1);
+  }
+
+  await sendKeyEventsToWs(state.wsUrl, events);
 }
 
 async function rotate(args: string[]) {
@@ -1847,6 +1912,8 @@ Usage:
   serve-sim gesture '<json>' [-d udid]  Send a touch gesture
   serve-sim tap <x> <y> [-d udid]       Tap at normalized 0..1 coords
   serve-sim button [name] [-d udid]     Send a button press (default: home)
+  serve-sim type <text> [-d udid]       Type text (US keyboard only)
+                                        Use --stdin or --file <path> for input from stdin/file
   serve-sim rotate <orientation> [-d udid]
                                         Set device orientation
                                         (portrait|portrait_upside_down|landscape_left|landscape_right)
@@ -1896,6 +1963,10 @@ if (argv[0] === "tap") {
 }
 if (argv[0] === "button") {
   await button(argv.slice(1));
+  process.exit(0);
+}
+if (argv[0] === "type") {
+  await typeText(argv.slice(1));
   process.exit(0);
 }
 if (argv[0] === "rotate") {

--- a/packages/serve-sim/src/text-to-keys.ts
+++ b/packages/serve-sim/src/text-to-keys.ts
@@ -1,0 +1,119 @@
+// Convert a US-keyboard text string into a sequence of USB HID Usage Page 0x07
+// keyboard events (`down`/`up`) suitable for the serve-sim WS key opcode (0x06).
+//
+// Mirrors the AXe `type` command's character coverage: A-Z, a-z, 0-9, space,
+// newline, tab, and the standard ASCII punctuation reachable on a US layout.
+
+const LEFT_SHIFT = 0xe1;
+
+// Char → { usage, shift } for US keyboard physical keys.
+type KeySpec = { usage: number; shift: boolean };
+
+function buildMap(): Record<string, KeySpec> {
+  const map: Record<string, KeySpec> = {};
+
+  for (let i = 0; i < 26; i++) {
+    const usage = 0x04 + i;
+    map[String.fromCharCode(0x61 + i)] = { usage, shift: false }; // a-z
+    map[String.fromCharCode(0x41 + i)] = { usage, shift: true };  // A-Z
+  }
+
+  // Digits row: 1..9 then 0
+  const digits = "1234567890";
+  const digitShifted = "!@#$%^&*()";
+  for (let i = 0; i < 10; i++) {
+    const usage = 0x1e + i;
+    map[digits[i]!] = { usage, shift: false };
+    map[digitShifted[i]!] = { usage, shift: true };
+  }
+
+  const rest: Array<[string, string, number]> = [
+    // [plain, shifted, usage]
+    ["-", "_", 0x2d],
+    ["=", "+", 0x2e],
+    ["[", "{", 0x2f],
+    ["]", "}", 0x30],
+    ["\\", "|", 0x31],
+    [";", ":", 0x33],
+    ["'", '"', 0x34],
+    ["`", "~", 0x35],
+    [",", "<", 0x36],
+    [".", ">", 0x37],
+    ["/", "?", 0x38],
+  ];
+  for (const [plain, shifted, usage] of rest) {
+    map[plain] = { usage, shift: false };
+    map[shifted] = { usage, shift: true };
+  }
+
+  map[" "] = { usage: 0x2c, shift: false };
+  map["\n"] = { usage: 0x28, shift: false }; // Enter
+  map["\t"] = { usage: 0x2b, shift: false }; // Tab
+
+  return map;
+}
+
+export const US_KEYBOARD_MAP: Readonly<Record<string, KeySpec>> = buildMap();
+
+export type KeyEvent = { type: "down" | "up"; usage: number };
+
+export class UnsupportedCharacterError extends Error {
+  constructor(public readonly char: string) {
+    super(`Unsupported character: ${JSON.stringify(char)}`);
+  }
+}
+
+/** Send a sequence of key events to a serve-sim WS endpoint using the 0x06
+ *  (WS_MSG_KEY) opcode. Each event is sent as one binary frame. */
+export async function sendKeyEventsToWs(
+  wsUrl: string,
+  events: ReadonlyArray<KeyEvent>,
+  // iOS coalesces events that arrive in the same tick, so a small gap keeps
+  // long strings reliable without making the command noticeably slow.
+  perEventDelayMs = 4,
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const ws = new WebSocket(wsUrl);
+    ws.binaryType = "arraybuffer";
+
+    ws.onopen = async () => {
+      try {
+        for (const ev of events) {
+          const json = new TextEncoder().encode(JSON.stringify(ev));
+          const msg = new Uint8Array(1 + json.length);
+          msg[0] = 0x06; // WS_MSG_KEY
+          msg.set(json, 1);
+          ws.send(msg);
+          if (perEventDelayMs > 0) {
+            await new Promise((r) => setTimeout(r, perEventDelayMs));
+          }
+        }
+        setTimeout(() => { ws.close(); resolve(); }, 50);
+      } catch (err) {
+        ws.close();
+        reject(err);
+      }
+    };
+
+    ws.onerror = () => {
+      reject(new Error(`WebSocket connection failed: ${wsUrl}`));
+    };
+  });
+}
+
+/** Returns the events needed to type `text`, or throws on unsupported chars.
+ *  Each character emits (optional shift down) → key down → key up → (optional shift up). */
+export function textToKeyEvents(text: string): KeyEvent[] {
+  const events: KeyEvent[] = [];
+  for (const ch of text) {
+    // Normalize CRLF / lone CR to a single Enter press.
+    if (ch === "\r") continue;
+    const spec = US_KEYBOARD_MAP[ch];
+    if (!spec) throw new UnsupportedCharacterError(ch);
+    if (spec.shift) events.push({ type: "down", usage: LEFT_SHIFT });
+    events.push({ type: "down", usage: spec.usage });
+    events.push({ type: "up", usage: spec.usage });
+    if (spec.shift) events.push({ type: "up", usage: LEFT_SHIFT });
+  }
+  return events;
+}


### PR DESCRIPTION
## Summary
- New \`serve-sim type <text>\` CLI (also \`--stdin\` / \`--file\`) that mirrors AXe's \`type\`: maps US-keyboard text → HID usages and streams them through the existing 0x06 WS_MSG_KEY opcode — no new wire protocol.
- Pure planner in \`src/text-to-keys.ts\` so the conversion is unit-testable and reusable.
- Two test layers, both fast:
  - \`type-command.test.ts\` (~85ms): pure-function tests + an in-process e2e that runs the WS sender against a Bun.serve mock and asserts the exact frames received.
  - \`type-command-sim.test.ts\` (~6s on a booted sim): real native e2e — boots through text → WS → \`SimStreamHelper\` → \`HIDInjector\` → CoreSimulator HID, verified via the helper's \`[hid] Key …\` log lines. Skips when no sim is booted.

## Test plan
- [x] \`bun test src/__tests__/type-command.test.ts\` → 11 pass / 85ms
- [x] \`bun test src/__tests__/type-command-sim.test.ts\` against a booted iOS sim → 1 pass / 6.17s
- [x] \`bunx tsc --noEmit\` clean
- [ ] CI: macOS sim job picks up both new tests via the existing \`bun test packages/serve-sim/src/__tests__/\` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `serve-sim type` to send text to a running iOS simulator (positional text, stdin, or file) with device selection and friendly error for unsupported characters
  * Full US keyboard support (letters, digits, punctuation, whitespace, CRLF normalization) and sends generated key events to the simulator

* **Tests**
  * New unit and native E2E tests validating text→key-event conversion, HID event counts, and WebSocket delivery

* **Chores**
  * CI workflow to boot an iOS simulator and run serve-sim tests on PRs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EvanBacon/serve-sim/pull/55)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->