### PR TITLE
Fix viewDidAppear: swizzle clobbering all view controllers

### DIFF
--- a/packages/serve-sim/Sources/SimCameraInjector/SimCamSwizzles.m
+++ b/packages/serve-sim/Sources/SimCameraInjector/SimCamSwizzles.m
@@ -49,7 +49,22 @@ static BOOL SwizzleInstanceMethod(Class cls, SEL orig, SEL swiz) {
             NSStringFromSelector(swiz));
         return NO;
     }
-    method_exchangeImplementations(o, s);
+    // `orig` may be inherited rather than implemented directly on `cls` (e.g.
+    // on iOS 26 UIImagePickerController no longer overrides viewDidAppear:).
+    // A plain method_exchangeImplementations would then mutate the *superclass*
+    // Method, clobbering that selector for every subclass — and our `swiz`
+    // selector only exists on `cls`, so unrelated controllers crash with
+    // "unrecognized selector simcam_…". Install the override directly on `cls`
+    // instead: add `orig` pointing at the swizzled IMP, and if that succeeds
+    // (no direct impl existed) repoint `swiz` at the inherited original so the
+    // [self simcam_…] call still reaches it.
+    IMP origIMP = method_getImplementation(o);
+    IMP swizIMP = method_getImplementation(s);
+    if (class_addMethod(cls, orig, swizIMP, method_getTypeEncoding(s))) {
+        class_replaceMethod(cls, swiz, origIMP, method_getTypeEncoding(o));
+    } else {
+        method_exchangeImplementations(o, s);
+    }
     return YES;
 }
 

--- a/packages/serve-sim/src/__tests__/accessibility-endpoint.test.ts
+++ b/packages/serve-sim/src/__tests__/accessibility-endpoint.test.ts
@@ -14,8 +14,9 @@ import { join } from "path";
 const CLI_PATH = join(import.meta.dir, "../../src/index.ts");
 const AX_RESPONSE_BUDGET_MS = process.env.CI ? 10_000 : 5_000;
 // The Swift helper returns 503 while the simulator's AX framework is still
-// warming up after boot. Poll past that startup window before failing.
-const AX_READY_BUDGET_MS = process.env.CI ? 60_000 : 10_000;
+// warming up after boot. A cold CI runner can take well past a minute on its
+// first AX touch, so give the startup window generous headroom before failing.
+const AX_READY_BUDGET_MS = process.env.CI ? 120_000 : 10_000;
 const AX_READY_POLL_INTERVAL_MS = 500;
 
 function firstBootedIosSim(): string | null {

--- a/packages/serve-sim/src/__tests__/permissions.e2e.test.ts
+++ b/packages/serve-sim/src/__tests__/permissions.e2e.test.ts
@@ -111,8 +111,9 @@ function locationAuth(bundleId: string): number | null {
 // Each case shells the built CLI a few times, and a cold `simctl privacy`
 // call (location) can take several seconds on a fresh CI sim — comfortably
 // past bun's 5s default. The beforeAll reset-all also cascades through every
-// permission while the sim is fully cold, so the budget has to cover that.
-const T = 90_000;
+// permission while the sim is fully cold, and that first touch has been seen
+// to run past 90s on a GitHub macOS runner, so keep the budget well above it.
+const T = 150_000;
 
 describeIfSim("serve-sim permissions (real simulator)", () => {
   beforeAll(() => {


### PR DESCRIPTION
## Problem

Attaching the camera on iOS 26 crashes the app on launch:

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason:
'-[SwiftUI.UIKitNavigationController simcam_viewDidAppear:]: unrecognized selector sent to instance'
...
14  libSimCameraInjector.dylib   -[UIImagePickerController(SimCam) simcam_viewDidAppear:] + 44
15  SwiftUI                      @objc UIKitNavigationController.viewDidAppear(_:) + 72
```

## Root cause

`SimCamInstallPickerSwizzles()` swizzled `-[UIImagePickerController viewDidAppear:]` via `method_exchangeImplementations`. On iOS 26 `UIImagePickerController` **no longer implements `viewDidAppear:` itself** — it inherits it. `class_getInstanceMethod` walks the hierarchy and returns the `Method` belonging to `UIViewController`/`UINavigationController`, so the exchange mutated the IMP on the **shared superclass method**.

Every view controller's `viewDidAppear:` then routed into `simcam_viewDidAppear:`, a selector that only exists on `UIImagePickerController`. The next unrelated controller to appear (here, SwiftUI's `UIKitNavigationController`) hit `doesNotRecognizeSelector` and aborted.

## Fix

Make `SwizzleInstanceMethod` safe against inherited methods using the standard `class_addMethod` / `class_replaceMethod` pattern: install the override **directly on the target class**, repointing the swizzled selector at the inherited original IMP so `[self simcam_…]` still reaches it. Fall back to `method_exchangeImplementations` only when the class already has a direct implementation (preserving existing behavior for all the AV* swizzles).

## Verification

Rebuilt the dylib and drove the documented camera e2e flow against an iOS 26.2 simulator (`serve-sim camera dev.servesim.SimCamTest`). The app now launches and renders the streamed placeholder feed (`running=1 frames=508 1280x720`), surviving the exact `viewDidAppear:` path that previously aborted. All injector swizzles install cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved camera injection behavior to handle inherited method implementations more robustly, reducing edge-case failures.
* **Tests**
  * Increased CI test startup/time budgets to reduce flaky timeouts for accessibility and permissions end-to-end tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EvanBacon/serve-sim/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->