### PR TITLE
Fix memory leaks in AX streamer cache and SSE log endpoints

### DIFF
--- a/packages/serve-sim/src/__tests__/ax-streamer-cache.test.ts
+++ b/packages/serve-sim/src/__tests__/ax-streamer-cache.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { createAxStreamerCache } from "../ax";
+
+describe("createAxStreamerCache", () => {
+  test("get() reuses the same streamer for a udid and retargets the port", () => {
+    const cache = createAxStreamerCache();
+    const a = cache.get("UDID-1", 4001);
+    const b = cache.get("UDID-1", 4002);
+    expect(a).toBe(b);
+    expect(cache.size()).toBe(1);
+  });
+
+  test("prune() drops streamers for udids no longer active", () => {
+    const cache = createAxStreamerCache();
+    cache.get("UDID-A", 4001);
+    cache.get("UDID-B", 4002);
+    cache.get("UDID-C", 4003);
+    expect(cache.size()).toBe(3);
+
+    cache.prune(["UDID-A", "UDID-C"]);
+    expect(cache.size()).toBe(2);
+
+    cache.prune([]);
+    expect(cache.size()).toBe(0);
+  });
+
+  test("a streamer disposed via prune() no longer accepts clients", () => {
+    const cache = createAxStreamerCache();
+    const streamer = cache.get("UDID-X", 4001);
+    cache.prune([]);
+
+    // Disposed streamer's addClient returns a no-op cleanup and never
+    // pushes data — verifies it won't keep poll timers alive after prune.
+    const writes: string[] = [];
+    const removeClient = streamer.addClient({ write: (s) => writes.push(s) });
+    expect(typeof removeClient).toBe("function");
+    expect(writes).toEqual([]);
+    removeClient();
+  });
+});

--- a/packages/serve-sim/src/ax.ts
+++ b/packages/serve-sim/src/ax.ts
@@ -159,6 +159,7 @@ function sseMessage(payload: unknown) {
 interface AxStreamer {
   addClient(res: { write(chunk: string): void }): () => void;
   setPort(port: number): void;
+  dispose(): void;
 }
 
 function createAxStreamer({ port }: { port: number }): AxStreamer {
@@ -168,15 +169,16 @@ function createAxStreamer({ port }: { port: number }): AxStreamer {
   let pollIntervalMs = POLL_INTERVAL_MS;
   let polling = false;
   let currentPort = port;
+  let disposed = false;
 
   const schedule = () => {
-    if (clients.size === 0 || timer) return;
+    if (disposed || clients.size === 0 || timer) return;
     timer = setTimeout(poll, pollIntervalMs);
   };
 
   const poll = async () => {
     timer = null;
-    if (polling || clients.size === 0) {
+    if (disposed || polling || clients.size === 0) {
       schedule();
       return;
     }
@@ -206,7 +208,7 @@ function createAxStreamer({ port }: { port: number }): AxStreamer {
 
   return {
     setPort(nextPort: number) {
-      if (nextPort === currentPort) return;
+      if (disposed || nextPort === currentPort) return;
       currentPort = nextPort;
       latestMessage = null;
       // Avoid sitting on the unavailable-backoff interval (15s) when the
@@ -219,6 +221,7 @@ function createAxStreamer({ port }: { port: number }): AxStreamer {
       void poll();
     },
     addClient(res) {
+      if (disposed) return () => {};
       clients.add(res);
       if (latestMessage) res.write(latestMessage);
       void poll();
@@ -230,10 +233,26 @@ function createAxStreamer({ port }: { port: number }): AxStreamer {
         }
       };
     },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      clients.clear();
+      latestMessage = null;
+    },
   };
 }
 
-export function createAxStreamerCache() {
+export interface AxStreamerCache {
+  get(udid: string, port: number): AxStreamer;
+  prune(activeUdids: Iterable<string>): void;
+  size(): number;
+}
+
+export function createAxStreamerCache(): AxStreamerCache {
   const streamers = new Map<string, AxStreamer>();
 
   return {
@@ -252,6 +271,24 @@ export function createAxStreamerCache() {
       const streamer = createAxStreamer({ port });
       streamers.set(udid, streamer);
       return streamer;
+    },
+    /**
+     * Drop streamers for simulators no longer present in `activeUdids`.
+     * Without this, the cache grew append-only across a server's lifetime
+     * as devices were booted/erased/reset, each entry holding a poll
+     * timer, last-snapshot buffer, and SSE client set.
+     */
+    prune(activeUdids) {
+      const active = activeUdids instanceof Set ? activeUdids : new Set(activeUdids);
+      for (const [udid, streamer] of streamers) {
+        if (!active.has(udid)) {
+          streamer.dispose();
+          streamers.delete(udid);
+        }
+      }
+    },
+    size() {
+      return streamers.size;
     },
   };
 }

--- a/packages/serve-sim/src/middleware.ts
+++ b/packages/serve-sim/src/middleware.ts
@@ -83,6 +83,11 @@ export interface ServeSimState {
 }
 
 const axStreamerCache = createAxStreamerCache();
+
+// Hard cap on the SSE line-assembly buffer for child-process stdout.
+// A malformed log entry without a newline can't grow this beyond 1 MB;
+// the partial line is dropped rather than retained indefinitely.
+const SSE_LINE_BUFFER_LIMIT = 1024 * 1024;
 let inspectWebKitBridge: Promise<WebKitBridge> | null = null;
 
 // Known bundle IDs that are always React Native shells (used as a fallback
@@ -1023,6 +1028,7 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
         "X-Accel-Buffering": "no",
       });
       res.write(":\n\n");
+      axStreamerCache.prune(states.map((s) => s.device));
       const ax = axStreamerCache.get(state.device, state.port);
       const removeClient = ax.addClient(res);
       req.on("close", removeClient);
@@ -1138,10 +1144,17 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
           buf = buf.slice(nl + 1);
           if (line) res.write("data: " + line + "\n\n");
         }
+        // Drop a runaway partial line so a malformed/never-terminated
+        // log entry can't grow `buf` without bound.
+        if (buf.length > SSE_LINE_BUFFER_LIMIT) buf = "";
       });
 
+      child.on("error", () => { try { res.end(); } catch {} });
       child.on("close", () => res.end());
-      req.on("close", () => child.kill());
+      req.on("close", () => {
+        child.stdout?.destroy();
+        child.kill();
+      });
       return;
     }
 
@@ -1225,11 +1238,17 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
           if (!event) continue;
           emitApp(event.bundleId, event.pid);
         }
+        if (buf.length > SSE_LINE_BUFFER_LIMIT) buf = "";
       });
 
+      child.on("error", () => {
+        closed = true;
+        try { res.end(); } catch {}
+      });
       child.on("close", () => res.end());
       req.on("close", () => {
         closed = true;
+        child.stdout?.destroy();
         child.kill();
       });
       return;


### PR DESCRIPTION
## Summary
- AX streamer cache (`ax.ts`) was append-only — entries keyed by simulator UDID were never removed, retaining a poll timer, last-snapshot buffer, and SSE client set per device for the server's lifetime. Added `dispose()` on the streamer and `prune(activeUdids)` on the cache, called from the `/ax` handler against the current `readServeSimStates()`.
- `/logs` and `/appstate` SSE handlers (`middleware.ts`) accumulated child-process stdout into a `let buf = ""` line-assembly buffer with no cap and no error handling. A malformed log entry without a newline could grow `buf` unbounded; an abnormal child exit would leak the response and listeners. Capped at 1 MB, added `child.on("error")` cleanup, and `child.stdout?.destroy()` on client disconnect.

## Test plan
- [x] New unit tests in `ax-streamer-cache.test.ts` cover reuse, prune semantics, and disposed-streamer no-op
- [x] Full `packages/serve-sim/src/__tests__/` suite: 123/124 pass (the one failure is a pre-existing env issue in `permissions.e2e.test.ts`, unrelated)
- [x] Repo-wide `tsc --noEmit` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for cache management functionality, including instance reuse and cleanup operations.

* **Bug Fixes**
  * Implemented memory limits for SSE stream buffers to prevent unbounded growth.
  * Improved child-process cleanup and lifecycle handling during stream disconnection.
  * Enhanced resource disposal and cleanup mechanisms for better stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EvanBacon/serve-sim/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->