### PR TITLE
Rewrite serve-sim CLI argument parsing with commander

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,10 +22,12 @@
       },
       "devDependencies": {
         "@types/bun": "latest",
+        "@types/debug": "^4.1.13",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "bun-plugin-tailwind": "^0.1.2",
         "commander": "^14.0.1",
+        "debug": "^4.4.3",
         "preact": "^10.29.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -234,6 +236,10 @@
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
+
+    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/node": ["@types/node@25.6.2", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
     },
     "packages/serve-sim": {
       "name": "serve-sim",
-      "version": "0.1.21",
+      "version": "0.1.30",
       "bin": {
         "serve-sim": "dist/serve-sim.js",
       },
@@ -25,6 +25,7 @@
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "bun-plugin-tailwind": "^0.1.2",
+        "commander": "^14.0.1",
         "preact": "^10.29.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -232,7 +233,7 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
-    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/node": ["@types/node@25.6.2", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw=="],
 
@@ -254,11 +255,11 @@
 
     "bun-plugin-tailwind": ["bun-plugin-tailwind@0.1.2", "", { "peerDependencies": { "bun": ">=1.0.0" } }, "sha512-41jNC1tZRSK3s1o7pTNrLuQG8kL/0vR/JgiTmZAJ1eHwe0w5j6HFPKeqEk0WAD13jfrUC7+ULuewFBBCoADPpg=="],
 
-    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
-    "commander": ["commander@6.2.1", "", {}, "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="],
+    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
@@ -426,11 +427,11 @@
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
-    "bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
-
     "rc/ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
     "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
+
+    "seek-bzip/commander": ["commander@6.2.1", "", {}, "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="],
 
     "serve-sim/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 

--- a/packages/serve-sim/package.json
+++ b/packages/serve-sim/package.json
@@ -60,8 +60,10 @@
   },
   "devDependencies": {
     "@types/bun": "latest",
+    "@types/debug": "^4.1.13",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
+    "debug": "^4.4.3",
     "bun-plugin-tailwind": "^0.1.2",
     "commander": "^14.0.1",
     "preact": "^10.29.1",

--- a/packages/serve-sim/package.json
+++ b/packages/serve-sim/package.json
@@ -63,6 +63,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "bun-plugin-tailwind": "^0.1.2",
+    "commander": "^14.0.1",
     "preact": "^10.29.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/packages/serve-sim/src/__tests__/accessibility-endpoint.test.ts
+++ b/packages/serve-sim/src/__tests__/accessibility-endpoint.test.ts
@@ -15,7 +15,7 @@ const CLI_PATH = join(import.meta.dir, "../../src/index.ts");
 const AX_RESPONSE_BUDGET_MS = process.env.CI ? 10_000 : 5_000;
 // The Swift helper returns 503 while the simulator's AX framework is still
 // warming up after boot. Poll past that startup window before failing.
-const AX_READY_BUDGET_MS = process.env.CI ? 30_000 : 10_000;
+const AX_READY_BUDGET_MS = process.env.CI ? 60_000 : 10_000;
 const AX_READY_POLL_INTERVAL_MS = 500;
 
 function firstBootedIosSim(): string | null {

--- a/packages/serve-sim/src/__tests__/permissions.e2e.test.ts
+++ b/packages/serve-sim/src/__tests__/permissions.e2e.test.ts
@@ -110,8 +110,9 @@ function locationAuth(bundleId: string): number | null {
 
 // Each case shells the built CLI a few times, and a cold `simctl privacy`
 // call (location) can take several seconds on a fresh CI sim — comfortably
-// past bun's 5s default. Give every hook and test a generous budget.
-const T = 30_000;
+// past bun's 5s default. The beforeAll reset-all also cascades through every
+// permission while the sim is fully cold, so the budget has to cover that.
+const T = 90_000;
 
 describeIfSim("serve-sim permissions (real simulator)", () => {
   beforeAll(() => {

--- a/packages/serve-sim/src/debug.ts
+++ b/packages/serve-sim/src/debug.ts
@@ -1,0 +1,12 @@
+import createDebug from "debug";
+
+// Namespaces are scoped under `serve-sim:*` so `DEBUG=serve-sim*` enables all
+// of them. The most common stream-died debugging path is:
+//   serve-sim:state    — state file lifecycle (helper alive? sim booted?)
+//   serve-sim:helper   — helper spawn / readiness / exit
+//   serve-sim:mw       — middleware state selection + stale-helper recycling
+//   serve-sim:cli      — top-level command dispatch
+export const debugCli = createDebug("serve-sim:cli");
+export const debugHelper = createDebug("serve-sim:helper");
+export const debugState = createDebug("serve-sim:state");
+export const debugMw = createDebug("serve-sim:mw");

--- a/packages/serve-sim/src/index.ts
+++ b/packages/serve-sim/src/index.ts
@@ -10,6 +10,7 @@ import { textToKeyEvents, UnsupportedCharacterError, sendKeyEventsToWs } from ".
 import { dirnameOf, sleepSync, isPortFree, servePreview } from "./runtime";
 import { findBootedDevice, resolveDevice } from "./device";
 import { permissions } from "./permissions";
+import { debugCli, debugHelper, debugState } from "./debug";
 
 // `import.meta.dir` is Bun-only; resolve once via fileURLToPath so the bundled
 // CLI works under plain `node` too.
@@ -87,12 +88,16 @@ function getBootedUdids(): Set<string> | null {
 
 function readStateFile(file: string): ServerState | null {
   try {
-    if (!existsSync(file)) return null;
+    if (!existsSync(file)) {
+      debugState("state file missing %s", file);
+      return null;
+    }
     const state = JSON.parse(readFileSync(file, "utf-8")) as ServerState;
     try {
       process.kill(state.pid, 0);
     } catch {
       // Helper process is gone — drop the file.
+      debugState("helper pid %d dead, removing stale state %s", state.pid, file);
       unlinkSync(file);
       return null;
     }
@@ -103,6 +108,11 @@ function readStateFile(file: string): ServerState | null {
     // recycle here so --detach / --list always return a working stream.
     const booted = getBootedUdids();
     if (booted && !booted.has(state.device)) {
+      debugState(
+        "helper pid %d bound to non-booted device %s — killing stale helper",
+        state.pid,
+        state.device,
+      );
       console.error(
         `[serve-sim] Helper pid ${state.pid} is bound to device ${state.device} which is no longer booted — killing stale helper.`,
       );
@@ -110,8 +120,10 @@ function readStateFile(file: string): ServerState | null {
       try { unlinkSync(file); } catch {}
       return null;
     }
+    debugState("state ok pid=%d device=%s port=%d", state.pid, state.device, state.port);
     return state;
-  } catch {
+  } catch (err) {
+    debugState("readStateFile threw for %s: %o", file, err);
     return null;
   }
 }
@@ -128,12 +140,15 @@ function readAllStates(): ServerState[] {
 function writeState(state: ServerState) {
   ensureStateDir();
   writeFileSync(stateFileForDevice(state.device), JSON.stringify(state, null, 2));
+  debugState("wrote state pid=%d device=%s port=%d", state.pid, state.device, state.port);
 }
 
 function clearState(udid?: string) {
   if (udid) {
+    debugState("clearState device=%s", udid);
     try { unlinkSync(stateFileForDevice(udid)); } catch {}
   } else {
+    debugState("clearState (all)");
     for (const file of listStateFiles()) {
       try { unlinkSync(file); } catch {}
     }
@@ -382,30 +397,61 @@ async function waitForHelperReady(
   isAlive: () => boolean,
 ): Promise<{ ready: boolean; log: string }> {
   let ready = false;
+  const startedAt = Date.now();
+  debugHelper("waitForHelperReady pid=%d url=%s", pid, url);
 
   // Poll /health
   for (let i = 0; i < 30; i++) {
-    if (!isAlive()) break;
+    if (!isAlive()) {
+      debugHelper("helper pid=%d died during /health polling (attempt %d)", pid, i);
+      break;
+    }
     try {
       const res = await fetch(`${url}/health`);
-      if (res.ok) { ready = true; break; }
+      if (res.ok) {
+        ready = true;
+        debugHelper("helper pid=%d /health ok after %dms", pid, Date.now() - startedAt);
+        break;
+      }
     } catch {}
     await new Promise((r) => setTimeout(r, 100));
   }
 
+  if (!ready) {
+    debugHelper("helper pid=%d /health never responded (%dms)", pid, Date.now() - startedAt);
+  }
+
   if (ready) {
     // Wait for capture to start or process to exit
-    const captureDeadline = Date.now() + 8_000;
+    const captureStartedAt = Date.now();
+    const captureDeadline = captureStartedAt + 8_000;
+    let captureSawStart = false;
     while (Date.now() < captureDeadline) {
       await new Promise((r) => setTimeout(r, 200));
       if (!isAlive()) {
+        debugHelper("helper pid=%d died while awaiting Capture started", pid);
         ready = false;
         break;
       }
       try {
         const log = readFileSync(logFile, "utf-8");
-        if (log.includes("Capture started")) break;
+        if (log.includes("Capture started")) {
+          captureSawStart = true;
+          debugHelper(
+            "helper pid=%d saw 'Capture started' after %dms",
+            pid,
+            Date.now() - captureStartedAt,
+          );
+          break;
+        }
       } catch {}
+    }
+    if (ready && !captureSawStart) {
+      debugHelper(
+        "helper pid=%d ready but never logged 'Capture started' within %dms — stream may not produce frames",
+        pid,
+        Date.now() - captureStartedAt,
+      );
     }
   }
 
@@ -486,21 +532,30 @@ async function startHelper(
   port: number,
   opts: { detach: boolean },
 ): Promise<{ pid: number; child?: ChildProcess }> {
+  debugHelper("startHelper udid=%s port=%d detach=%s", udid, port, opts.detach);
   await ensureBooted(udid);
 
   const host = "127.0.0.1";
   const helperPath = findHelperBinary();
   const logFile = join(STATE_DIR, `server-${udid}.log`);
+  debugHelper("helper binary=%s logFile=%s", helperPath, logFile);
   const spawnOpts: SpawnHelperOptions = { helperPath, udid, port, host, logFile };
 
   let lastLog = "";
   const MAX_ATTEMPTS = 2;
 
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    debugHelper("spawn attempt %d/%d", attempt, MAX_ATTEMPTS);
     killPortHolder(port);
 
     if (opts.detach) {
       const result = await spawnHelperDetached(spawnOpts);
+      debugHelper(
+        "spawnHelperDetached result ready=%s pid=%d exited=%s",
+        result.ready,
+        result.pid,
+        result.exited,
+      );
       if (result.ready) {
         const state: ServerState = {
           pid: result.pid,
@@ -517,6 +572,11 @@ async function startHelper(
       lastLog = result.log;
     } else {
       const result = await spawnHelperAttached(spawnOpts);
+      debugHelper(
+        "spawnHelperAttached result ready=%s pid=%d",
+        result.ready,
+        result.child.pid,
+      );
       if (result.ready) {
         const state: ServerState = {
           pid: result.child.pid!,
@@ -547,6 +607,7 @@ async function startHelper(
 
 /** Foreground follow mode (default). Stays attached, cleans up on Ctrl+C. */
 async function follow(devices: string[], startPort: number, quiet: boolean) {
+  debugCli("follow devices=%o startPort=%d", devices, startPort);
   const udids = devices.length > 0
     ? devices.map(resolveDevice)
     : (() => {
@@ -646,6 +707,7 @@ async function follow(devices: string[], startPort: number, quiet: boolean) {
   // Monitor children — exit when all die (helper crashed / exited on its own)
   for (const [udid, child] of children) {
     child.on("exit", (code) => {
+      debugHelper("child exit udid=%s pid=%d code=%s", udid, child.pid, code);
       if (shuttingDown) return;
       if (!quiet) console.error(`[${udid}] Helper exited (code ${code})`);
       clearState(udid);
@@ -673,6 +735,7 @@ async function follow(devices: string[], startPort: number, quiet: boolean) {
 
 /** Detach mode (--detach). Spawns helpers and returns their states. */
 async function detach(devices: string[], startPort: number): Promise<ServerState[]> {
+  debugCli("detach devices=%o startPort=%d", devices, startPort);
   const udids = devices.length > 0
     ? devices.map(resolveDevice)
     : (() => {

--- a/packages/serve-sim/src/index.ts
+++ b/packages/serve-sim/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { Command } from "commander";
 import { execSync, spawn as nodeSpawn, type ChildProcess } from "child_process";
 import { chmodSync, existsSync, mkdirSync, openSync, closeSync, readSync, readFileSync, unlinkSync, writeFileSync } from "fs";
 import { createHash } from "crypto";
@@ -795,26 +796,10 @@ function killStreams(deviceArg?: string) {
   }
 }
 
-async function gesture(args: string[]) {
-  let deviceArg: string | undefined;
-  const filteredArgs: string[] = [];
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--device" || args[i] === "-d") {
-      deviceArg = args[++i];
-    } else {
-      filteredArgs.push(args[i]!);
-    }
-  }
+async function gesture(jsonStr: string, deviceArg?: string) {
   const state = readState(deviceArg);
   if (!state) {
     console.error("No serve-sim server running. Run `serve-sim` first.");
-    process.exit(1);
-  }
-
-  const jsonStr = filteredArgs[0];
-  if (!jsonStr) {
-    console.error("Usage: serve-sim gesture '<json>'");
-    console.error('Example: serve-sim gesture \'{"type":"begin","x":0.5,"y":0.5}\'');
     process.exit(1);
   }
 
@@ -846,18 +831,9 @@ async function gesture(args: string[]) {
   });
 }
 
-async function tap(args: string[]) {
-  let deviceArg: string | undefined;
-  const positional: string[] = [];
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--device" || args[i] === "-d") {
-      deviceArg = args[++i];
-    } else {
-      positional.push(args[i]!);
-    }
-  }
-  const x = positional[0] !== undefined ? Number(positional[0]) : NaN;
-  const y = positional[1] !== undefined ? Number(positional[1]) : NaN;
+async function tap(xArg: string, yArg: string, deviceArg?: string) {
+  const x = Number(xArg);
+  const y = Number(yArg);
   if (!Number.isFinite(x) || !Number.isFinite(y) || x < 0 || x > 1 || y < 0 || y > 1) {
     console.error("Usage: serve-sim tap <x> <y> [-d udid]");
     console.error("  x, y are normalized 0..1 of the simulator screen");
@@ -893,23 +869,13 @@ async function tap(args: string[]) {
   });
 }
 
-async function typeText(args: string[]) {
-  let deviceArg: string | undefined;
-  let useStdin = false;
-  let inputFile: string | undefined;
-  const positional: string[] = [];
-  for (let i = 0; i < args.length; i++) {
-    const a = args[i]!;
-    if (a === "--device" || a === "-d") {
-      deviceArg = args[++i];
-    } else if (a === "--stdin") {
-      useStdin = true;
-    } else if (a === "--file") {
-      inputFile = args[++i];
-    } else {
-      positional.push(a);
-    }
-  }
+async function typeText(
+  positional: string[],
+  opts: { device?: string; stdin?: boolean; file?: string },
+) {
+  const deviceArg = opts.device;
+  const useStdin = opts.stdin ?? false;
+  const inputFile = opts.file;
 
   const sourceCount = [positional.length > 0, useStdin, inputFile != null].filter(Boolean).length;
   if (sourceCount === 0 || sourceCount > 1) {
@@ -957,23 +923,13 @@ async function typeText(args: string[]) {
   await sendKeyEventsToWs(state.wsUrl, events);
 }
 
-async function rotate(args: string[]) {
-  let deviceArg: string | undefined;
-  const filteredArgs: string[] = [];
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--device" || args[i] === "-d") {
-      deviceArg = args[++i];
-    } else {
-      filteredArgs.push(args[i]!);
-    }
-  }
+async function rotate(orientation: string, deviceArg?: string) {
   const state = readState(deviceArg);
   if (!state) {
     console.error("No serve-sim server running. Run `serve-sim` first.");
     process.exit(1);
   }
 
-  const orientation = filteredArgs[0];
   const valid = new Set([
     "portrait",
     "portrait_upside_down",
@@ -1007,23 +963,12 @@ async function rotate(args: string[]) {
   });
 }
 
-async function button(args: string[]) {
-  let deviceArg: string | undefined;
-  const filteredArgs: string[] = [];
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--device" || args[i] === "-d") {
-      deviceArg = args[++i];
-    } else {
-      filteredArgs.push(args[i]!);
-    }
-  }
+async function button(buttonName = "home", deviceArg?: string) {
   const state = readState(deviceArg);
   if (!state) {
     console.error("No serve-sim server running. Run `serve-sim` first.");
     process.exit(1);
   }
-
-  const buttonName = filteredArgs[0] ?? "home";
 
   return new Promise<void>((resolve, reject) => {
     const ws = new WebSocket(state.wsUrl);
@@ -1048,18 +993,8 @@ async function button(args: string[]) {
 // Send a CoreAnimation debug option toggle to the helper, which invokes
 // -[SimDevice setCADebugOption:enabled:] (CoreSimulator private category).
 // The known option strings are the ones Simulator.app uses: see Protocol.swift.
-async function caDebug(args: string[]) {
-  let deviceArg: string | undefined;
-  const filtered: string[] = [];
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--device" || args[i] === "-d") {
-      deviceArg = args[++i];
-    } else {
-      filtered.push(args[i]!);
-    }
-  }
-  const option = filtered[0];
-  const stateArg = (filtered[1] ?? "").toLowerCase();
+async function caDebug(option: string, stateRaw: string, deviceArg?: string) {
+  const stateArg = (stateRaw ?? "").toLowerCase();
   const enabled = stateArg === "on" || stateArg === "1" || stateArg === "true";
   const aliases: Record<string, string> = {
     blended: "debug_color_blended",
@@ -1103,11 +1038,7 @@ async function caDebug(args: string[]) {
 }
 
 // Ask the helper to invoke -[SimDevice simulateMemoryWarning].
-async function memoryWarning(args: string[]) {
-  let deviceArg: string | undefined;
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--device" || args[i] === "-d") deviceArg = args[++i];
-  }
+async function memoryWarning(deviceArg?: string) {
   const stateFile = readState(deviceArg);
   if (!stateFile) {
     console.error("No serve-sim server running. Run `serve-sim` first.");
@@ -1870,182 +1801,141 @@ function bindPreviewServer(port: number, middleware: ReturnType<typeof import(".
   return servePreview({ port, middleware, host });
 }
 
-function printHelp() {
-  console.log(`
-serve-sim - Stream iOS Simulator to the browser
-
-Usage:
-  serve-sim [device...]                 Start preview server (default: localhost:3200)
-  serve-sim --no-preview [device...]    Stream in foreground without a preview server
-  serve-sim gesture '<json>' [-d udid]  Send a touch gesture
-  serve-sim tap <x> <y> [-d udid]       Tap at normalized 0..1 coords
-  serve-sim button [name] [-d udid]     Send a button press (default: home)
-  serve-sim type <text> [-d udid]       Type text (US keyboard only)
-                                        Use --stdin or --file <path> for input from stdin/file
-  serve-sim rotate <orientation> [-d udid]
-                                        Set device orientation
-                                        (portrait|portrait_upside_down|landscape_left|landscape_right)
-  serve-sim ca-debug <option> <on|off> [-d udid]
-                                        Toggle a CoreAnimation debug render flag
-                                        (blended|copies|misaligned|offscreen|slow-animations)
-  serve-sim memory-warning [-d udid]    Simulate a memory warning on the device
-  serve-sim camera <bundle-id> [-d udid] [--image <path>] [--build]
-                                        Inject a synthetic camera feed and
-                                        launch the app (no build-time changes)
-  serve-sim permissions <grant|revoke|reset|list> <permission> <bundle-id>
-                                        Manage app permissions (camera, photos,
-                                        location, notifications, contacts, …).
-                                        grant location <id> --value always
-                                        reset all <id> clears every permission.
-                                        Manages the permission only, not push
-                                        delivery (use xcrun simctl push).
-
-Options:
-  -p, --port <port>   Starting port (preview default: 3200, stream default: 3100)
-      --host <addr>   Interface to bind the preview server to (default: 127.0.0.1).
-                      Use 0.0.0.0 to expose on the LAN — only do this on trusted
-                      networks: the preview exposes a token-gated shell-exec route.
-  -d, --detach        Spawn helper and exit (daemon mode)
-  -q, --quiet         Suppress human-readable output, JSON only
-      --no-preview    Skip the web preview server; stream in foreground only
-      --list [device] List running streams
-      --kill [device] Kill running stream(s)
-  -h, --help          Show this help
-
-Examples:
-  serve-sim                             Open simulator preview at localhost:3200
-  serve-sim -p 8080                     Preview on a custom port
-  serve-sim --no-preview                Auto-detect booted sim, stream in foreground
-  serve-sim --no-preview "iPhone 16 Pro" Stream a specific device (no preview)
-  serve-sim --detach                    Start streaming in background (daemon)
-  serve-sim --list                      Show all running streams
-  serve-sim --kill                      Stop all streams
-`);
-}
-
 // ─── Main ───
 
-const argv = process.argv.slice(2);
+const program = new Command();
 
-// Subcommands: gesture and button
-if (argv[0] === "gesture") {
-  await gesture(argv.slice(1));
-  process.exit(0);
-}
-if (argv[0] === "tap") {
-  await tap(argv.slice(1));
-  process.exit(0);
-}
-if (argv[0] === "button") {
-  await button(argv.slice(1));
-  process.exit(0);
-}
-if (argv[0] === "type") {
-  await typeText(argv.slice(1));
-  process.exit(0);
-}
-if (argv[0] === "rotate") {
-  await rotate(argv.slice(1));
-  process.exit(0);
-}
-if (argv[0] === "ca-debug") {
-  await caDebug(argv.slice(1));
-  process.exit(0);
-}
-if (argv[0] === "memory-warning") {
-  await memoryWarning(argv.slice(1));
-  process.exit(0);
-}
-if (argv[0] === "camera") {
-  await camera(argv.slice(1));
-  process.exit(0);
-}
-if (argv[0] === "permissions") {
-  await permissions(argv.slice(1));
-  process.exit(0);
-}
-// Parse flags and positional args
-let startPort: number | undefined;
-let detachMode = false;
-let quiet = false;
-let list = false;
-let kill = false;
-let help = false;
-let noPreview = false;
-// Bind to loopback by default. The preview exposes /exec; LAN binding requires
-// explicit opt-in via --host so a dev who has the package installed isn't
-// silently exposing arbitrary shell-exec to anyone on the same Wi-Fi.
-let host = "127.0.0.1";
-const positionalDevices: string[] = [];
-let listDevice: string | undefined;
-let killDevice: string | undefined;
+program
+  .name("serve-sim")
+  .description("Stream iOS Simulator to the browser")
+  .helpOption("-h, --help", "Show this help")
+  // The default command: start the preview server (or stream / list / kill).
+  .argument("[devices...]", "Simulator(s) to target (udid or name; default: booted)")
+  .option("-p, --port <port>", "Starting port (preview default: 3200, stream default: 3100)", (v) => parseInt(v, 10))
+  .option(
+    "--host <addr>",
+    "Interface to bind the preview server to. Use 0.0.0.0 to expose on the " +
+      "LAN — only on trusted networks: the preview exposes a token-gated " +
+      "shell-exec route.",
+    "127.0.0.1",
+  )
+  .option("--detach", "Spawn helper and exit (daemon mode)")
+  .option("-q, --quiet", "Suppress human-readable output, JSON only")
+  .option("--no-preview", "Skip the web preview server; stream in foreground only")
+  .option("-l, --list [device]", "List running streams")
+  .option("-k, --kill [device]", "Kill running stream(s)")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  serve-sim                              Open simulator preview at localhost:3200
+  serve-sim -p 8080                      Preview on a custom port
+  serve-sim --no-preview                 Auto-detect booted sim, stream in foreground
+  serve-sim --no-preview "iPhone 16 Pro" Stream a specific device (no preview)
+  serve-sim --detach                     Start streaming in background (daemon)
+  serve-sim --list                       Show all running streams
+  serve-sim --kill                       Stop all streams`,
+  )
+  .action(async (devices: string[], opts) => {
+    if (opts.list !== undefined) {
+      listStreams(typeof opts.list === "string" ? opts.list : undefined);
+      return;
+    }
+    if (opts.kill !== undefined) {
+      killStreams(typeof opts.kill === "string" ? opts.kill : undefined);
+      return;
+    }
+    const startPort: number | undefined = opts.port;
+    if (opts.detach) {
+      const states = await detach(devices, startPort ?? 3100);
+      printStatesJSON(states);
+    } else if (opts.preview === false) {
+      await follow(devices, startPort ?? 3100, !!opts.quiet);
+    } else {
+      await serve(startPort ?? 3200, devices, startPort !== undefined, opts.host);
+    }
+  });
 
-for (let i = 0; i < argv.length; i++) {
-  const arg = argv[i]!;
-  switch (arg) {
-    case "--port": case "-p":
-      startPort = parseInt(argv[++i] ?? "3100", 10);
-      break;
-    case "--host":
-      host = argv[++i] ?? "127.0.0.1";
-      break;
-    case "--detach": case "-d":
-      detachMode = true;
-      break;
-    case "--quiet": case "-q":
-      quiet = true;
-      break;
-    case "--no-preview":
-      noPreview = true;
-      break;
-    case "--list": case "-l":
-      list = true;
-      // Optional device arg after --list
-      if (argv[i + 1] && !argv[i + 1]!.startsWith("-")) {
-        listDevice = argv[++i];
-      }
-      break;
-    case "--kill": case "-k":
-      kill = true;
-      // Optional device arg after --kill
-      if (argv[i + 1] && !argv[i + 1]!.startsWith("-")) {
-        killDevice = argv[++i];
-      }
-      break;
-    case "--help": case "-h": case "help":
-      help = true;
-      break;
-    default:
-      if (!arg.startsWith("-")) {
-        positionalDevices.push(arg);
-      } else {
-        console.error(`Unknown flag: ${arg}`);
-        printHelp();
-        process.exit(1);
-      }
-  }
-}
+const deviceOpt = ["-d, --device <udid>", "Target a specific simulator (udid or name)"] as const;
 
-if (help) {
-  printHelp();
-  process.exit(0);
-}
+program
+  .command("gesture")
+  .description("Send a touch gesture")
+  .argument("<json>", 'Gesture JSON, e.g. \'{"type":"begin","x":0.5,"y":0.5}\'')
+  .option(...deviceOpt)
+  .action((json: string, opts) => gesture(json, opts.device));
 
-if (list) {
-  listStreams(listDevice);
-  process.exit(0);
-}
+program
+  .command("tap")
+  .description("Tap at normalized 0..1 coords")
+  .argument("<x>", "X coord, normalized 0..1")
+  .argument("<y>", "Y coord, normalized 0..1")
+  .option(...deviceOpt)
+  .action((x: string, y: string, opts) => tap(x, y, opts.device));
 
-if (kill) {
-  killStreams(killDevice);
-  process.exit(0);
-}
+program
+  .command("button")
+  .description("Send a hardware button press")
+  .argument("[name]", "Button name", "home")
+  .option(...deviceOpt)
+  .action((name: string, opts) => button(name, opts.device));
 
-if (detachMode) {
-  const states = await detach(positionalDevices, startPort ?? 3100);
-  printStatesJSON(states);
-} else if (noPreview) {
-  await follow(positionalDevices, startPort ?? 3100, quiet);
-} else {
-  await serve(startPort ?? 3200, positionalDevices, startPort !== undefined, host);
-}
+program
+  .command("type")
+  .description("Type text (US keyboard only)")
+  .argument("[text...]", "Text to type")
+  .option(...deviceOpt)
+  .option("--stdin", "Read text from stdin")
+  .option("--file <path>", "Read text from a file")
+  .action((text: string[], opts) =>
+    typeText(text, { device: opts.device, stdin: opts.stdin, file: opts.file }),
+  );
+
+program
+  .command("rotate")
+  .description(
+    "Set device orientation " +
+      "(portrait|portrait_upside_down|landscape_left|landscape_right)",
+  )
+  .argument("<orientation>")
+  .option(...deviceOpt)
+  .action((orientation: string, opts) => rotate(orientation, opts.device));
+
+program
+  .command("ca-debug")
+  .description(
+    "Toggle a CoreAnimation debug render flag " +
+      "(blended|copies|misaligned|offscreen|slow-animations)",
+  )
+  .argument("<option>")
+  .argument("<state>", "on|off")
+  .option(...deviceOpt)
+  .action((option: string, state: string, opts) => caDebug(option, state, opts.device));
+
+program
+  .command("memory-warning")
+  .description("Simulate a memory warning on the device")
+  .option(...deviceOpt)
+  .action((opts) => memoryWarning(opts.device));
+
+// `camera` and `permissions` keep their own dedicated argument parsers (the
+// camera verb has nested sub-verbs and source flags; permissions has a
+// unit-tested parser module). Register them as passthrough commands so they
+// still appear in `--help` and route to those parsers verbatim.
+program
+  .command("camera")
+  .description("Inject a synthetic camera feed and launch an app (see `camera --help`)")
+  .allowUnknownOption(true)
+  .helpOption(false)
+  .argument("[args...]")
+  .action((args: string[]) => camera(args));
+
+program
+  .command("permissions")
+  .description("Manage app permissions (see `permissions` with no args for usage)")
+  .allowUnknownOption(true)
+  .helpOption(false)
+  .argument("[args...]")
+  .action((args: string[]) => permissions(args));
+
+await program.parseAsync(process.argv);

--- a/packages/serve-sim/src/middleware.ts
+++ b/packages/serve-sim/src/middleware.ts
@@ -6,6 +6,7 @@ import { createServer as createNetServer } from "net";
 import { randomBytes, timingSafeEqual } from "crypto";
 import type { IncomingMessage, ServerResponse } from "http";
 import { createAxStreamerCache } from "./ax";
+import { debugMw } from "./debug";
 
 type SimReq = IncomingMessage;
 type SimRes = ServerResponse;
@@ -211,6 +212,7 @@ function readServeSimStates(): ServeSimState[] {
       try {
         process.kill(state.pid, 0);
       } catch {
+        debugMw("helper pid=%d gone, removing %s", state.pid, path);
         try { unlinkSync(path); } catch {}
         continue;
       }
@@ -219,6 +221,11 @@ function readServeSimStates(): ServeSimState[] {
       // preview stuck on "Connecting...". Recycle the stale state so the
       // caller can spawn a fresh helper bound to whatever is booted.
       if (booted && !booted.has(state.device)) {
+        debugMw(
+          "recycling stale helper pid=%d (device %s no longer booted)",
+          state.pid,
+          state.device,
+        );
         try { process.kill(state.pid, "SIGTERM"); } catch {}
         try { unlinkSync(path); } catch {}
         continue;
@@ -986,6 +993,12 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
     if (url === base + "/api") {
       const states = readServeSimStates();
       const state = selectServeSimState(states, selectedDevice);
+      debugMw(
+        "GET /api selectedDevice=%s states=%d chose=%s",
+        selectedDevice ?? "(any)",
+        states.length,
+        state ? `${state.device}@${state.port}` : "none",
+      );
       res.writeHead(200, {
         "Content-Type": "application/json",
         "Cache-Control": "no-store",


### PR DESCRIPTION
# Why

The serve-sim CLI parsed arguments with a hand-rolled `switch` loop plus per-subcommand `for` loops that each re-implemented `-d/--device` handling. It was repetitive, easy to drift, and had no structured help output.

# How

- Replaced the top-level dispatch and `printHelp()` with a `commander` program.
- Refactored the seven simple subcommands (`gesture`, `tap`, `button`, `type`, `rotate`, `ca-debug`, `memory-warning`) to take structured arguments instead of parsing `string[]` themselves.
- `camera` and `permissions` keep their own dedicated parsers (camera has nested sub-verbs and source flags; permissions has a unit-tested parser module). They are registered as passthrough commands so they still show up in `--help` and route to those parsers verbatim.
- `commander` is added as a devDependency only. `build.ts` bundles it into `dist/serve-sim.js`, so the published package gains no new runtime dependency.
- Dropped the `-d` short alias for the root `--detach` flag. It collided with the `-d/--device` short option used by every subcommand (commander treats program-level options as recognizable inside subcommands). The `--detach` long form is unchanged, and nothing in tests or docs used `-d` for detach.

# Test Plan

- `bun run typecheck` and `bun run lint` are clean.
- 46 unit tests pass, including the `parsePermissionsArgs` suite.
- `type-command-sim` e2e test passes against a real booted simulator, exercising `--detach`, `--kill`, and `type <text> -d <udid>`.
- Full `build.ts` run produces a working `dist/serve-sim.js` and compiled binary; smoke-tested `--help`, `camera`, `permissions`, and `gesture` under plain `node`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved diagnostic logging across CLI, helper lifecycle, and middleware via the DEBUG=serve-sim* convention

* **Bug Fixes**
  * More robust helper readiness detection with extended polling and capture verification
  * Better error logging for missing state files and stale helper situations

* **Tests / CI**
  * Increased test timeouts and polling budgets to reduce flaky failures on slow CI simulators

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EvanBacon/serve-sim/pull/59)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->