### PR TITLE
Shorten skill description for agent discovery

### DIFF
--- a/skills/serve-sim/SKILL.md
+++ b/skills/serve-sim/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: serve-sim
-description: Controls a running iOS, iPad, or Apple Watch Simulator via the serve-sim CLI (npx serve-sim) and streams it into the host agent's preview pane. Use whenever the user wants an AI agent to view or drive an Apple Simulator — streaming to preview, taps at normalized coordinates, multi-touch gestures, hardware buttons, rotation, memory warnings, CoreAnimation debug, synthetic camera injection, media drag-drop, or managing app privacy permissions. Triggers include "serve-sim", "iOS simulator", "Apple simulator", "iPad simulator", "Apple Watch simulator", "stream the simulator", "show the simulator in preview", "view the simulator here", "open simulator in preview", "simulator gestures", "tap on the simulator", "rotate the simulator", "inject camera feed", "grant simulator permissions", "allow push notifications in the simulator", or any request to drive or display an Apple Simulator visually. Do NOT use for Android emulators, building/installing an iOS app (use xcodebuild), booting a simulator from scratch (use xcrun simctl boot), in-app React Native runtime debugging (use rn-debugger), or real iOS hardware.
+description: Control and stream a running iOS, iPad, or Apple Watch Simulator with npx serve-sim. Use for simulator preview, taps, gestures, hardware buttons, rotation, camera injection, permissions, accessibility, and CoreAnimation debug.
 license: Apache-2.0
 ---
 


### PR DESCRIPTION
The long description (>1024 characters) has made codex & claude code not finding the skill despite it was installed properly.

**References:**

https://agentskills.io/specification
> Description: Must be 1-1024 characters

I also think it's better to make it much shorter and not list specific triggers, otherwise the skill will take 1/4 of the applied limit for skills:
> To avoid crowding out the rest of the prompt, this list is capped at roughly 2% of the model’s context window, or 8,000 characters when the context window is unknown. 

https://developers.openai.com/codex/skills

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the serve-sim skill description to better reflect its capabilities for controlling and streaming iOS, iPadOS, and watchOS simulators, including simulator preview, gestures, hardware buttons, rotation, camera injection, permissions, and accessibility features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EvanBacon/serve-sim/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->