### PR TITLE
Narrow home-indicator swipe hot zone to bottom 7%

### DIFF
--- a/packages/serve-sim-client/src/simulator/SimulatorView.tsx
+++ b/packages/serve-sim-client/src/simulator/SimulatorView.tsx
@@ -9,6 +9,7 @@ import {
 import type { StreamConfig } from "../types.js";
 import {
   HID_EDGE_BOTTOM,
+  homeIndicatorEdge,
   rawEdgeForDisplayEdge,
   rawPointForDisplayPoint,
   streamDisplayGeometry,
@@ -66,9 +67,9 @@ export interface SimulatorViewProps {
  * Connects directly to the serve-sim server (not through the gateway).
  *
  * Touch input is forwarded as normalized (0–1) coordinates over WebSocket.
- * Drags starting in the bottom 12% of the image (y > 0.88) are sent with
- * `edge: 3` (IndigoHIDEdge bottom), which iOS routes to the system gesture
- * recognizer for interactive swipe-to-home on Face ID devices.
+ * Drags starting in the home-indicator hot zone (see HOME_INDICATOR_BAND_NORM)
+ * are sent with `edge: 3` (IndigoHIDEdge bottom), which iOS routes to the
+ * system gesture recognizer for interactive swipe-to-home on Face ID devices.
  */
 export function SimulatorView({
   url,
@@ -745,9 +746,10 @@ export function SimulatorView({
             }
 
             showTouchIndicator(x, y);
-            if (y > 0.88) {
+            const edge = homeIndicatorEdge(y);
+            if (edge !== undefined) {
               edgeGestureRef.current = true;
-              sendTouch({ type: "begin", x, y, edge: HID_EDGE_BOTTOM });
+              sendTouch({ type: "begin", x, y, edge });
             } else {
               edgeGestureRef.current = false;
               handleTouch("begin", e);
@@ -896,9 +898,10 @@ export function SimulatorView({
             const x = (touch.clientX - rect.left) / rect.width;
             const y = (touch.clientY - rect.top) / rect.height;
             showTouchIndicator(x, y);
-            if (y > 0.88) {
+            const edge = homeIndicatorEdge(y);
+            if (edge !== undefined) {
               edgeGestureRef.current = true;
-              sendTouch({ type: "begin", x, y, edge: HID_EDGE_BOTTOM });
+              sendTouch({ type: "begin", x, y, edge });
             } else {
               edgeGestureRef.current = false;
               sendTouch({ type: "begin", x, y });

--- a/packages/serve-sim-client/src/simulator/orientation.ts
+++ b/packages/serve-sim-client/src/simulator/orientation.ts
@@ -5,6 +5,30 @@ export const HID_EDGE_TOP = 2;
 export const HID_EDGE_BOTTOM = 3;
 export const HID_EDGE_RIGHT = 4;
 
+/**
+ * Bottom fraction of the display treated as the home-indicator hot zone, in
+ * normalized (0–1) display coordinates. A drag that *starts* here is tagged
+ * with `HID_EDGE_BOTTOM` so iOS routes it to the interactive swipe-to-home
+ * recognizer.
+ *
+ * Kept narrow (bottom 7%). The previous 0.88 (bottom 12%) reached up into
+ * Safari's bottom URL bar, so swiping up on the URL bar to reveal the tab
+ * overview was misread as swipe-to-home. iOS only uses the flag for swipe
+ * disambiguation, so a tighter band still lets the genuine home gesture
+ * through while leaving URL-bar swipes as plain touches.
+ */
+export const HOME_INDICATOR_BAND_NORM = 0.93;
+
+/**
+ * Returns `HID_EDGE_BOTTOM` when a display-space touch beginning at normalized
+ * `y` falls inside the home-indicator hot zone, otherwise `undefined`. Edge
+ * remapping for non-portrait orientations is handled downstream by
+ * {@link rawEdgeForDisplayEdge}.
+ */
+export function homeIndicatorEdge(y: number): number | undefined {
+  return y >= HOME_INDICATOR_BAND_NORM ? HID_EDGE_BOTTOM : undefined;
+}
+
 export function isLandscapeOrientation(
   orientation?: SimulatorOrientation | null,
 ): boolean {


### PR DESCRIPTION
## Summary

Tightens the home-indicator swipe-to-home hot zone from the bottom 12% (`y > 0.88`) to the bottom 7% (`y >= 0.93`).

The previous 12% band reached up into Safari's bottom URL bar, so swiping up on the URL bar to reveal the tab overview was misread as a swipe-to-home gesture. iOS only uses the `HID_EDGE_BOTTOM` flag for swipe disambiguation, so a tighter band still lets the genuine home gesture through while leaving URL-bar swipes as plain touches.

## Changes

- Add `HOME_INDICATOR_BAND_NORM` constant and `homeIndicatorEdge(y)` helper in `orientation.ts`.
- Replace the inline `y > 0.88` checks in `SimulatorView.tsx` (both touch and pointer handlers) with `homeIndicatorEdge(y)`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the simulator's ability to accurately detect home-indicator touches at the bottom screen edge for more reliable swipe-to-home gesture recognition.
  * Enhanced edge detection logic with refined threshold calculations to reduce false-positive triggers and provide smoother interaction handling at screen boundaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EvanBacon/serve-sim/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->