### PR TITLE
Add Device Logs panel

### DIFF
--- a/packages/serve-sim/src/__tests__/device-logs.test.ts
+++ b/packages/serve-sim/src/__tests__/device-logs.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+import { queryLogLevel } from "../middleware";
+import {
+  appendLogEntryBuffer,
+  filterDeviceLogs,
+  matchesCurrentApp,
+  normalizeLogLevel,
+  parseDeviceLogEntry,
+  type DeviceLogEntry,
+} from "../client/utils/logs";
+
+describe("device log parsing", () => {
+  test("normalizes known log levels", () => {
+    expect(normalizeLogLevel("Error")).toBe("error");
+    expect(normalizeLogLevel("fault")).toBe("fault");
+    expect(normalizeLogLevel("notice")).toBe("unknown");
+  });
+
+  test("parses os_log ndjson rows into table entries", () => {
+    const entry = parseDeviceLogEntry({
+      timestamp: "2026-05-16 12:10:11.000000-0300",
+      messageType: "Info",
+      processImagePath: "/Containers/Bundle/Application/App/Goodword",
+      processID: 1234,
+      subsystem: "com.goodword.app",
+      category: "network",
+      eventMessage: "Loaded profile",
+    }, 7);
+    expect(entry).toMatchObject({
+      id: 7,
+      level: "info",
+      process: "Goodword",
+      processKey: "goodword",
+      processID: 1234,
+      subsystem: "com.goodword.app",
+      category: "network",
+      message: "Loaded profile",
+    });
+  });
+
+  test("drops rows without a message", () => {
+    expect(parseDeviceLogEntry({ messageType: "Info" }, 1)).toBeNull();
+  });
+});
+
+describe("device log filtering", () => {
+  const entries: DeviceLogEntry[] = [
+    makeEntry(1, "info", "Goodword", "profile loaded", 101, "com.goodword.app", "api"),
+    makeEntry(2, "error", "SpringBoard", "launch failed", 202, "com.apple.springboard", "lifecycle"),
+    makeEntry(3, "debug", "Goodword", "cache hit", 101, "com.goodword.app", "storage"),
+  ];
+
+  test("filters by level, search, and current app", () => {
+    const visible = filterDeviceLogs(entries, {
+      search: "PROFILE",
+      levels: new Set(["info", "error", "fault", "default", "debug"]),
+      process: "",
+      currentAppOnly: true,
+      currentApp: { bundleId: "com.goodword.app", pid: 101, executable: "Goodword" },
+    });
+    expect(visible.map((entry) => entry.id)).toEqual([1]);
+  });
+
+  test("matches current app by pid, executable, or bundle text", () => {
+    expect(matchesCurrentApp(entries[0]!, { bundleId: "x", pid: 101 })).toBe(true);
+    expect(matchesCurrentApp(entries[0]!, { bundleId: "x", executable: "Goodword" })).toBe(true);
+    expect(matchesCurrentApp(makeEntry(4, "info", "Other", "com.goodword.app did work"), { bundleId: "com.goodword.app" })).toBe(true);
+  });
+
+  test("keeps the log buffer bounded", () => {
+    const next = appendLogEntryBuffer(entries, makeEntry(4, "fault", "Goodword", "boom"), 3);
+    expect(next.map((entry) => entry.id)).toEqual([2, 3, 4]);
+  });
+});
+
+describe("queryLogLevel", () => {
+  test("allows only supported simctl stream levels", () => {
+    expect(queryLogLevel("/logs?level=debug")).toBe("debug");
+    expect(queryLogLevel("/logs?level=default")).toBe("default");
+    expect(queryLogLevel("/logs?level=fault")).toBe("info");
+    expect(queryLogLevel("/logs")).toBe("info");
+  });
+});
+
+function makeEntry(
+  id: number,
+  level: DeviceLogEntry["level"],
+  process: string,
+  message: string,
+  processID?: number,
+  subsystem = "",
+  category = "",
+): DeviceLogEntry {
+  return {
+    id,
+    timestamp: "",
+    level,
+    process,
+    processKey: process.toLowerCase(),
+    processID,
+    subsystem,
+    category,
+    message,
+    searchText: [message, process, subsystem, category, level].join("\n").toLowerCase(),
+    raw: { eventMessage: message },
+  };
+}

--- a/packages/serve-sim/src/__tests__/idle-floor.test.ts
+++ b/packages/serve-sim/src/__tests__/idle-floor.test.ts
@@ -190,7 +190,7 @@ describeWithSim(`serve-sim idle frame floor (booted sim ${bootedUdid ?? "<skippe
     }
 
     clearTimeout(timer);
-    try { reader.cancel(); } catch {}
+    try { await reader.cancel(); } catch {}
 
     expect(firstFrameAt).not.toBeNull();
     expect(firstFrameAt).toBeLessThanOrEqual(FIRST_FRAME_BUDGET_MS);
@@ -229,7 +229,7 @@ describeWithSim(`serve-sim idle frame floor (booted sim ${bootedUdid ?? "<skippe
     }
 
     clearTimeout(timer);
-    try { reader.cancel(); } catch {}
+    try { await reader.cancel(); } catch {}
 
     expect(frameCount).toBeGreaterThanOrEqual(MIN_FRAMES_IN_IDLE_WINDOW);
     // Every frame should have a reasonable size — serve-sim emits a real

--- a/packages/serve-sim/src/client/client.tsx
+++ b/packages/serve-sim/src/client/client.tsx
@@ -26,6 +26,7 @@ import { AxStateProvider } from "./components/ax-state-provider";
 import { AxToolbarButton } from "./components/ax-toolbar-button";
 import { BootEmptyState } from "./components/boot-empty-state";
 import { DevicePicker } from "./components/device-picker";
+import { DeviceLogsPanel } from "./components/device-logs-panel";
 import { GridPanel } from "./components/grid-panel";
 import { ResizeHandle } from "./components/resize-handle";
 import { SimulatorResizeCornerHandle } from "./components/simulator-resize-corner-handle";
@@ -43,6 +44,7 @@ import { fileExtension } from "./utils/drop";
 import { execOnHost } from "./utils/exec";
 import { hidUsageForCode } from "./utils/hid";
 import {
+  DEVICE_LOGS_PANEL_WIDTH,
   DEVTOOLS_PANEL_WIDTH,
   GRID_PANEL_WIDTH,
   PANEL_WIDTH,
@@ -134,76 +136,6 @@ function App() {
       clearInterval(interval);
     };
   }, []);
-
-  // Stream simctl logs into the browser console with colors + grouping
-  useEffect(() => {
-    if (!config?.logsEndpoint) return;
-    const es = new EventSource(config.logsEndpoint);
-
-    const procColors = new Map<string, string>();
-    const palette = [
-      "#8be9fd", "#50fa7b", "#ffb86c", "#ff79c6", "#bd93f9",
-      "#f1fa8c", "#6272a4", "#ff5555", "#69ff94", "#d6acff",
-      "#ffffa5", "#a4ffff", "#ff6e6e", "#caa9fa", "#5af78e",
-    ];
-    function colorFor(name: string): string {
-      let c = procColors.get(name);
-      if (!c) {
-        let h = 0;
-        for (let i = 0; i < name.length; i++) h = ((h << 5) - h + name.charCodeAt(i)) | 0;
-        c = palette[Math.abs(h) % palette.length]!;
-        procColors.set(name, c);
-      }
-      return c;
-    }
-
-    let lastProc = "";
-    let groupOpen = false;
-
-    es.onmessage = (event) => {
-      try {
-        const entry = JSON.parse(event.data);
-        const proc = entry.processImagePath?.split("/").pop() ?? entry.senderImagePath?.split("/").pop() ?? "";
-        const subsystem = entry.subsystem ?? "";
-        const category = entry.category ?? "";
-        const msg = entry.eventMessage ?? "";
-        if (!msg) return;
-
-        if (proc !== lastProc) {
-          if (groupOpen) console.groupEnd();
-          const color = colorFor(proc);
-          console.groupCollapsed(
-            `%c${proc}${subsystem ? ` %c${subsystem}${category ? ":" + category : ""}` : ""}`,
-            `color:${color};font-weight:bold`,
-            ...(subsystem ? ["color:#888;font-weight:normal"] : []),
-          );
-          groupOpen = true;
-          lastProc = proc;
-        }
-
-        const level = (entry.messageType ?? "").toLowerCase();
-        const tag = subsystem && proc === lastProc
-          ? `%c${category || subsystem}%c `
-          : "";
-        const tagStyles = tag
-          ? ["color:#888;font-style:italic", "color:inherit"]
-          : [];
-
-        if (level === "fault" || level === "error") {
-          console.log(`${tag}%c${msg}`, ...tagStyles, "color:#ff5555");
-        } else if (level === "debug") {
-          console.log(`${tag}%c${msg}`, ...tagStyles, "color:#6272a4");
-        } else {
-          console.log(`${tag}%c${msg}`, ...tagStyles, "color:inherit");
-        }
-      } catch {}
-    };
-
-    return () => {
-      if (groupOpen) console.groupEnd();
-      es.close();
-    };
-  }, [config?.logsEndpoint]);
 
   if (!config) {
     return (
@@ -417,11 +349,18 @@ function AppWithConfig({
   // Subscribe to app-state SSE.
   const [currentApp, setCurrentApp] = useState<{ bundleId: string; isReactNative: boolean; pid?: number } | null>(null);
   const [panelOpen, setPanelOpen] = useState(false);
+  const [logsOpen, setLogsOpen] = useState(false);
   const { width: toolsPanelWidth, onPointerDown: onToolsResize } = useResizableWidth(
     "serve-sim:tools-panel-width",
     PANEL_WIDTH,
     240,
     720,
+  );
+  const { width: logsPanelWidth, onPointerDown: onLogsResize } = useResizableWidth(
+    "serve-sim:device-logs-panel-width",
+    DEVICE_LOGS_PANEL_WIDTH,
+    420,
+    1400,
   );
   const { width: devtoolsPanelWidth, onPointerDown: onDevtoolsResize } = useResizableWidth(
     "serve-sim:devtools-panel-width",
@@ -616,6 +555,8 @@ function AppWithConfig({
     ? devtoolsPanelWidth
     : gridOpen
     ? gridPanelWidth
+    : logsOpen
+    ? logsPanelWidth
     : panelOpen
     ? toolsPanelWidth
     : 0;
@@ -824,10 +765,11 @@ function AppWithConfig({
 
       {/* Right-edge sidebar rail. */}
       <div
-        className={`fixed top-3 right-3 flex flex-col gap-1 p-1 bg-panel-bg border border-white/8 rounded-[10px] backdrop-blur-[12px] [-webkit-backdrop-filter:blur(12px)] [transition:opacity_0.18s_ease] z-40 ${(panelOpen || devtoolsOpen || gridOpen) ? "opacity-0 pointer-events-none" : "opacity-100 pointer-events-auto"}`}
+        className={`fixed top-3 right-3 flex flex-col gap-1 p-1 bg-panel-bg border border-white/8 rounded-[10px] backdrop-blur-[12px] [-webkit-backdrop-filter:blur(12px)] [transition:opacity_0.18s_ease] z-40 ${(panelOpen || logsOpen || devtoolsOpen || gridOpen) ? "opacity-0 pointer-events-none" : "opacity-100 pointer-events-auto"}`}
       >
         <button
           onClick={() => {
+            setLogsOpen(false);
             setDevtoolsOpen(false);
             setGridOpen(false);
             setPanelOpen((o) => !o);
@@ -845,6 +787,24 @@ function AppWithConfig({
         <button
           onClick={() => {
             setPanelOpen(false);
+            setDevtoolsOpen(false);
+            setGridOpen(false);
+            setLogsOpen((o) => !o);
+          }}
+          className="w-[30px] h-[30px] flex items-center justify-center bg-transparent border-none rounded-md text-[#8e8e93] cursor-pointer [transition:background_0.15s_ease,color_0.15s_ease] hover:bg-white/8 hover:text-white"
+          aria-label="Open Device Logs"
+          aria-pressed={logsOpen}
+          title="Device Logs"
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+            <rect x="4" y="4" width="16" height="16" rx="2.5" />
+            <path d="M8 9h.01M11 9h5m-8 3h.01M11 12h5m-8 3h.01M11 15h5" />
+          </svg>
+        </button>
+        <button
+          onClick={() => {
+            setPanelOpen(false);
+            setLogsOpen(false);
             setGridOpen(false);
             setDevtoolsOpen((o) => !o);
           }}
@@ -862,6 +822,7 @@ function AppWithConfig({
         <button
           onClick={() => {
             setPanelOpen(false);
+            setLogsOpen(false);
             setDevtoolsOpen(false);
             setGridOpen((o) => !o);
           }}
@@ -893,6 +854,21 @@ function AppWithConfig({
         visible={panelOpen}
         onPointerDown={onToolsResize}
         ariaLabel="Resize tools panel"
+      />
+
+      <DeviceLogsPanel
+        open={logsOpen}
+        onClose={() => setLogsOpen(false)}
+        udid={config.device}
+        currentApp={currentApp}
+        logsEndpoint={config.logsEndpoint}
+        width={logsPanelWidth}
+      />
+      <ResizeHandle
+        panelWidth={logsPanelWidth}
+        visible={logsOpen}
+        onPointerDown={onLogsResize}
+        ariaLabel="Resize Device Logs panel"
       />
 
       <GridPanel

--- a/packages/serve-sim/src/client/client.tsx
+++ b/packages/serve-sim/src/client/client.tsx
@@ -137,6 +137,75 @@ function App() {
     };
   }, []);
 
+  useEffect(() => {
+    if (!config?.logsEndpoint) return;
+    const es = new EventSource(config.logsEndpoint);
+
+    const procColors = new Map<string, string>();
+    const palette = [
+      "#8be9fd", "#50fa7b", "#ffb86c", "#ff79c6", "#bd93f9",
+      "#f1fa8c", "#6272a4", "#ff5555", "#69ff94", "#d6acff",
+      "#ffffa5", "#a4ffff", "#ff6e6e", "#caa9fa", "#5af78e",
+    ];
+    function colorFor(name: string): string {
+      let c = procColors.get(name);
+      if (!c) {
+        let h = 0;
+        for (let i = 0; i < name.length; i++) h = ((h << 5) - h + name.charCodeAt(i)) | 0;
+        c = palette[Math.abs(h) % palette.length]!;
+        procColors.set(name, c);
+      }
+      return c;
+    }
+
+    let lastProc = "";
+    let groupOpen = false;
+
+    es.onmessage = (event) => {
+      try {
+        const entry = JSON.parse(event.data);
+        const proc = entry.processImagePath?.split("/").pop() ?? entry.senderImagePath?.split("/").pop() ?? "";
+        const subsystem = entry.subsystem ?? "";
+        const category = entry.category ?? "";
+        const msg = entry.eventMessage ?? "";
+        if (!msg) return;
+
+        if (proc !== lastProc) {
+          if (groupOpen) console.groupEnd();
+          const color = colorFor(proc);
+          console.groupCollapsed(
+            `%c${proc}${subsystem ? ` %c${subsystem}${category ? ":" + category : ""}` : ""}`,
+            `color:${color};font-weight:bold`,
+            ...(subsystem ? ["color:#888;font-weight:normal"] : []),
+          );
+          groupOpen = true;
+          lastProc = proc;
+        }
+
+        const level = (entry.messageType ?? "").toLowerCase();
+        const tag = subsystem && proc === lastProc
+          ? `%c${category || subsystem}%c `
+          : "";
+        const tagStyles = tag
+          ? ["color:#888;font-style:italic", "color:inherit"]
+          : [];
+
+        if (level === "fault" || level === "error") {
+          console.log(`${tag}%c${msg}`, ...tagStyles, "color:#ff5555");
+        } else if (level === "debug") {
+          console.log(`${tag}%c${msg}`, ...tagStyles, "color:#6272a4");
+        } else {
+          console.log(`${tag}%c${msg}`, ...tagStyles, "color:inherit");
+        }
+      } catch {}
+    };
+
+    return () => {
+      if (groupOpen) console.groupEnd();
+      es.close();
+    };
+  }, [config?.logsEndpoint]);
+
   if (!config) {
     return (
       <BootEmptyState

--- a/packages/serve-sim/src/client/components/device-logs-panel.tsx
+++ b/packages/serve-sim/src/client/components/device-logs-panel.tsx
@@ -1,0 +1,42 @@
+import { Panel, PanelCloseButton, PanelHeader, PanelTitle } from "../Panel";
+import { DeviceLogsTool } from "./device-logs-tool";
+
+export function DeviceLogsPanel({
+  open,
+  onClose,
+  udid,
+  currentApp,
+  logsEndpoint,
+  width,
+}: {
+  open: boolean;
+  onClose: () => void;
+  udid: string;
+  currentApp: { bundleId: string; isReactNative: boolean; pid?: number } | null;
+  logsEndpoint?: string;
+  width: number;
+}) {
+  return (
+    <Panel open={open} width={width}>
+      <PanelHeader>
+        <PanelTitle>Device Logs</PanelTitle>
+        <PanelCloseButton
+          onClick={onClose}
+          ariaLabel="Close Device Logs"
+          title="Close"
+          iconSize={15}
+        />
+      </PanelHeader>
+
+      {open && (
+        <div className="p-3.5 overflow-hidden flex-1 flex flex-col">
+          <DeviceLogsTool
+            udid={udid}
+            currentApp={currentApp}
+            logsEndpoint={logsEndpoint}
+          />
+        </div>
+      )}
+    </Panel>
+  );
+}

--- a/packages/serve-sim/src/client/components/device-logs-tool.tsx
+++ b/packages/serve-sim/src/client/components/device-logs-tool.tsx
@@ -1,0 +1,311 @@
+import { memo, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
+import { useDeviceLogs } from "../hooks/use-device-logs";
+import { fetchAppDetails } from "../utils/app-icon";
+import { execOnHost } from "../utils/exec";
+import {
+  filterDeviceLogs,
+  type DeviceLogEntry,
+  type DeviceLogLevel,
+  type DeviceLogStreamLevel,
+} from "../utils/logs";
+
+const LEVELS: DeviceLogLevel[] = ["debug", "info", "default", "error", "fault"];
+const STREAM_LEVELS: DeviceLogStreamLevel[] = ["info", "debug", "default"];
+
+export function DeviceLogsTool({
+  udid,
+  currentApp,
+  logsEndpoint,
+}: {
+  udid: string;
+  currentApp: { bundleId: string; isReactNative: boolean; pid?: number } | null;
+  logsEndpoint?: string;
+}) {
+  const [paused, setPaused] = useState(false);
+  const [followTail, setFollowTail] = useState(true);
+  const [search, setSearch] = useState("");
+  const [process, setProcess] = useState("");
+  const [streamLevel, setStreamLevel] = useState<DeviceLogStreamLevel>("info");
+  const [levels, setLevels] = useState<Set<DeviceLogLevel>>(() => new Set(["info", "default", "error", "fault"]));
+  const [currentAppOnly, setCurrentAppOnly] = useState(false);
+  const [appExecutable, setAppExecutable] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const deferredSearch = useDeferredValue(search);
+  const currentBundleId = currentApp?.bundleId ?? null;
+  const currentPid = currentApp?.pid;
+  const canScopeToCurrentApp = Boolean(currentBundleId && currentBundleId !== "com.apple.springboard");
+
+  const { entries, status, error, clear } = useDeviceLogs({
+    endpoint: logsEndpoint,
+    enabled: !paused,
+    streamLevel,
+  });
+
+  useEffect(() => {
+    const bundleId = currentBundleId;
+    setCurrentAppOnly(false);
+    setProcess("");
+    setAppExecutable(null);
+    if (!bundleId) return;
+    let cancelled = false;
+    fetchAppDetails(execOnHost, udid, bundleId).then((details) => {
+      if (!cancelled) setAppExecutable(details.executable ?? null);
+    }).catch(() => {
+      if (!cancelled) setAppExecutable(null);
+    });
+    return () => { cancelled = true; };
+  }, [udid, currentBundleId]);
+
+  const processOptions = useMemo(() => {
+    const names = new Set<string>();
+    for (const entry of entries) {
+      if (entry.process) names.add(entry.process);
+    }
+    return [...names].sort((a, b) => a.localeCompare(b));
+  }, [entries]);
+
+  const currentAppFilter = useMemo(() => currentBundleId ? {
+    bundleId: currentBundleId,
+    pid: currentPid,
+    executable: appExecutable,
+  } : null, [currentBundleId, currentPid, appExecutable]);
+
+  const visible = useMemo(() => filterDeviceLogs(entries, {
+    search: deferredSearch,
+    levels,
+    process,
+    currentAppOnly,
+    currentApp: currentAppFilter,
+  }), [entries, deferredSearch, levels, process, currentAppOnly, currentAppFilter]);
+
+  useEffect(() => {
+    if (!followTail) return;
+    const el = listRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+  }, [visible.length, followTail]);
+
+  const toggleLevel = (level: DeviceLogLevel) => {
+    setLevels((prev) => {
+      const next = new Set(prev);
+      if (next.has(level)) next.delete(level);
+      else next.add(level);
+      if (next.size === 0) next.add(level);
+      return next;
+    });
+  };
+
+  const exportVisible = () => {
+    const body = visible.map((entry) => JSON.stringify(entry.raw)).join("\n");
+    const blob = new Blob([body], { type: "application/x-ndjson" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `serve-sim-${udid}-logs.ndjson`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="min-h-0 flex-1 flex flex-col gap-2.5">
+      <div className="grid [grid-template-columns:auto_1fr_auto] items-center gap-2 min-h-[24px] leading-none">
+        <DeviceLogsStatusLabel status={paused ? "paused" : status} />
+      </div>
+
+      <div className="grid grid-cols-[1fr_auto_auto] gap-1.5">
+        <input
+          value={search}
+          onChange={(event) => setSearch(event.currentTarget.value)}
+          placeholder="Search logs"
+          className="min-w-0 h-7 rounded-md border border-white/10 bg-panel-deep px-2 text-[12px] text-white/90 outline-none placeholder:text-white/35"
+        />
+        <button
+          type="button"
+          onClick={() => setPaused((value) => !value)}
+          className="h-7 rounded-md border border-white/12 bg-white/[0.03] px-2 text-[10px] text-white/75 cursor-pointer"
+        >
+          {paused ? "Resume" : "Pause"}
+        </button>
+        <button
+          type="button"
+          onClick={clear}
+          className="h-7 rounded-md border border-white/12 bg-white/[0.03] px-2 text-[10px] text-white/75 cursor-pointer"
+        >
+          Clear
+        </button>
+      </div>
+
+      <div className="grid grid-cols-2 gap-1.5">
+        <select
+          value={process}
+          onChange={(event) => setProcess(event.currentTarget.value)}
+          className="min-w-0 h-7 rounded-md border border-white/10 bg-panel-deep px-2 text-[11px] text-white/80 outline-none"
+          title="Process filter"
+        >
+          <option value="">All processes</option>
+          {processOptions.map((name) => <option key={name} value={name}>{name}</option>)}
+        </select>
+        <select
+          value={streamLevel}
+          onChange={(event) => setStreamLevel(event.currentTarget.value as DeviceLogStreamLevel)}
+          className="min-w-0 h-7 rounded-md border border-white/10 bg-panel-deep px-2 text-[11px] text-white/80 outline-none"
+          title="Stream verbosity"
+        >
+          {STREAM_LEVELS.map((level) => <option key={level} value={level}>Stream {level}</option>)}
+        </select>
+      </div>
+
+      <div className="flex flex-wrap gap-1.5">
+        {LEVELS.map((level) => (
+          <button
+            key={level}
+            type="button"
+            onClick={() => toggleLevel(level)}
+            aria-pressed={levels.has(level)}
+            className={`rounded-md border px-2 py-1 text-[10px] uppercase tracking-[0.03em] cursor-pointer ${levels.has(level) ? levelClass(level) : "border-white/10 bg-transparent text-white/45"}`}
+          >
+            {level}
+          </button>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-[1fr_auto_auto] items-center gap-2 text-[11px] text-white/55">
+        <label className="inline-flex items-center gap-1.5 min-w-0">
+          <input
+            type="checkbox"
+            checked={currentAppOnly}
+            disabled={!canScopeToCurrentApp}
+            onChange={(event) => setCurrentAppOnly(event.currentTarget.checked)}
+            className="m-0"
+          />
+          <span className="truncate">{canScopeToCurrentApp ? "Current app" : "All device"}</span>
+        </label>
+        <label className="inline-flex items-center gap-1.5">
+          <input
+            type="checkbox"
+            checked={followTail}
+            onChange={(event) => setFollowTail(event.currentTarget.checked)}
+            className="m-0"
+          />
+          Follow
+        </label>
+        <button
+          type="button"
+          onClick={exportVisible}
+          disabled={visible.length === 0}
+          className="rounded-md border border-white/12 bg-transparent px-2 py-1 text-[10px] text-white/70 cursor-pointer disabled:cursor-default disabled:text-white/30"
+        >
+          Export
+        </button>
+      </div>
+
+      {error && (
+        <div className="bg-danger/10 border border-danger/20 text-danger-soft text-[11px] px-2 py-1.5 rounded-md">
+          {error}
+        </div>
+      )}
+
+      <div className="flex-1 rounded-lg border border-white/8 bg-panel-deep overflow-hidden min-h-0 flex flex-col">
+        <div className="grid grid-cols-[54px_52px_82px_1fr] gap-2 border-b border-white/8 px-2 py-1.5 text-[10px] font-semibold uppercase tracking-[0.06em] text-white/45">
+          <span>Time</span>
+          <span>Level</span>
+          <span>Process</span>
+          <span>Message</span>
+        </div>
+        <div ref={listRef} className="flex-1 min-h-0 overflow-y-auto [scrollbar-width:thin]">
+          {visible.length === 0 ? (
+            <div className="p-5 text-center text-[12px] text-white/45">
+              {entries.length === 0 ? (paused ? "Log stream is paused." : "Waiting for device logs…") : "No logs match the current filters."}
+            </div>
+          ) : visible.map((entry) => (
+            <LogRow
+              key={entry.id}
+              entry={entry}
+              expanded={expandedId === entry.id}
+              onToggle={() => setExpandedId((value) => value === entry.id ? null : entry.id)}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="flex justify-between gap-2 text-[10px] text-white/45 font-mono">
+        <span>{visible.length}/{entries.length} rows</span>
+        <span>{currentAppOnly && appExecutable ? appExecutable : udid.slice(0, 8)}</span>
+      </div>
+    </div>
+  );
+}
+
+function DeviceLogsStatusLabel({ status }: { status: "idle" | "connecting" | "live" | "error" | "paused" }) {
+  return (
+    <>
+      <span className="text-[11px] font-semibold text-white/50 uppercase tracking-[0.08em] leading-none inline-flex items-center">Device Logs</span>
+      <span />
+      <span className="inline-flex items-center gap-1.5 text-[10px] text-white/55 font-mono">
+        <span className={`w-1.5 h-1.5 rounded-full ${status === "live" ? "bg-success" : status === "error" ? "bg-danger" : status === "paused" ? "bg-warning" : "bg-white/35"}`} />
+        {status}
+      </span>
+    </>
+  );
+}
+
+const LogRow = memo(function LogRow({
+  entry,
+  expanded,
+  onToggle,
+}: {
+  entry: DeviceLogEntry;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const copy = async () => {
+    await navigator.clipboard?.writeText(JSON.stringify(entry.raw, null, 2));
+  };
+  return (
+    <div className="border-b border-white/[0.04] last:border-b-0">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="grid w-full grid-cols-[54px_52px_82px_1fr] gap-2 border-none bg-transparent px-2 py-1.5 text-left text-[11px] text-white/80 cursor-pointer hover:bg-white/[0.04]"
+      >
+        <span className="font-mono text-white/45 truncate">{formatTime(entry.timestamp)}</span>
+        <span className={`w-fit rounded px-1.5 py-0.5 text-[9px] uppercase tracking-[0.03em] ${levelClass(entry.level)}`}>{entry.level}</span>
+        <span className="font-mono text-white/55 truncate" title={entry.process}>{entry.process || "—"}</span>
+        <span className="min-w-0 truncate" title={entry.message}>{entry.message}</span>
+      </button>
+      {expanded && (
+        <div className="border-t border-white/[0.04] bg-black/20 px-2 py-2">
+          <div className="flex items-center justify-between gap-2 pb-1.5">
+            <span className="min-w-0 truncate text-[10px] text-white/45">
+              {[entry.subsystem, entry.category].filter(Boolean).join(" · ") || "No subsystem"}
+            </span>
+            <button
+              type="button"
+              onClick={copy}
+              className="rounded-md border border-white/12 bg-transparent px-2 py-1 text-[10px] text-white/70 cursor-pointer"
+            >
+              Copy
+            </button>
+          </div>
+          <pre className="m-0 max-h-44 overflow-auto whitespace-pre-wrap break-words rounded-md bg-black/30 p-2 font-mono text-[10px] leading-4 text-white/65 [scrollbar-width:thin]">{JSON.stringify(entry.raw, null, 2)}</pre>
+        </div>
+      )}
+    </div>
+  );
+}, (prev, next) => prev.entry === next.entry && prev.expanded === next.expanded);
+
+function levelClass(level: DeviceLogLevel): string {
+  if (level === "fault") return "border-danger/30 bg-danger/18 text-danger-soft";
+  if (level === "error") return "border-danger/25 bg-danger/12 text-danger-soft";
+  if (level === "debug") return "border-accent/25 bg-accent/12 text-accent";
+  if (level === "info") return "border-success/25 bg-success/12 text-success";
+  return "border-white/12 bg-white/[0.06] text-white/70";
+}
+
+function formatTime(value: string): string {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value.slice(11, 19) || value.slice(0, 8);
+  return date.toLocaleTimeString([], { hour12: false, hour: "2-digit", minute: "2-digit", second: "2-digit" });
+}

--- a/packages/serve-sim/src/client/hooks/use-device-logs.ts
+++ b/packages/serve-sim/src/client/hooks/use-device-logs.ts
@@ -9,6 +9,8 @@ import {
 export type DeviceLogStatus = "idle" | "connecting" | "live" | "error";
 
 const MAX_LOG_ROWS = 1_500;
+const MAX_PENDING_LOG_ROWS = MAX_LOG_ROWS;
+const FLUSH_TIMEOUT_MS = 250;
 
 export function useDeviceLogs({
   endpoint,
@@ -25,6 +27,7 @@ export function useDeviceLogs({
   const nextId = useRef(1);
   const pendingEntries = useRef<DeviceLogEntry[]>([]);
   const frame = useRef<number | null>(null);
+  const flushTimer = useRef<number | null>(null);
 
   useEffect(() => {
     if (!endpoint || !enabled) {
@@ -34,6 +37,10 @@ export function useDeviceLogs({
 
     const flush = () => {
       frame.current = null;
+      if (flushTimer.current != null) {
+        window.clearTimeout(flushTimer.current);
+        flushTimer.current = null;
+      }
       const pending = pendingEntries.current;
       if (pending.length === 0) return;
       pendingEntries.current = [];
@@ -45,8 +52,18 @@ export function useDeviceLogs({
 
     const enqueue = (entry: DeviceLogEntry) => {
       pendingEntries.current.push(entry);
+      if (pendingEntries.current.length > MAX_PENDING_LOG_ROWS) {
+        pendingEntries.current = pendingEntries.current.slice(-MAX_PENDING_LOG_ROWS);
+      }
       if (frame.current != null) return;
       frame.current = window.requestAnimationFrame(flush);
+      flushTimer.current = window.setTimeout(() => {
+        if (frame.current != null) {
+          window.cancelAnimationFrame(frame.current);
+          frame.current = null;
+        }
+        flush();
+      }, FLUSH_TIMEOUT_MS);
     };
 
     setStatus("connecting");
@@ -81,6 +98,10 @@ export function useDeviceLogs({
         window.cancelAnimationFrame(frame.current);
         frame.current = null;
       }
+      if (flushTimer.current != null) {
+        window.clearTimeout(flushTimer.current);
+        flushTimer.current = null;
+      }
       pendingEntries.current = [];
     };
   }, [endpoint, enabled, streamLevel]);
@@ -95,6 +116,10 @@ export function useDeviceLogs({
       if (frame.current != null) {
         window.cancelAnimationFrame(frame.current);
         frame.current = null;
+      }
+      if (flushTimer.current != null) {
+        window.clearTimeout(flushTimer.current);
+        flushTimer.current = null;
       }
       setEntries([]);
     },

--- a/packages/serve-sim/src/client/hooks/use-device-logs.ts
+++ b/packages/serve-sim/src/client/hooks/use-device-logs.ts
@@ -1,0 +1,102 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  buildLogsEndpoint,
+  parseDeviceLogEntry,
+  type DeviceLogEntry,
+  type DeviceLogStreamLevel,
+} from "../utils/logs";
+
+export type DeviceLogStatus = "idle" | "connecting" | "live" | "error";
+
+const MAX_LOG_ROWS = 1_500;
+
+export function useDeviceLogs({
+  endpoint,
+  enabled,
+  streamLevel,
+}: {
+  endpoint: string | null | undefined;
+  enabled: boolean;
+  streamLevel: DeviceLogStreamLevel;
+}) {
+  const [entries, setEntries] = useState<DeviceLogEntry[]>([]);
+  const [status, setStatus] = useState<DeviceLogStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const nextId = useRef(1);
+  const pendingEntries = useRef<DeviceLogEntry[]>([]);
+  const frame = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!endpoint || !enabled) {
+      setStatus("idle");
+      return;
+    }
+
+    const flush = () => {
+      frame.current = null;
+      const pending = pendingEntries.current;
+      if (pending.length === 0) return;
+      pendingEntries.current = [];
+      setEntries((prev) => {
+        const next = prev.concat(pending);
+        return next.length > MAX_LOG_ROWS ? next.slice(next.length - MAX_LOG_ROWS) : next;
+      });
+    };
+
+    const enqueue = (entry: DeviceLogEntry) => {
+      pendingEntries.current.push(entry);
+      if (frame.current != null) return;
+      frame.current = window.requestAnimationFrame(flush);
+    };
+
+    setStatus("connecting");
+    setError(null);
+    const eventSource = new EventSource(buildLogsEndpoint(endpoint, streamLevel));
+
+    eventSource.onopen = () => {
+      setStatus("live");
+      setError(null);
+    };
+
+    eventSource.onmessage = (event) => {
+      let value: unknown;
+      try {
+        value = JSON.parse(event.data);
+      } catch {
+        return;
+      }
+      const entry = parseDeviceLogEntry(value, nextId.current++);
+      if (!entry) return;
+      enqueue(entry);
+    };
+
+    eventSource.onerror = () => {
+      setStatus("error");
+      setError("Log stream disconnected. serve-sim will retry while the tool stays open.");
+    };
+
+    return () => {
+      eventSource.close();
+      if (frame.current != null) {
+        window.cancelAnimationFrame(frame.current);
+        frame.current = null;
+      }
+      pendingEntries.current = [];
+    };
+  }, [endpoint, enabled, streamLevel]);
+
+  return {
+    entries,
+    status,
+    error,
+    clear: () => {
+      nextId.current = 1;
+      pendingEntries.current = [];
+      if (frame.current != null) {
+        window.cancelAnimationFrame(frame.current);
+        frame.current = null;
+      }
+      setEntries([]);
+    },
+  };
+}

--- a/packages/serve-sim/src/client/utils/logs.ts
+++ b/packages/serve-sim/src/client/utils/logs.ts
@@ -1,0 +1,102 @@
+export type DeviceLogLevel = "debug" | "info" | "default" | "error" | "fault" | "unknown";
+export type DeviceLogStreamLevel = "debug" | "info" | "default";
+
+export type DeviceLogEntry = {
+  id: number;
+  timestamp: string;
+  level: DeviceLogLevel;
+  process: string;
+  processKey: string;
+  processID?: number;
+  subsystem: string;
+  category: string;
+  message: string;
+  searchText: string;
+  raw: Record<string, unknown>;
+};
+
+export type DeviceLogFilters = {
+  search: string;
+  levels: Set<DeviceLogLevel>;
+  process: string;
+  currentAppOnly: boolean;
+  currentApp?: {
+    bundleId: string;
+    pid?: number;
+    executable?: string | null;
+  } | null;
+};
+
+const LOG_LEVELS: DeviceLogLevel[] = ["debug", "info", "default", "error", "fault", "unknown"];
+
+export function normalizeLogLevel(value: unknown): DeviceLogLevel {
+  const level = String(value ?? "").toLowerCase();
+  if (LOG_LEVELS.includes(level as DeviceLogLevel)) return level as DeviceLogLevel;
+  return "unknown";
+}
+
+export function parseDeviceLogEntry(rawValue: unknown, id: number): DeviceLogEntry | null {
+  if (!rawValue || typeof rawValue !== "object") return null;
+  const raw = rawValue as Record<string, unknown>;
+  const message = String(raw.eventMessage ?? "");
+  if (!message) return null;
+  const processPath = String(raw.processImagePath ?? raw.senderImagePath ?? "");
+  const process = processPath.split("/").filter(Boolean).pop() ?? String(raw.process ?? "");
+  const processID = typeof raw.processID === "number" ? raw.processID : undefined;
+  const timestamp = String(raw.timestamp ?? raw.machTimestamp ?? "");
+  const level = normalizeLogLevel(raw.messageType);
+  const subsystem = String(raw.subsystem ?? "");
+  const category = String(raw.category ?? "");
+  return {
+    id,
+    timestamp,
+    level,
+    process,
+    processKey: process.toLowerCase(),
+    processID,
+    subsystem,
+    category,
+    message,
+    searchText: [message, process, subsystem, category, level, timestamp]
+      .join("\n")
+      .toLowerCase(),
+    raw,
+  };
+}
+
+export function appendLogEntryBuffer(
+  entries: DeviceLogEntry[],
+  entry: DeviceLogEntry,
+  limit: number,
+): DeviceLogEntry[] {
+  const next = entries.length >= limit ? entries.slice(entries.length - limit + 1) : entries.slice();
+  next.push(entry);
+  return next;
+}
+
+export function filterDeviceLogs(entries: DeviceLogEntry[], filters: DeviceLogFilters): DeviceLogEntry[] {
+  const search = filters.search.trim().toLowerCase();
+  const process = filters.process.trim().toLowerCase();
+  return entries.filter((entry) => {
+    if (!filters.levels.has(entry.level)) return false;
+    if (process && entry.processKey !== process) return false;
+    if (filters.currentAppOnly && !matchesCurrentApp(entry, filters.currentApp)) return false;
+    return !search || entry.searchText.includes(search);
+  });
+}
+
+export function matchesCurrentApp(
+  entry: DeviceLogEntry,
+  currentApp: DeviceLogFilters["currentApp"],
+): boolean {
+  if (!currentApp) return false;
+  if (currentApp.pid != null && entry.processID === currentApp.pid) return true;
+  if (currentApp.executable && entry.process === currentApp.executable) return true;
+  return entry.searchText.includes(currentApp.bundleId.toLowerCase());
+}
+
+export function buildLogsEndpoint(endpoint: string, streamLevel: DeviceLogStreamLevel): string {
+  const url = new URL(endpoint, window.location.origin);
+  url.searchParams.set("level", streamLevel);
+  return url.pathname + url.search + url.hash;
+}

--- a/packages/serve-sim/src/client/utils/panel-widths.ts
+++ b/packages/serve-sim/src/client/utils/panel-widths.ts
@@ -1,3 +1,4 @@
 export const PANEL_WIDTH = 320;
+export const DEVICE_LOGS_PANEL_WIDTH = 680;
 export const DEVTOOLS_PANEL_WIDTH = 760;
 export const GRID_PANEL_WIDTH = 720;

--- a/packages/serve-sim/src/middleware.ts
+++ b/packages/serve-sim/src/middleware.ts
@@ -252,6 +252,14 @@ function queryDevice(rawUrl: string): string | null {
   return new URLSearchParams(rawUrl.slice(qIndex + 1)).get("device");
 }
 
+export function queryLogLevel(rawUrl: string): "debug" | "info" | "default" {
+  const qIndex = rawUrl.indexOf("?");
+  if (qIndex === -1) return "info";
+  const value = new URLSearchParams(rawUrl.slice(qIndex + 1)).get("level");
+  if (value === "debug" || value === "default") return value;
+  return "info";
+}
+
 function endpoint(base: string, path: string, device: string): string {
   const value = `${base}${path}`;
   return `${value}?device=${encodeURIComponent(device)}`;
@@ -1115,6 +1123,7 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
         return;
       }
       const udid = state.device;
+      const level = queryLogLevel(rawUrl);
       res.writeHead(200, {
         "Content-Type": "text/event-stream",
         "Cache-Control": "no-cache",
@@ -1126,7 +1135,7 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
       const child: ChildProcess = spawn("xcrun", [
         "simctl", "spawn", udid, "log", "stream",
         "--style", "ndjson",
-        "--level", "info",
+        "--level", level,
       ], { stdio: ["ignore", "pipe", "ignore"] });
 
       let buf = "";


### PR DESCRIPTION
# Summary
Adds a dedicated Device Logs panel for viewing simulator logs from the serve-sim UI while preserving the existing browser-console log stream used by agent/browser tooling.

# Changes
- Add a right-rail Device Logs entry with a resizable log viewer panel
- Stream simulator device logs through the existing `/logs` SSE endpoint with controlled verbosity
- Preserve browser-console mirroring of simulator logs for MCP and DevTools workflows
- Add search, level, process, current-app, follow-tail, pause, clear, export, and row expansion controls
- Batch incoming log rows, precompute filter/search keys, and bound pending rows when rendering is throttled
- Cover log parsing, filtering, buffer limits, stream-level parsing, and idle stream cleanup with focused tests
