### PR TITLE
Fix CI: close version gap, harden AX flake + publish race

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -135,10 +135,22 @@ jobs:
 
           # Bump from max(local, npm-published) + 1 so a previous run that
           # published but failed to push the bump back to main can't poison
-          # the next run with a 403 from npm.
+          # the next run with a 403 from npm. Retry `npm view` a few times:
+          # right after a publish, the registry can briefly return empty for
+          # a fresh version, and silently falling back to LOCAL has caused
+          # 403 "cannot publish over" collisions on the next run.
           LOCAL=$(node -p "require('./package.json').version")
-          PUBLISHED=$(npm view serve-sim version 2>/dev/null || echo "")
-          [ -z "$PUBLISHED" ] && PUBLISHED="$LOCAL"
+          PUBLISHED=""
+          for i in 1 2 3 4 5; do
+            PUBLISHED=$(npm view serve-sim version 2>/dev/null || echo "")
+            [ -n "$PUBLISHED" ] && break
+            echo "npm view returned empty (attempt $i/5), retrying..."
+            sleep 5
+          done
+          if [ -z "$PUBLISHED" ]; then
+            echo "::error::npm view serve-sim version returned empty after 5 attempts; refusing to publish to avoid version collision"
+            exit 1
+          fi
           NEW=$(node -e "
             const a='$LOCAL'.split('.').map(Number);
             const b='$PUBLISHED'.split('.').map(Number);

--- a/packages/serve-sim/package.json
+++ b/packages/serve-sim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serve-sim",
-  "version": "0.1.34",
+  "version": "0.1.36",
   "type": "module",
   "author": {
     "name": "Evan Bacon",

--- a/packages/serve-sim/src/__tests__/accessibility-endpoint.test.ts
+++ b/packages/serve-sim/src/__tests__/accessibility-endpoint.test.ts
@@ -15,7 +15,7 @@ const CLI_PATH = join(import.meta.dir, "../../src/index.ts");
 const AX_RESPONSE_BUDGET_MS = process.env.CI ? 10_000 : 5_000;
 // The Swift helper returns 503 while the simulator's AX framework is still
 // warming up after boot. Poll past that startup window before failing.
-const AX_READY_BUDGET_MS = process.env.CI ? 60_000 : 10_000;
+const AX_READY_BUDGET_MS = process.env.CI ? 120_000 : 10_000;
 const AX_READY_POLL_INTERVAL_MS = 500;
 
 function firstBootedIosSim(): string | null {


### PR DESCRIPTION
## Summary
- Bump `packages/serve-sim/package.json` to `0.1.36` to match npm. The previous publish run pushed `0.1.36` to npm but couldn't push the bump back to `main` (branch protection), so every subsequent push to `packages/` would re-enter the gap-detection publish path and fail again.
- Raise `AX_READY_BUDGET_MS` from 60s to 120s on CI in `accessibility-endpoint.test.ts`. The simulator's AX framework intermittently takes >60s to warm up on `macos-latest` (this is what killed run #64 on main).
- Retry `npm view serve-sim version` on empty results in `publish.yml`. Right after a publish, the registry can briefly return empty for a fresh version, and silently falling back to `LOCAL` caused run #66 to attempt a republish of `0.1.35` and get a 403.

## Test plan
- [ ] sim-test.yml passes on the PR
- [ ] After merge, the publish workflow on main sees no gap and skips publishing (sim=false)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.1.36.
  * Publishing workflow now includes enhanced version detection with automatic retry logic to improve release reliability and ensure successful package publishing.
  * Accessibility framework initialization timeout in CI test environments has been extended to improve test stability and reduce flaky failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EvanBacon/serve-sim/pull/68?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->