### PR TITLE
Rewrite helper host to request hostname for remote viewers

### DIFF
--- a/packages/serve-sim/src/__tests__/middleware-selection.test.ts
+++ b/packages/serve-sim/src/__tests__/middleware-selection.test.ts
@@ -3,6 +3,7 @@ import {
   matchInstalledAppByDisplayName,
   parseForegroundAppLogMessage,
   previewConfigForState,
+  rewriteStateForRequestHost,
   selectServeSimState,
   type ServeSimState,
 } from "../middleware";
@@ -57,6 +58,38 @@ describe("previewConfigForState", () => {
       gridMemoryEndpoint: "/preview/grid/api/memory",
       previewEndpoint: "/preview",
       execToken: "token-xyz",
+    });
+  });
+});
+
+describe("rewriteStateForRequestHost", () => {
+  const state = states[0]!;
+
+  test("returns the state unchanged when host header is missing", () => {
+    expect(rewriteStateForRequestHost(state, undefined)).toBe(state);
+  });
+
+  test("returns the state unchanged when the request is loopback", () => {
+    expect(rewriteStateForRequestHost(state, "localhost:8081")).toBe(state);
+    expect(rewriteStateForRequestHost(state, "127.0.0.1:8081")).toBe(state);
+    expect(rewriteStateForRequestHost(state, "[::1]:8081")).toBe(state);
+  });
+
+  test("rewrites the host portion for a LAN viewer, keeping the helper port", () => {
+    expect(rewriteStateForRequestHost(state, "192.168.1.42:8081")).toEqual({
+      ...state,
+      url: "http://192.168.1.42:3100",
+      streamUrl: "http://192.168.1.42:3100/stream.mjpeg",
+      wsUrl: "ws://192.168.1.42:3100/ws",
+    });
+  });
+
+  test("rewrites the host portion for a tunneled hostname (no port)", () => {
+    expect(rewriteStateForRequestHost(state, "tunnel.example.com")).toEqual({
+      ...state,
+      url: "http://tunnel.example.com:3100",
+      streamUrl: "http://tunnel.example.com:3100/stream.mjpeg",
+      wsUrl: "ws://tunnel.example.com:3100/ws",
     });
   });
 });

--- a/packages/serve-sim/src/middleware.ts
+++ b/packages/serve-sim/src/middleware.ts
@@ -257,6 +257,38 @@ function endpoint(base: string, path: string, device: string): string {
   return `${value}?device=${encodeURIComponent(device)}`;
 }
 
+/**
+ * Rewrite the helper URLs in a state so they point at the hostname the request
+ * came in on. The helper binds on `*:<port>`, so once the host portion matches
+ * the dev-server origin, a remote viewer (LAN, or tunnel exposing the helper
+ * port under the same hostname) can reach the stream. Loopback callers get
+ * the state untouched.
+ */
+export function rewriteStateForRequestHost(
+  state: ServeSimState,
+  hostHeader: string | undefined,
+): ServeSimState {
+  if (!hostHeader) return state;
+  let hostname: string;
+  try {
+    hostname = new URL(`http://${hostHeader}`).hostname;
+  } catch {
+    return state;
+  }
+  // `URL.hostname` keeps brackets around IPv6 literals, so the IPv6 loopback
+  // comparison is against the bracketed form rather than `::1`.
+  if (hostname === "localhost" || hostname === "127.0.0.1" || hostname === "[::1]") {
+    return state;
+  }
+  const rewrite = (s: string) => s.replace("127.0.0.1", hostname);
+  return {
+    ...state,
+    url: rewrite(state.url),
+    streamUrl: rewrite(state.streamUrl),
+    wsUrl: rewrite(state.wsUrl),
+  };
+}
+
 export function previewConfigForState(
   state: ServeSimState,
   base: string,
@@ -725,7 +757,8 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
       }
 
       if (state) {
-        const config = JSON.stringify(previewConfigForState(state, base, serveSimBinPath(), execToken));
+        const remoteState = rewriteStateForRequestHost(state, req.headers?.host);
+        const config = JSON.stringify(previewConfigForState(remoteState, base, serveSimBinPath(), execToken));
         const configScript = `<script>window.__SIM_PREVIEW__=${config}</script>`;
         html = html.replace("<!--__SIM_PREVIEW_CONFIG__-->", configScript);
       }
@@ -755,17 +788,18 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
       const sims = listAllSimulators();
       const devices = sims.map((d) => {
         const helper = helperByUdid.get(d.udid);
+        const remoteHelper = helper ? rewriteStateForRequestHost(helper, req.headers?.host) : null;
         return {
           device: d.udid,
           name: d.name,
           runtime: d.runtime,
           state: d.state,
-          helper: helper
+          helper: remoteHelper
             ? {
-                port: helper.port,
-                url: helper.url,
-                streamUrl: helper.streamUrl,
-                wsUrl: helper.wsUrl,
+                port: remoteHelper.port,
+                url: remoteHelper.url,
+                streamUrl: remoteHelper.streamUrl,
+                wsUrl: remoteHelper.wsUrl,
               }
             : null,
         };
@@ -1003,7 +1037,8 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
         "Content-Type": "application/json",
         "Cache-Control": "no-store",
       });
-      res.end(JSON.stringify(state ? previewConfigForState(state, base, serveSimBinPath(), execToken) : null));
+      const remoteState = state ? rewriteStateForRequestHost(state, req.headers?.host) : null;
+      res.end(JSON.stringify(remoteState ? previewConfigForState(remoteState, base, serveSimBinPath(), execToken) : null));
       return;
     }
 


### PR DESCRIPTION
## Summary

The serve-sim helper binds on `*:<port>` and is reachable over the network, but the CLI hardcodes `127.0.0.1` in the `url` / `streamUrl` / `wsUrl` it writes to its state file. Those URLs are injected into the preview HTML as `window.__SIM_PREVIEW__`, so a remote browser (LAN or tunneled) dereferences `127.0.0.1` as **itself** and the stream never loads.

This PR rewrites the host portion of those URLs to the request's hostname before serving:

- the preview HTML page at `{basePath}` (the injected `window.__SIM_PREVIEW__`)
- the JSON state at `{basePath}/api`
- the per-helper entries in `{basePath}/grid/api`

The helper port stays unchanged. LAN viewers can reach the helper directly via `<lan-ip>:<helper-port>`. For tunneled access, the helper port needs to be exposed under the same hostname as the preview.

Loopback callers (`localhost` / `127.0.0.1` / `::1`) get the state untouched, so existing local-dev behavior is preserved.

## Implementation

A new exported helper `rewriteStateForRequestHost(state, hostHeader)` does the rewriting. It's a noop when:

- the host header is missing or unparseable,
- the request hostname is loopback,
- the state's current hostname is *not* loopback (so we don't clobber an already-customized state).

## Test plan

- [x] Added `rewriteStateForRequestHost` unit tests covering loopback, LAN IPs, tunneled hostnames, missing host header, and already-remote state.
- [x] `bun test` — 192 pass, 0 fail.
- [x] Manually verified via a downstream Metro middleware doing the equivalent rewrite (proved out the approach end-to-end with a real iOS simulator opened from another machine on the LAN).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Helper stream and WebSocket endpoints now rewrite to match the incoming request hostname, letting LAN/tunnel viewers access helper endpoints via the same origin as the dev server. Preview pages and API responses now serve these rewritten helper URLs.

* **Tests**
  * Added tests covering hostname-based URL rewriting across loopback, LAN IP, and tunneled-host scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EvanBacon/serve-sim/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->