### PR TITLE
Add Android support to serve-sim

### DIFF
--- a/packages/serve-sim-client/src/simulator/SimulatorView.tsx
+++ b/packages/serve-sim-client/src/simulator/SimulatorView.tsx
@@ -234,6 +234,7 @@ export function SimulatorView({
       if (!connectedRef.current) {
         clearTimeout(watchdog);
         setConnected(true);
+        onStreamingChangeRef.current?.(true);
         setError(null);
       }
     });
@@ -285,6 +286,7 @@ export function SimulatorView({
         clearTimeout(slowWatchdog);
         clearTimeout(errorWatchdog);
         setConnected(true);
+        onStreamingChangeRef.current?.(true);
         setError(null);
       }
     });
@@ -488,14 +490,13 @@ export function SimulatorView({
     };
   }, [url, streamUrl, relayMode, updateScreenConfig, wsUrlProp]);
 
-  // FPS counter + stale-frame detection for relay mode.
-  // Unlike non-relay mode (where WS close flips connected=false), relay mode
-  // only knows the stream is alive when frames arrive. Without this, killing
-  // the upstream helper leaves the UI stuck on "live" forever.
+  // FPS counter + stale-frame detection for MJPEG relay mode. Android H.264 can
+  // legitimately pause decoded frames on an idle screen after the first image.
   useEffect(() => {
     if (!relayMode) return;
-    const STALE_MS = videoRelayMode ? 8000 : 2000;
+    const STALE_MS = 2000;
     const checkStaleness = () => {
+      if (videoRelayMode) return;
       const last = lastFrameAtRef.current;
       if (!last || !connectedRef.current) return;
       if (Date.now() - last > STALE_MS) setConnected(false);
@@ -803,34 +804,34 @@ export function SimulatorView({
               touchAction: "none",
             }}
             onMouseDown={(e) => {
-            e.preventDefault();
-            const rect = getInputRect();
-            if (!rect) return;
-            const x = (e.clientX - rect.left) / rect.width;
-            const y = (e.clientY - rect.top) / rect.height;
+              e.preventDefault();
+              const rect = getInputRect();
+              if (!rect) return;
+              const x = (e.clientX - rect.left) / rect.width;
+              const y = (e.clientY - rect.top) / rect.height;
 
-            if (e.altKey) {
-              // Multi-touch mode: begin gesture
-              multiTouchActiveRef.current = true;
-              multiTouchShiftRef.current = e.shiftKey;
-              const fingers = { x1: x, y1: y, x2: 1.0 - x, y2: 1.0 - y };
-              // For pan mode, lock the offset between fingers
-              panOffsetRef.current = { dx: 1.0 - x - x, dy: 1.0 - y - y };
-              setFingerIndicators(fingers);
-              sendMultiTouch({ type: "begin", ...fingers });
-              return;
-            }
+              if (e.altKey) {
+                // Multi-touch mode: begin gesture
+                multiTouchActiveRef.current = true;
+                multiTouchShiftRef.current = e.shiftKey;
+                const fingers = { x1: x, y1: y, x2: 1.0 - x, y2: 1.0 - y };
+                // For pan mode, lock the offset between fingers
+                panOffsetRef.current = { dx: 1.0 - x - x, dy: 1.0 - y - y };
+                setFingerIndicators(fingers);
+                sendMultiTouch({ type: "begin", ...fingers });
+                return;
+              }
 
-            showTouchIndicator(x, y);
-            const edge = homeIndicatorEdge(y);
-            if (edge !== undefined) {
-              edgeGestureRef.current = true;
-              sendTouch({ type: "begin", x, y, edge });
-            } else {
-              edgeGestureRef.current = false;
-              handleTouch("begin", e);
-            }
-          }}
+              showTouchIndicator(x, y);
+              const edge = homeIndicatorEdge(y);
+              if (edge !== undefined) {
+                edgeGestureRef.current = true;
+                sendTouch({ type: "begin", x, y, edge });
+              } else {
+                edgeGestureRef.current = false;
+                handleTouch("begin", e);
+              }
+            }}
           onMouseMove={(e) => {
             const rect = getInputRect();
             if (!rect) return;

--- a/packages/serve-sim-client/src/simulator/SimulatorView.tsx
+++ b/packages/serve-sim-client/src/simulator/SimulatorView.tsx
@@ -122,6 +122,9 @@ export function SimulatorView({
   }, []);
   const [fps, setFps] = useState(0);
   const frameCountRef = useRef(0);
+  const lastFrameAtRef = useRef(0);
+  const hasReceivedFrameRef = useRef(false);
+  const [hasReceivedFrame, setHasReceivedFrame] = useState(false);
   const [showSlowOverlay, setShowSlowOverlay] = useState(false);
   const slowOverlayTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -150,7 +153,11 @@ export function SimulatorView({
 
   useEffect(() => {
     screenSizeRef.current = null;
+    lastFrameAtRef.current = 0;
+    hasReceivedFrameRef.current = false;
     setScreenSize(null);
+    setConnected(false);
+    setHasReceivedFrame(false);
   }, [url]);
 
   const updateScreenConfig = useCallback((config: StreamConfig | null | undefined) => {
@@ -206,6 +213,10 @@ export function SimulatorView({
     const unsubscribe = subscribeFrame((blobUrl) => {
       frameCountRef.current++;
       lastFrameAtRef.current = Date.now();
+      if (!hasReceivedFrameRef.current) {
+        hasReceivedFrameRef.current = true;
+        setHasReceivedFrame(true);
+      }
       const img = relayImgRef.current;
       if (img) {
         // Revoke the previous blob URL to avoid memory leaks
@@ -254,6 +265,10 @@ export function SimulatorView({
 
       frameCountRef.current++;
       lastFrameAtRef.current = Date.now();
+      if (!hasReceivedFrameRef.current) {
+        hasReceivedFrameRef.current = true;
+        setHasReceivedFrame(true);
+      }
       if (!connectedRef.current) {
         clearTimeout(watchdog);
         setConnected(true);
@@ -463,10 +478,9 @@ export function SimulatorView({
   // Unlike non-relay mode (where WS close flips connected=false), relay mode
   // only knows the stream is alive when frames arrive. Without this, killing
   // the upstream helper leaves the UI stuck on "live" forever.
-  const lastFrameAtRef = useRef(0);
   useEffect(() => {
     if (!relayMode) return;
-    const STALE_MS = 2000;
+    const STALE_MS = videoRelayMode ? 8000 : 2000;
     const checkStaleness = () => {
       const last = lastFrameAtRef.current;
       if (!last || !connectedRef.current) return;
@@ -486,7 +500,7 @@ export function SimulatorView({
       clearInterval(interval);
       document.removeEventListener("visibilitychange", onVis);
     };
-  }, [relayMode]);
+  }, [relayMode, videoRelayMode]);
 
   const getViewElement = useCallback(() => {
     if (videoRelayMode) return relayCanvasRef.current;
@@ -1056,7 +1070,7 @@ export function SimulatorView({
             />
           </>
         )}
-        {!connected && !error && (
+        {!connected && !error && !hasReceivedFrame && (
           <div style={{...overlayStyle, ...(imageStyle || {})}}>
             <span style={{ color: "#888", fontSize: 14 }}>Connecting...</span>
           </div>

--- a/packages/serve-sim-client/src/simulator/SimulatorView.tsx
+++ b/packages/serve-sim-client/src/simulator/SimulatorView.tsx
@@ -23,6 +23,9 @@ const WS_MSG_TOUCH = 0x03;
 const WS_MSG_BUTTON = 0x04;
 const WS_MSG_MULTI_TOUCH = 0x05;
 const WS_MSG_DIGITAL_CROWN = 0x0a;
+const RELAY_STARTUP_ERROR_MS = 6000;
+const VIDEO_RELAY_STARTUP_ERROR_MS = 30000;
+const VIDEO_RELAY_STARTUP_SLOW_MS = 8000;
 
 export interface SimulatorViewProps {
   /** Base URL of the serve-sim server, e.g. "http://localhost:3100" */
@@ -125,6 +128,7 @@ export function SimulatorView({
   const lastFrameAtRef = useRef(0);
   const hasReceivedFrameRef = useRef(false);
   const [hasReceivedFrame, setHasReceivedFrame] = useState(false);
+  const [startupSlow, setStartupSlow] = useState(false);
   const [showSlowOverlay, setShowSlowOverlay] = useState(false);
   const slowOverlayTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -158,6 +162,8 @@ export function SimulatorView({
     setScreenSize(null);
     setConnected(false);
     setHasReceivedFrame(false);
+    setStartupSlow(false);
+    setError(null);
   }, [url]);
 
   const updateScreenConfig = useCallback((config: StreamConfig | null | undefined) => {
@@ -204,12 +210,11 @@ export function SimulatorView({
     // the window. Catches the silent-failure mode where the helper accepts
     // the MJPEG connection but its underlying simulator was shut down —
     // /stream.mjpeg keeps the socket open forever without emitting bytes.
-    const STARTUP_MS = 6000;
     const watchdog = setTimeout(() => {
       if (!connectedRef.current) {
         setError("Stream is not producing frames. The simulator may have stopped — try reconnecting.");
       }
-    }, STARTUP_MS);
+    }, RELAY_STARTUP_ERROR_MS);
     const unsubscribe = subscribeFrame((blobUrl) => {
       frameCountRef.current++;
       lastFrameAtRef.current = Date.now();
@@ -244,12 +249,18 @@ export function SimulatorView({
 
   useEffect(() => {
     if (!videoRelayMode || !subscribeVideoFrame) return;
-    const STARTUP_MS = 6000;
-    const watchdog = setTimeout(() => {
-      if (!connectedRef.current) {
-        setError("Stream is not producing frames. The simulator may have stopped — try reconnecting.");
+    setError(null);
+    setStartupSlow(false);
+    const slowWatchdog = setTimeout(() => {
+      if (!connectedRef.current && !hasReceivedFrameRef.current) {
+        setStartupSlow(true);
       }
-    }, STARTUP_MS);
+    }, VIDEO_RELAY_STARTUP_SLOW_MS);
+    const errorWatchdog = setTimeout(() => {
+      if (!connectedRef.current && !hasReceivedFrameRef.current) {
+        setError("Android stream is still starting. Try reconnecting if it does not appear.");
+      }
+    }, VIDEO_RELAY_STARTUP_ERROR_MS);
 
     const unsubscribe = subscribeVideoFrame((frame) => {
       const width = Number(frame.displayWidth || frame.codedWidth || 0);
@@ -269,15 +280,18 @@ export function SimulatorView({
         hasReceivedFrameRef.current = true;
         setHasReceivedFrame(true);
       }
+      setStartupSlow(false);
       if (!connectedRef.current) {
-        clearTimeout(watchdog);
+        clearTimeout(slowWatchdog);
+        clearTimeout(errorWatchdog);
         setConnected(true);
         setError(null);
       }
     });
 
     return () => {
-      clearTimeout(watchdog);
+      clearTimeout(slowWatchdog);
+      clearTimeout(errorWatchdog);
       unsubscribe?.();
     };
   }, [videoRelayMode, subscribeVideoFrame, updateScreenConfig]);
@@ -1072,7 +1086,9 @@ export function SimulatorView({
         )}
         {!connected && !error && !hasReceivedFrame && (
           <div style={{...overlayStyle, ...(imageStyle || {})}}>
-            <span style={{ color: "#888", fontSize: 14 }}>Connecting...</span>
+            <span style={{ color: "#888", fontSize: 14 }}>
+              {startupSlow ? "Starting video..." : "Connecting..."}
+            </span>
           </div>
         )}
         {error && (

--- a/packages/serve-sim-client/src/simulator/SimulatorView.tsx
+++ b/packages/serve-sim-client/src/simulator/SimulatorView.tsx
@@ -50,6 +50,8 @@ export interface SimulatorViewProps {
   subscribeFrame?: (cb: (blobUrl: string) => void) => () => void;
   /** Relay mode: latest blob URL JPEG frame from the relay (used for initial render) */
   streamFrame?: string | null;
+  /** Relay mode: subscribe to decoded video frames. Callback must draw synchronously. */
+  subscribeVideoFrame?: (cb: (frame: any) => void) => () => void;
   /** Relay mode: screen config from relay */
   streamConfig?: StreamConfig | null;
   /** Called when the rendered stream reports new dimensions or orientation. */
@@ -85,6 +87,7 @@ export function SimulatorView({
   enableDigitalCrown,
   subscribeFrame,
   streamFrame: _streamFrame,
+  subscribeVideoFrame,
   streamConfig,
   onScreenConfigChange,
   hideControls,
@@ -92,8 +95,10 @@ export function SimulatorView({
   connectionQuality,
 }: SimulatorViewProps) {
   const relayMode = !!onStreamTouch;
+  const videoRelayMode = relayMode && !!subscribeVideoFrame;
   const imgRef = useRef<HTMLImageElement | null>(null);
   const relayImgRef = useRef<HTMLImageElement | null>(null);
+  const relayCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const surfaceRef = useRef<HTMLDivElement | null>(null);
   const inputLayerRef = useRef<HTMLDivElement | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
@@ -187,7 +192,7 @@ export function SimulatorView({
   connectedRef.current = connected;
   const prevBlobUrlRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!relayMode || !subscribeFrame) return;
+    if (!relayMode || videoRelayMode || !subscribeFrame) return;
     // Startup watchdog: flag the stream as broken if no frame arrives within
     // the window. Catches the silent-failure mode where the helper accepts
     // the MJPEG connection but its underlying simulator was shut down —
@@ -224,7 +229,43 @@ export function SimulatorView({
         prevBlobUrlRef.current = null;
       }
     };
-  }, [relayMode, subscribeFrame]);
+  }, [relayMode, videoRelayMode, subscribeFrame]);
+
+  useEffect(() => {
+    if (!videoRelayMode || !subscribeVideoFrame) return;
+    const STARTUP_MS = 6000;
+    const watchdog = setTimeout(() => {
+      if (!connectedRef.current) {
+        setError("Stream is not producing frames. The simulator may have stopped — try reconnecting.");
+      }
+    }, STARTUP_MS);
+
+    const unsubscribe = subscribeVideoFrame((frame) => {
+      const width = Number(frame.displayWidth || frame.codedWidth || 0);
+      const height = Number(frame.displayHeight || frame.codedHeight || 0);
+      const canvas = relayCanvasRef.current;
+      const ctx = canvas?.getContext("2d", { alpha: false });
+      if (!canvas || !ctx || width <= 0 || height <= 0) return;
+
+      if (canvas.width !== width) canvas.width = width;
+      if (canvas.height !== height) canvas.height = height;
+      ctx.drawImage(frame, 0, 0, width, height);
+      updateScreenConfig({ width, height });
+
+      frameCountRef.current++;
+      lastFrameAtRef.current = Date.now();
+      if (!connectedRef.current) {
+        clearTimeout(watchdog);
+        setConnected(true);
+        setError(null);
+      }
+    });
+
+    return () => {
+      clearTimeout(watchdog);
+      unsubscribe?.();
+    };
+  }, [videoRelayMode, subscribeVideoFrame, updateScreenConfig]);
 
   const sendTouch = useCallback(
     (touch: {
@@ -448,8 +489,9 @@ export function SimulatorView({
   }, [relayMode]);
 
   const getViewElement = useCallback(() => {
+    if (videoRelayMode) return relayCanvasRef.current;
     return relayMode ? relayImgRef.current : imgRef.current;
-  }, [relayMode]);
+  }, [relayMode, videoRelayMode]);
 
   const getInputRect = useCallback(() => {
     return surfaceRef.current?.getBoundingClientRect()
@@ -692,21 +734,9 @@ export function SimulatorView({
             cornerShape: clipStyle?.cornerShape,
           } as CSSProperties}
         >
-        <img
-          ref={imgRef}
-          src={relayMode ? undefined : streamUrl}
-          draggable={false}
-          onLoad={(e) => {
-            const el = e.currentTarget;
-            if (el.naturalWidth > 0 && el.naturalHeight > 0) {
-              updateScreenConfig({ width: el.naturalWidth, height: el.naturalHeight });
-            }
-          }}
-          style={relayMode ? { display: "none" } : streamImageStyle}
-        />
-        {relayMode && (
           <img
-            ref={relayImgRef}
+            ref={imgRef}
+            src={relayMode ? undefined : streamUrl}
             draggable={false}
             onLoad={(e) => {
               const el = e.currentTarget;
@@ -714,19 +744,37 @@ export function SimulatorView({
                 updateScreenConfig({ width: el.naturalWidth, height: el.naturalHeight });
               }
             }}
-            style={streamImageStyle}
+            style={relayMode ? { display: "none" } : streamImageStyle}
           />
-        )}
-        {/* Interactive overlay — captures all pointer events */}
-        <div
-          ref={inputLayerRef}
-          style={{
-            position: "absolute",
-            inset: 0,
-            cursor: FINGER_CURSOR,
-            touchAction: "none",
-          }}
-          onMouseDown={(e) => {
+          {relayMode && !videoRelayMode && (
+            <img
+              ref={relayImgRef}
+              draggable={false}
+              onLoad={(e) => {
+                const el = e.currentTarget;
+                if (el.naturalWidth > 0 && el.naturalHeight > 0) {
+                  updateScreenConfig({ width: el.naturalWidth, height: el.naturalHeight });
+                }
+              }}
+              style={streamImageStyle}
+            />
+          )}
+          {videoRelayMode && (
+            <canvas
+              ref={relayCanvasRef}
+              style={streamImageStyle}
+            />
+          )}
+          {/* Interactive overlay — captures all pointer events */}
+          <div
+            ref={inputLayerRef}
+            style={{
+              position: "absolute",
+              inset: 0,
+              cursor: FINGER_CURSOR,
+              touchAction: "none",
+            }}
+            onMouseDown={(e) => {
             e.preventDefault();
             const rect = getInputRect();
             if (!rect) return;

--- a/packages/serve-sim-client/src/simulator/deviceFrames.tsx
+++ b/packages/serve-sim-client/src/simulator/deviceFrames.tsx
@@ -9,7 +9,7 @@ import {
   isLandscapeConfig,
 } from "./orientation.js";
 
-export type DeviceType = "iphone" | "ipad" | "watch" | "vision";
+export type DeviceType = "iphone" | "ipad" | "watch" | "vision" | "android";
 
 export function getDeviceType(name?: string | null): DeviceType {
   if (!name) return "iphone";
@@ -17,6 +17,7 @@ export function getDeviceType(name?: string | null): DeviceType {
   if (lower.includes("ipad")) return "ipad";
   if (lower.includes("watch")) return "watch";
   if (lower.includes("vision")) return "vision";
+  if (lower.includes("pixel") || lower.includes("android") || lower.includes("sdk")) return "android";
   return "iphone";
 }
 
@@ -26,6 +27,7 @@ export const DEVICE_FRAMES = {
   ipad: { width: 430, height: 605, bezelX: 16, bezelY: 16, innerRadius: 12 },
   watch: { width: 274, height: 322, bezelX: 12, bezelY: 12, innerRadius: 79 },
   vision: { width: 640, height: 400, bezelX: 12, bezelY: 12, innerRadius: 32 },
+  android: { width: 420, height: 880, bezelX: 14, bezelY: 14, innerRadius: 36 },
 } as const;
 
 // Legacy named exports for backwards compat
@@ -115,6 +117,8 @@ export function simulatorMaxWidth(
         return 720;
       case "vision":
         return 580;
+      case "android":
+        return 620;
       case "watch":
         return 200;
       default:
@@ -128,6 +132,8 @@ export function simulatorMaxWidth(
       return 200;
     case "vision":
       return 580;
+    case "android":
+      return 320;
     default:
       return 320;
   }
@@ -241,6 +247,8 @@ export function DeviceFrameChrome({ type = "iphone", streaming = false }: { type
       return <WatchFrameChrome streaming={streaming} />;
     case "vision":
       return <VisionProFrameChrome streaming={streaming} />;
+    case "android":
+      return <AndroidFrameChrome streaming={streaming} />;
     default:
       return <PhoneFrameChrome streaming={streaming} />;
   }
@@ -460,6 +468,48 @@ function VisionProFrameChrome({ streaming = false }: { streaming?: boolean }) {
       {/* Front sensors (EyeSight display area indicator) */}
       <ellipse cx={w / 2} cy={h / 2} rx={w / 2 - 30} ry={h / 2 - 24} stroke="#4a4a4d" strokeWidth="0.5" opacity="0.3"
         style={{ opacity: streaming ? 0 : 0.3, transition: 'opacity 0.3s ease' }}
+      />
+    </svg>
+  );
+}
+
+function AndroidFrameChrome({ streaming = false }: { streaming?: boolean }) {
+  const w = DEVICE_FRAMES.android.width;
+  const h = DEVICE_FRAMES.android.height;
+  const outerRx = 46;
+  const innerRx = 40;
+
+  return (
+    <svg viewBox={`0 0 ${w} ${h}`} style={{ width: '100%', height: '100%' }} fill="none" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <filter id="android-glow0" x="0" y="0" width={w} height={h} filterUnits="userSpaceOnUse" colorInterpolationFilters="sRGB">
+          <feFlood floodOpacity="0" result="BackgroundImageFix" />
+          <feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape" />
+          <feGaussianBlur stdDeviation="0.5" result="blur" />
+        </filter>
+      </defs>
+      <rect x="0.833" y="0.833" width={w - 1.666} height={h - 1.666} rx={outerRx} stroke="#37373a" strokeWidth="1.666" />
+      <rect x="3.5" y="3.5" width={w - 7} height={h - 7} rx={innerRx} stroke="#454548" strokeWidth="4" />
+      <g opacity="0.9" filter="url(#android-glow0)">
+        <rect x="1.5" y="1.5" width={w - 3} height={h - 3} rx={outerRx - 1} stroke="#545458" strokeWidth="1.666" />
+      </g>
+      <circle
+        cx={w / 2}
+        cy={22}
+        r="5"
+        fill="#111"
+        stroke="#343438"
+        strokeWidth="1"
+        style={{ opacity: streaming ? 0 : 1, transition: 'opacity 0.3s ease' }}
+      />
+      <rect
+        x={(w - 116) / 2}
+        y={h - 20}
+        width="116"
+        height="4"
+        rx="2"
+        fill="white"
+        style={{ opacity: streaming ? 0 : 0.55, transition: 'opacity 0.3s ease' }}
       />
     </svg>
   );

--- a/packages/serve-sim/dev.ts
+++ b/packages/serve-sim/dev.ts
@@ -158,8 +158,9 @@ function endpoint(path: string, device: string): string {
   return `/${path}?device=${encodeURIComponent(device)}`;
 }
 
-function platformFromBody(value: unknown): Platform {
-  return value === "android" ? "android" : "ios";
+function platformFromBody(value: unknown): Platform | null {
+  if (value == null) return "ios";
+  return value === "ios" || value === "android" ? value : null;
 }
 
 function isValidDeviceId(value: string, platform: Platform): boolean {
@@ -420,6 +421,9 @@ Bun.serve({
       return req.json().then((body: any) => {
         const udid: string = body?.udid ?? "";
         const platform = platformFromBody(body?.platform);
+        if (!platform) {
+          return Response.json({ ok: false, error: "Invalid platform" }, { status: 400 });
+        }
         if (!isValidDeviceId(udid, platform)) {
           return Response.json({ ok: false, error: "Invalid or missing device id" }, { status: 400 });
         }
@@ -457,6 +461,9 @@ Bun.serve({
       return req.json().then((body: any) => {
         const udid: string = body?.udid ?? "";
         const platform = platformFromBody(body?.platform);
+        if (!platform) {
+          return Response.json({ ok: false, error: "Invalid platform" }, { status: 400 });
+        }
         if (!isValidDeviceId(udid, platform)) {
           return Response.json({ ok: false, error: "Invalid or missing device id" }, { status: 400 });
         }

--- a/packages/serve-sim/dev.ts
+++ b/packages/serve-sim/dev.ts
@@ -11,6 +11,7 @@ import { tmpdir } from "os";
 import { join, resolve } from "path";
 import tailwindPlugin from "bun-plugin-tailwind";
 import { createAxStreamerCache } from "./src/ax";
+import { androidDeviceBootStatus, shutdownAndroidDevice } from "./src/android-device";
 
 const RN_BUNDLE_IDS = new Set<string>([
   "host.exp.Exponent",
@@ -62,10 +63,15 @@ type ServeSimState = {
   pid: number;
   port: number;
   device: string;
+  platform?: "ios" | "android";
+  name?: string;
+  runtime?: string;
   url: string;
   streamUrl: string;
   wsUrl: string;
 };
+
+type Platform = "ios" | "android";
 
 // ─── Serve-sim state ───
 
@@ -124,7 +130,9 @@ function readServeSimStates(): ServeSimState[] {
       // Helper alive but bound to a shutdown simulator — the Swift helper
       // keeps accepting MJPEG connections and /health returns OK, but no
       // frames ever flow. Recycle so a fresh helper is spawned on demand.
-      if (booted && !booted.has(state.device)) {
+      const platform = state.platform ?? "ios";
+      const androidGone = platform === "android" && androidDeviceBootStatus(state.device) === "not_booted";
+      if ((platform === "ios" && booted && !booted.has(state.device)) || androidGone) {
         console.error(
           `\x1b[33m[serve-sim] Recycling stale helper pid ${state.pid} — device ${state.device} is no longer booted.\x1b[0m`,
         );
@@ -150,6 +158,22 @@ function endpoint(path: string, device: string): string {
   return `/${path}?device=${encodeURIComponent(device)}`;
 }
 
+function platformFromBody(value: unknown): Platform {
+  return value === "android" ? "android" : "ios";
+}
+
+function isValidDeviceId(value: string, platform: Platform): boolean {
+  if (!value) return false;
+  return platform === "android"
+    ? /^[A-Za-z0-9_.:-]+$/.test(value)
+    : /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i.test(value);
+}
+
+function stopServeSimState(state: ServeSimState): void {
+  try { process.kill(state.pid, "SIGTERM"); } catch {}
+  try { unlinkSync(join(STATE_DIR, `server-${state.device}.json`)); } catch {}
+}
+
 function previewConfigForState(state: ServeSimState) {
   return {
     ...state,
@@ -157,6 +181,8 @@ function previewConfigForState(state: ServeSimState) {
     logsEndpoint: endpoint("logs", state.device),
     appStateEndpoint: endpoint("appstate", state.device),
     axEndpoint: endpoint("ax", state.device),
+    gridStartEndpoint: "/grid/api/start",
+    gridShutdownEndpoint: "/grid/api/shutdown",
     serveSimBin: SERVE_SIM_BIN,
   };
 }
@@ -393,11 +419,12 @@ Bun.serve({
     if (url.pathname === "/grid/api/start" && req.method === "POST") {
       return req.json().then((body: any) => {
         const udid: string = body?.udid ?? "";
-        if (!/^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i.test(udid)) {
-          return Response.json({ ok: false, error: "Invalid or missing udid" }, { status: 400 });
+        const platform = platformFromBody(body?.platform);
+        if (!isValidDeviceId(udid, platform)) {
+          return Response.json({ ok: false, error: "Invalid or missing device id" }, { status: 400 });
         }
         return new Promise<Response>((resolve) => {
-          const child = spawn("bun", [SERVE_SIM_BIN, "--detach", udid], {
+          const child = spawn("bun", [SERVE_SIM_BIN, "--detach", "--platform", platform, udid], {
             stdio: ["ignore", "pipe", "pipe"],
             detached: false,
           });
@@ -409,7 +436,12 @@ Bun.serve({
           child.on("close", (code) => {
             clearTimeout(timer);
             if (code === 0) {
-              resolve(Response.json({ ok: true, stdout: stdout.trim() }));
+              let device = udid;
+              try {
+                const parsed = JSON.parse(stdout.trim());
+                device = parsed.device ?? device;
+              } catch {}
+              resolve(Response.json({ ok: true, stdout: stdout.trim(), device }));
             } else {
               resolve(Response.json({
                 ok: false,
@@ -424,10 +456,27 @@ Bun.serve({
     if (url.pathname === "/grid/api/shutdown" && req.method === "POST") {
       return req.json().then((body: any) => {
         const udid: string = body?.udid ?? "";
-        if (!/^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i.test(udid)) {
-          return Response.json({ ok: false, error: "Invalid or missing udid" }, { status: 400 });
+        const platform = platformFromBody(body?.platform);
+        if (!isValidDeviceId(udid, platform)) {
+          return Response.json({ ok: false, error: "Invalid or missing device id" }, { status: 400 });
         }
         bootedSnapshot = { at: 0, booted: null };
+        if (platform === "android") {
+          const state = readServeSimStates().find((s) => s.device === udid && (s.platform ?? "ios") === "android");
+          if (state && !udid.startsWith("emulator-")) {
+            stopServeSimState(state);
+            return Response.json({ ok: true, stopped: true, shutdown: false });
+          }
+          try {
+            shutdownAndroidDevice(udid);
+            return Response.json({ ok: true });
+          } catch (err) {
+            return Response.json({
+              ok: false,
+              error: err instanceof Error ? err.message : String(err),
+            }, { status: 500 });
+          }
+        }
         return new Promise<Response>((resolve) => {
           execFile("xcrun", ["simctl", "shutdown", udid], { timeout: 30_000 }, (err, _stdout, stderr) => {
             if (err) {

--- a/packages/serve-sim/src/__tests__/android-device-controls.test.tsx
+++ b/packages/serve-sim/src/__tests__/android-device-controls.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { SimulatorToolbar } from "serve-sim-client/simulator";
+import { AndroidDeviceControls } from "../client/components/android-device-controls";
+
+describe("AndroidDeviceControls", () => {
+  test("renders Android emulator-style hardware and navigation buttons", () => {
+    const html = renderToStaticMarkup(
+      <SimulatorToolbar
+        exec={async () => ({ stdout: "", stderr: "", exitCode: 0 })}
+        deviceUdid="emulator-5554"
+        deviceName="Pixel 8"
+        deviceRuntime="Android"
+        streaming
+      >
+        <SimulatorToolbar.Actions>
+          <AndroidDeviceControls onButton={() => {}} />
+        </SimulatorToolbar.Actions>
+      </SimulatorToolbar>,
+    );
+
+    expect(html).toContain('aria-label="Android Back"');
+    expect(html).toContain('aria-label="Android Home"');
+    expect(html).toContain('aria-label="Android Recents"');
+    expect(html).toContain('aria-label="Android Volume Down"');
+    expect(html).toContain('aria-label="Android Volume Up"');
+    expect(html).toContain('aria-label="Android Power"');
+  });
+});

--- a/packages/serve-sim/src/__tests__/android-device.test.ts
+++ b/packages/serve-sim/src/__tests__/android-device.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { androidInputTextArg, parseAdbDevices, parseWmSize } from "../android-device";
+import {
+  androidInputTextArg,
+  parseAdbDevices,
+  parseWmSize,
+  shutdownAndroidDevice,
+} from "../android-device";
 import { androidKeyCodeForHidUsage, parsePngDimensions } from "../android-helper";
 
 describe("Android device parsing", () => {
@@ -40,6 +45,10 @@ ZY22 offline usb:336592896X product:oriole model:Pixel_6 device:oriole
   test("escapes text for adb input text", () => {
     expect(androidInputTextArg("Hi there 100%")).toBe("Hi%sthere%s100%25");
     expect(androidInputTextArg("a&b")).toBe("a\\&b");
+  });
+
+  test("refuses to power off physical Android devices", () => {
+    expect(() => shutdownAndroidDevice("ZY22")).toThrow("Physical Android devices");
   });
 });
 

--- a/packages/serve-sim/src/__tests__/android-device.test.ts
+++ b/packages/serve-sim/src/__tests__/android-device.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
+  androidBootStatusFromAdbError,
+  androidBootStatusFromAdbGetState,
   androidInputTextArg,
   parseAdbDevices,
   parseWmSize,
@@ -45,6 +47,16 @@ ZY22 offline usb:336592896X product:oriole model:Pixel_6 device:oriole
   test("escapes text for adb input text", () => {
     expect(androidInputTextArg("Hi there 100%")).toBe("Hi%sthere%s100%25");
     expect(androidInputTextArg("a&b")).toBe("a\\&b");
+  });
+
+  test("distinguishes confirmed shutdown from unknown adb failures", () => {
+    expect(androidBootStatusFromAdbGetState("device\n")).toBe("booted");
+    expect(androidBootStatusFromAdbGetState("offline\n")).toBe("not_booted");
+    expect(androidBootStatusFromAdbError({
+      stderr: Buffer.from("error: device 'emulator-5554' not found"),
+    })).toBe("not_booted");
+    expect(androidBootStatusFromAdbError(new Error("adb get-state timed out"))).toBe("unknown");
+    expect(androidBootStatusFromAdbError(new Error("adb not found"))).toBe("unknown");
   });
 
   test("refuses to power off physical Android devices", () => {

--- a/packages/serve-sim/src/__tests__/android-device.test.ts
+++ b/packages/serve-sim/src/__tests__/android-device.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { androidInputTextArg, parseAdbDevices, parseWmSize } from "../android-device";
+import { androidKeyCodeForHidUsage, parsePngDimensions } from "../android-helper";
+
+describe("Android device parsing", () => {
+  test("parses adb devices -l output", () => {
+    expect(parseAdbDevices(`List of devices attached
+emulator-5554 device product:sdk_gphone64_arm64 model:sdk_gphone64_arm64 device:emu64a transport_id:1
+ZY22 offline usb:336592896X product:oriole model:Pixel_6 device:oriole
+`)).toEqual([
+      {
+        serial: "emulator-5554",
+        state: "device",
+        attrs: {
+          product: "sdk_gphone64_arm64",
+          model: "sdk_gphone64_arm64",
+          device: "emu64a",
+          transport_id: "1",
+        },
+      },
+      {
+        serial: "ZY22",
+        state: "offline",
+        attrs: {
+          usb: "336592896X",
+          product: "oriole",
+          model: "Pixel_6",
+          device: "oriole",
+        },
+      },
+    ]);
+  });
+
+  test("parses wm size output", () => {
+    expect(parseWmSize("Physical size: 1080x2400")).toEqual({ width: 1080, height: 2400 });
+    expect(parseWmSize("Override size: 720x1280")).toEqual({ width: 720, height: 1280 });
+    expect(parseWmSize("no size here")).toBeNull();
+  });
+
+  test("escapes text for adb input text", () => {
+    expect(androidInputTextArg("Hi there 100%")).toBe("Hi%sthere%s100%25");
+    expect(androidInputTextArg("a&b")).toBe("a\\&b");
+  });
+});
+
+describe("Android helper parsing", () => {
+  test("reads PNG dimensions from IHDR", () => {
+    const png = new Uint8Array(24);
+    png.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const view = new DataView(png.buffer);
+    view.setUint32(16, 1080);
+    view.setUint32(20, 2400);
+    expect(parsePngDimensions(png)).toEqual({ width: 1080, height: 2400 });
+  });
+
+  test("maps common HID usages to Android keycodes", () => {
+    expect(androidKeyCodeForHidUsage(0x04)).toBe(29);
+    expect(androidKeyCodeForHidUsage(0x1e)).toBe(8);
+    expect(androidKeyCodeForHidUsage(0x27)).toBe(7);
+    expect(androidKeyCodeForHidUsage(0x2c)).toBe(62);
+    expect(androidKeyCodeForHidUsage(0xe1)).toBeNull();
+  });
+});

--- a/packages/serve-sim/src/__tests__/drop.test.ts
+++ b/packages/serve-sim/src/__tests__/drop.test.ts
@@ -47,4 +47,29 @@ describe("uploadDroppedFile", () => {
       /^adb -s 'emulator-5554' shell am broadcast -a android\.intent\.action\.MEDIA_SCANNER_SCAN_FILE -d 'file:\/\/\/sdcard\/Download\/serve-sim-upload-[^']+\.jpg'$/.test(command),
     )).toBe(true);
   });
+
+  test("rejects platform-incompatible app packages before uploading", async () => {
+    const commands: string[] = [];
+    const exec = createExecRecorder(commands);
+
+    await expect(uploadDroppedFile(
+      new File(["ipa"], "app.ipa"),
+      "ipa",
+      exec,
+      "emulator-5554",
+      "android",
+      () => {},
+    )).rejects.toThrow("IPA files are not supported on android");
+
+    await expect(uploadDroppedFile(
+      new File(["apk"], "app.apk"),
+      "apk",
+      exec,
+      "A-B-C",
+      "ios",
+      () => {},
+    )).rejects.toThrow("APK files are not supported on ios");
+
+    expect(commands).toEqual([]);
+  });
 });

--- a/packages/serve-sim/src/__tests__/drop.test.ts
+++ b/packages/serve-sim/src/__tests__/drop.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { uploadDroppedFile } from "../client/utils/drop";
+import type { ExecResult } from "../client/utils/exec";
+
+function createExecRecorder(commands: string[]) {
+  return async (command: string): Promise<ExecResult> => {
+    commands.push(command);
+    return { stdout: "", stderr: "", exitCode: 0 };
+  };
+}
+
+describe("uploadDroppedFile", () => {
+  test("installs Android APKs with shell-escaped host arguments", async () => {
+    const commands: string[] = [];
+
+    await uploadDroppedFile(
+      new File(["apk"], "app.apk", { type: "application/vnd.android.package-archive" }),
+      "apk",
+      createExecRecorder(commands),
+      "emulator-5554",
+      "android",
+      () => {},
+    );
+
+    expect(commands.some((command) =>
+      /^adb -s 'emulator-5554' install -r '\/tmp\/serve-sim-install-[^']+\.apk'$/.test(command),
+    )).toBe(true);
+    expect(commands.at(-1)).toMatch(/^rm -f '\/tmp\/serve-sim-install-[^']+\.apk'$/);
+  });
+
+  test("pushes Android media and asks MediaScanner to index the copied file", async () => {
+    const commands: string[] = [];
+
+    await uploadDroppedFile(
+      new File(["jpg"], "photo.jpg", { type: "image/jpeg" }),
+      "media",
+      createExecRecorder(commands),
+      "emulator-5554",
+      "android",
+      () => {},
+    );
+
+    expect(commands.some((command) =>
+      /^adb -s 'emulator-5554' push '\/tmp\/serve-sim-upload-[^']+\.jpg' '\/sdcard\/Download\/serve-sim-upload-[^']+\.jpg'$/.test(command),
+    )).toBe(true);
+    expect(commands.some((command) =>
+      /^adb -s 'emulator-5554' shell am broadcast -a android\.intent\.action\.MEDIA_SCANNER_SCAN_FILE -d 'file:\/\/\/sdcard\/Download\/serve-sim-upload-[^']+\.jpg'$/.test(command),
+    )).toBe(true);
+  });
+});

--- a/packages/serve-sim/src/__tests__/grid-capacity-banner.test.tsx
+++ b/packages/serve-sim/src/__tests__/grid-capacity-banner.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { GridCapacityBanner } from "../client/components/grid-capacity-banner";
+
+describe("GridCapacityBanner", () => {
+  test("labels the capacity estimate as iOS simulator capacity", () => {
+    const html = renderToStaticMarkup(
+      <GridCapacityBanner
+        report={{
+          availableBytes: 4_000_000_000,
+          estimatedAdditional: 2,
+          perSimAvgBytes: 1_000_000_000,
+          perSimSource: "estimated",
+          runningSimulators: 1,
+          totalBytes: 8_000_000_000,
+        }}
+      />,
+    );
+
+    expect(html).toContain("1/3 iOS sims");
+    expect(html).not.toContain("1/3 devices");
+  });
+});

--- a/packages/serve-sim/src/__tests__/grid-device-actions.test.tsx
+++ b/packages/serve-sim/src/__tests__/grid-device-actions.test.tsx
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { GridTile } from "../client/components/grid-tile";
+import { canShutdownDevice, canStartDevice, type GridDevice } from "../client/utils/grid";
+
+const baseDevice: GridDevice = {
+  device: "emulator-5554",
+  platform: "android",
+  name: "Pixel 8",
+  runtime: "Android",
+  state: "Booted",
+  helper: null,
+};
+
+describe("Android grid actions", () => {
+  test("only offers start for booted Android devices or stopped emulators", () => {
+    expect(canStartDevice({ platform: "android", state: "Booted", runtime: "Android" })).toBe(true);
+    expect(canStartDevice({ platform: "android", state: "Shutdown", runtime: "Android Emulator" })).toBe(true);
+    expect(canStartDevice({ platform: "android", state: "Offline", runtime: "Android" })).toBe(false);
+    expect(canStartDevice({ platform: "android", state: "Unauthorized", runtime: "Android" })).toBe(false);
+    expect(canStartDevice({ platform: "ios", state: "Shutdown", runtime: "iOS-18-0" })).toBe(true);
+  });
+
+  test("only exposes shutdown for Android emulators", () => {
+    expect(canShutdownDevice("android", "emulator-5554")).toBe(true);
+    expect(canShutdownDevice("android", "ZY22")).toBe(false);
+    expect(canShutdownDevice("ios", "00000000-0000-0000-0000-000000000000")).toBe(true);
+  });
+
+  test("does not render a shutdown button for physical Android devices", () => {
+    const html = renderToStaticMarkup(
+      <GridTile
+        device={{ ...baseDevice, device: "ZY22", name: "Pixel 6" }}
+        active={false}
+        previewEndpoint="/"
+        starting={false}
+        shuttingDown={false}
+        error={null}
+        onStart={() => {}}
+        onShutdown={() => {}}
+      />,
+    );
+
+    expect(html).not.toContain("Shutdown Android emulator");
+  });
+
+  test("offers to stop a live physical Android stream without calling it shutdown", () => {
+    const html = renderToStaticMarkup(
+      <GridTile
+        device={{
+          ...baseDevice,
+          device: "ZY22",
+          name: "Pixel 6",
+          helper: {
+            port: 3300,
+            url: "http://127.0.0.1:3300",
+            streamUrl: "http://127.0.0.1:3300/stream.mjpeg",
+            wsUrl: "ws://127.0.0.1:3300/ws",
+          },
+        }}
+        active={false}
+        previewEndpoint="/"
+        starting={false}
+        shuttingDown={false}
+        error={null}
+        onStart={() => {}}
+        onShutdown={() => {}}
+      />,
+    );
+
+    expect(html).toContain("Stop Android stream");
+    expect(html).not.toContain("Shutdown Android emulator");
+  });
+
+  test("renders physical Android devices that are not online as unavailable", () => {
+    const html = renderToStaticMarkup(
+      <GridTile
+        device={{ ...baseDevice, device: "ZY22", name: "Pixel 6", state: "Offline", runtime: "Android" }}
+        active={false}
+        previewEndpoint="/"
+        starting={false}
+        shuttingDown={false}
+        error={null}
+        onStart={() => {}}
+        onShutdown={() => {}}
+      />,
+    );
+
+    expect(html).toContain("Unavailable");
+    expect(html).toContain("disabled=");
+  });
+});

--- a/packages/serve-sim/src/__tests__/h264-annex-b.test.ts
+++ b/packages/serve-sim/src/__tests__/h264-annex-b.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { H264AnnexBAccessUnitParser } from "../client/utils/h264-annex-b";
+
+function collect(...chunks: number[][]) {
+  const units: Array<{ data: number[]; type: "key" | "delta" }> = [];
+  const parser = new H264AnnexBAccessUnitParser((unit) => {
+    units.push({ data: [...unit.data], type: unit.type });
+  });
+  for (const chunk of chunks) parser.push(new Uint8Array(chunk));
+  parser.flush();
+  return units;
+}
+
+describe("H264AnnexBAccessUnitParser", () => {
+  test("groups SPS, PPS, and IDR into a key access unit", () => {
+    const units = collect([
+      0, 0, 1, 0x67, 1,
+      0, 0, 1, 0x68, 2,
+      0, 0, 1, 0x65, 0x80,
+    ]);
+
+    expect(units).toEqual([
+      {
+        data: [0, 0, 1, 0x67, 1, 0, 0, 1, 0x68, 2, 0, 0, 1, 0x65, 0x80],
+        type: "key",
+      },
+    ]);
+  });
+
+  test("splits consecutive frames across arbitrary chunks", () => {
+    const units = collect(
+      [0, 0],
+      [1, 0x65, 0x80, 0, 0, 0],
+      [1, 0x41, 0x80, 0, 0, 1, 0x41, 0x80],
+    );
+
+    expect(units).toEqual([
+      { data: [0, 0, 1, 0x65, 0x80], type: "key" },
+      { data: [0, 0, 0, 1, 0x41, 0x80], type: "delta" },
+      { data: [0, 0, 1, 0x41, 0x80], type: "delta" },
+    ]);
+  });
+
+  test("keeps multiple slices for one frame in the same access unit", () => {
+    const units = collect([
+      0, 0, 1, 0x41, 0x80,
+      0, 0, 1, 0x41, 0x40,
+      0, 0, 1, 0x41, 0x80,
+    ]);
+
+    expect(units).toEqual([
+      {
+        data: [0, 0, 1, 0x41, 0x80, 0, 0, 1, 0x41, 0x40],
+        type: "delta",
+      },
+      { data: [0, 0, 1, 0x41, 0x80], type: "delta" },
+    ]);
+  });
+
+  test("uses access unit delimiters as hard frame boundaries", () => {
+    const units = collect([
+      0, 0, 1, 0x09, 0xf0,
+      0, 0, 1, 0x65, 0x80,
+      0, 0, 1, 0x09, 0xf0,
+      0, 0, 1, 0x41, 0x80,
+    ]);
+
+    expect(units).toEqual([
+      { data: [0, 0, 1, 0x09, 0xf0, 0, 0, 1, 0x65, 0x80], type: "key" },
+      { data: [0, 0, 1, 0x09, 0xf0, 0, 0, 1, 0x41, 0x80], type: "delta" },
+    ]);
+  });
+});

--- a/packages/serve-sim/src/__tests__/h264-stream-config.test.ts
+++ b/packages/serve-sim/src/__tests__/h264-stream-config.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { preserveStreamOrientation } from "../client/hooks/use-h264-stream";
+
+describe("preserveStreamOrientation", () => {
+  test("keeps the last known orientation when decoded frames only report dimensions", () => {
+    expect(
+      preserveStreamOrientation(
+        { width: 1080, height: 2400, orientation: "landscape_left" },
+        { width: 1080, height: 2400 },
+      ),
+    ).toEqual({ width: 1080, height: 2400, orientation: "landscape_left" });
+  });
+
+  test("allows explicit orientation updates from the device config endpoint", () => {
+    expect(
+      preserveStreamOrientation(
+        { width: 1080, height: 2400, orientation: "landscape_left" },
+        { width: 1080, height: 2400, orientation: "portrait" },
+      ),
+    ).toEqual({ width: 1080, height: 2400, orientation: "portrait" });
+  });
+});

--- a/packages/serve-sim/src/__tests__/location-commands.test.ts
+++ b/packages/serve-sim/src/__tests__/location-commands.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { locationClearCommand, locationSetCommand } from "../client/utils/location-commands";
+
+describe("location command formatting", () => {
+  test("formats iOS simctl location commands", () => {
+    expect(locationSetCommand("ios", "A-B-C", { lat: 37.3349, lng: -122.00902 }))
+      .toBe("xcrun simctl location 'A-B-C' set 37.3349000,-122.0090200");
+    expect(locationClearCommand("ios", "A-B-C")).toBe("xcrun simctl location 'A-B-C' clear");
+  });
+
+  test("formats Android emulator geo fix commands with longitude before latitude", () => {
+    expect(locationSetCommand("android", "emulator-5554", { lat: 37.3349, lng: -122.00902 }))
+      .toBe("adb -s 'emulator-5554' emu geo fix -122.0090200 37.3349000");
+    expect(locationClearCommand("android", "emulator-5554")).toBeNull();
+  });
+});

--- a/packages/serve-sim/src/__tests__/middleware-selection.test.ts
+++ b/packages/serve-sim/src/__tests__/middleware-selection.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   matchInstalledAppByDisplayName,
+  normalizeRequestPlatform,
   parseForegroundAppLogMessage,
   previewConfigForState,
   rewriteStateForRequestHost,
@@ -59,6 +60,20 @@ describe("previewConfigForState", () => {
       previewEndpoint: "/preview",
       execToken: "token-xyz",
     });
+  });
+});
+
+describe("normalizeRequestPlatform", () => {
+  test("defaults missing platform to ios", () => {
+    expect(normalizeRequestPlatform(undefined)).toBe("ios");
+    expect(normalizeRequestPlatform(null)).toBe("ios");
+  });
+
+  test("accepts only known platforms", () => {
+    expect(normalizeRequestPlatform("ios")).toBe("ios");
+    expect(normalizeRequestPlatform("android")).toBe("android");
+    expect(normalizeRequestPlatform("andorid")).toBeNull();
+    expect(normalizeRequestPlatform(1)).toBeNull();
   });
 });
 

--- a/packages/serve-sim/src/__tests__/middleware-selection.test.ts
+++ b/packages/serve-sim/src/__tests__/middleware-selection.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  isValidDeviceId,
   matchInstalledAppByDisplayName,
   normalizeRequestPlatform,
   parseForegroundAppLogMessage,
@@ -74,6 +75,20 @@ describe("normalizeRequestPlatform", () => {
     expect(normalizeRequestPlatform("android")).toBe("android");
     expect(normalizeRequestPlatform("andorid")).toBeNull();
     expect(normalizeRequestPlatform(1)).toBeNull();
+  });
+});
+
+describe("isValidDeviceId", () => {
+  test("validates iOS devices as simulator UDIDs", () => {
+    expect(isValidDeviceId("01234567-89AB-CDEF-0123-456789ABCDEF", "ios")).toBe(true);
+    expect(isValidDeviceId("emulator-5554", "ios")).toBe(false);
+    expect(isValidDeviceId("not-a-uuid", "ios")).toBe(false);
+  });
+
+  test("allows Android emulator and device serials", () => {
+    expect(isValidDeviceId("emulator-5554", "android")).toBe(true);
+    expect(isValidDeviceId("ZY22:transport-1", "android")).toBe(true);
+    expect(isValidDeviceId("bad serial", "android")).toBe(false);
   });
 });
 

--- a/packages/serve-sim/src/android-device.ts
+++ b/packages/serve-sim/src/android-device.ts
@@ -293,13 +293,10 @@ export async function ensureAndroidBooted(target: AndroidTarget, logFile?: strin
 }
 
 export function shutdownAndroidDevice(serial: string): void {
-  if (serial.startsWith("emulator-")) {
-    try {
-      adb(["-s", serial, "emu", "kill"], { timeout: 5_000 });
-      return;
-    } catch {}
+  if (!serial.startsWith("emulator-")) {
+    throw new Error("Physical Android devices cannot be shut down by serve-sim.");
   }
-  adb(["-s", serial, "shell", "reboot", "-p"], { timeout: 5_000 });
+  adb(["-s", serial, "emu", "kill"], { timeout: 5_000 });
 }
 
 export function parseWmSize(stdout: string): { width: number; height: number } | null {

--- a/packages/serve-sim/src/android-device.ts
+++ b/packages/serve-sim/src/android-device.ts
@@ -1,0 +1,321 @@
+import { execFileSync, spawn } from "child_process";
+import { existsSync, openSync, closeSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+export type AndroidTargetState = "Booted" | "Shutdown" | "Offline" | "Unauthorized" | "Unknown";
+
+export interface AndroidTarget {
+  platform: "android";
+  device: string;
+  name: string;
+  runtime: string;
+  state: AndroidTargetState;
+  serial?: string;
+  avdName?: string;
+  isEmulator: boolean;
+}
+
+export interface ParsedAdbDevice {
+  serial: string;
+  state: string;
+  attrs: Record<string, string>;
+}
+
+const DEFAULT_ADB_TIMEOUT_MS = 3_000;
+const ANDROID_BOOT_TIMEOUT_MS = 120_000;
+
+function sdkRoots(): string[] {
+  return [
+    process.env.ANDROID_HOME,
+    process.env.ANDROID_SDK_ROOT,
+    join(homedir(), "Library/Android/sdk"),
+  ].filter((value): value is string => !!value);
+}
+
+function commandWorks(command: string, args: string[] = ["--version"]): boolean {
+  try {
+    execFileSync(command, args, {
+      encoding: "utf-8",
+      stdio: ["ignore", "ignore", "ignore"],
+      timeout: 1500,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function findAdb(): string | null {
+  for (const root of sdkRoots()) {
+    const candidate = join(root, "platform-tools", "adb");
+    if (existsSync(candidate)) return candidate;
+  }
+  return commandWorks("adb", ["version"]) ? "adb" : null;
+}
+
+export function findEmulator(): string | null {
+  for (const root of sdkRoots()) {
+    const candidate = join(root, "emulator", "emulator");
+    if (existsSync(candidate)) return candidate;
+  }
+  return commandWorks("emulator", ["-version"]) ? "emulator" : null;
+}
+
+export function adb(args: string[], opts?: { timeout?: number; encoding?: BufferEncoding }): string {
+  const command = findAdb();
+  if (!command) {
+    throw new Error("adb not found. Install Android Studio or set ANDROID_HOME/ANDROID_SDK_ROOT.");
+  }
+  return execFileSync(command, args, {
+    encoding: opts?.encoding ?? "utf-8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: opts?.timeout ?? DEFAULT_ADB_TIMEOUT_MS,
+  }).toString();
+}
+
+export function parseAdbDevices(stdout: string): ParsedAdbDevice[] {
+  const devices: ParsedAdbDevice[] = [];
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("List of devices")) continue;
+    const [serial, state, ...rest] = line.split(/\s+/);
+    if (!serial || !state) continue;
+    const attrs: Record<string, string> = {};
+    for (const part of rest) {
+      const idx = part.indexOf(":");
+      if (idx <= 0) continue;
+      attrs[part.slice(0, idx)] = part.slice(idx + 1);
+    }
+    devices.push({ serial, state, attrs });
+  }
+  return devices;
+}
+
+function androidState(adbState: string): AndroidTargetState {
+  switch (adbState) {
+    case "device":
+      return "Booted";
+    case "offline":
+      return "Offline";
+    case "unauthorized":
+      return "Unauthorized";
+    default:
+      return "Unknown";
+  }
+}
+
+function friendlyModel(value: string | undefined, fallback: string): string {
+  return (value || fallback).replace(/_/g, " ");
+}
+
+function getAndroidProp(serial: string, prop: string, timeout = 1500): string {
+  try {
+    return adb(["-s", serial, "shell", "getprop", prop], { timeout }).trim();
+  } catch {
+    return "";
+  }
+}
+
+function describeRunningDevice(device: ParsedAdbDevice): AndroidTarget {
+  const isEmulator = device.serial.startsWith("emulator-");
+  const release = getAndroidProp(device.serial, "ro.build.version.release");
+  const api = getAndroidProp(device.serial, "ro.build.version.sdk");
+  const avdName = isEmulator
+    ? getAndroidProp(device.serial, "ro.kernel.qemu.avd_name") || undefined
+    : undefined;
+  const name = avdName
+    ? avdName.replace(/_/g, " ")
+    : friendlyModel(device.attrs.model, device.serial);
+  const runtime = release
+    ? `Android ${release}${api ? ` (API ${api})` : ""}`
+    : "Android";
+  return {
+    platform: "android",
+    device: device.serial,
+    serial: device.serial,
+    avdName,
+    name,
+    runtime,
+    state: androidState(device.state),
+    isEmulator,
+  };
+}
+
+export function listRunningAndroidDevices(): AndroidTarget[] {
+  try {
+    return parseAdbDevices(adb(["devices", "-l"]))
+      .map(describeRunningDevice)
+      .filter((device) => device.state !== "Unknown");
+  } catch {
+    return [];
+  }
+}
+
+export function listAndroidAvds(): AndroidTarget[] {
+  const emulator = findEmulator();
+  if (!emulator) return [];
+  try {
+    const out = execFileSync(emulator, ["-list-avds"], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 3_000,
+    });
+    return out
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((avdName) => ({
+        platform: "android" as const,
+        device: avdName,
+        avdName,
+        name: avdName.replace(/_/g, " "),
+        runtime: "Android Emulator",
+        state: "Shutdown" as const,
+        isEmulator: true,
+      }));
+  } catch {
+    return [];
+  }
+}
+
+export function listAndroidTargets(): AndroidTarget[] {
+  const running = listRunningAndroidDevices();
+  const runningAvds = new Set(
+    running
+      .map((device) => device.avdName)
+      .filter((value): value is string => !!value),
+  );
+  const stoppedAvds = listAndroidAvds().filter(
+    (device) => !device.avdName || !runningAvds.has(device.avdName),
+  );
+  return [...running, ...stoppedAvds];
+}
+
+export function findBootedAndroidDevice(): string | null {
+  return listRunningAndroidDevices().find((device) => device.state === "Booted")?.device ?? null;
+}
+
+export function isAndroidDeviceBooted(serial: string): boolean {
+  try {
+    return adb(["-s", serial, "get-state"], { timeout: 1500 }).trim() === "device";
+  } catch {
+    return false;
+  }
+}
+
+export function resolveRunningAndroidDevice(nameOrSerial: string): AndroidTarget | null {
+  const wanted = nameOrSerial.toLowerCase();
+  for (const device of listRunningAndroidDevices()) {
+    if (device.device.toLowerCase() === wanted) return device;
+    if (device.serial?.toLowerCase() === wanted) return device;
+    if (device.avdName?.toLowerCase() === wanted) return device;
+    if (device.name.toLowerCase() === wanted) return device;
+  }
+  return null;
+}
+
+export function resolveAndroidTarget(nameOrSerial: string): AndroidTarget | null {
+  const running = resolveRunningAndroidDevice(nameOrSerial);
+  if (running) return running;
+  const wanted = nameOrSerial.toLowerCase();
+  return listAndroidAvds().find(
+    (device) =>
+      device.device.toLowerCase() === wanted ||
+      device.avdName?.toLowerCase() === wanted ||
+      device.name.toLowerCase() === wanted,
+  ) ?? null;
+}
+
+export function pickDefaultAndroidTarget(): AndroidTarget | null {
+  return listRunningAndroidDevices().find((device) => device.state === "Booted")
+    ?? listAndroidAvds()[0]
+    ?? null;
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForBootedAndroidDevice(
+  match: (device: AndroidTarget) => boolean,
+  timeoutMs = ANDROID_BOOT_TIMEOUT_MS,
+): Promise<AndroidTarget> {
+  const deadline = Date.now() + timeoutMs;
+  let lastDevice: AndroidTarget | null = null;
+  while (Date.now() < deadline) {
+    const devices = listRunningAndroidDevices();
+    lastDevice = devices.find(match) ?? null;
+    if (lastDevice?.serial && lastDevice.state === "Booted") {
+      const completed = getAndroidProp(lastDevice.serial, "sys.boot_completed", 2500);
+      if (completed === "1") return lastDevice;
+    }
+    await sleep(1000);
+  }
+  throw new Error(
+    lastDevice
+      ? `Android device ${lastDevice.device} did not finish booting in time`
+      : "Android emulator did not appear in adb devices in time",
+  );
+}
+
+export async function ensureAndroidBooted(target: AndroidTarget, logFile?: string): Promise<AndroidTarget> {
+  if (target.serial && target.state === "Booted" && isAndroidDeviceBooted(target.serial)) {
+    return target;
+  }
+
+  if (!target.avdName) {
+    throw new Error(`Android device ${target.device} is not booted`);
+  }
+
+  const emulator = findEmulator();
+  if (!emulator) {
+    throw new Error("Android emulator not found. Install Android Studio or set ANDROID_HOME/ANDROID_SDK_ROOT.");
+  }
+
+  const before = new Set(listRunningAndroidDevices().map((device) => device.device));
+  let outFd: number | undefined;
+  try {
+    if (logFile) outFd = openSync(logFile, "a");
+    const child = spawn(emulator, ["-avd", target.avdName], {
+      detached: true,
+      stdio: ["ignore", outFd ?? "ignore", outFd ?? "ignore"],
+    });
+    child.unref();
+  } finally {
+    if (outFd !== undefined) closeSync(outFd);
+  }
+
+  return waitForBootedAndroidDevice((device) => {
+    if (device.avdName === target.avdName) return true;
+    return device.isEmulator && !before.has(device.device);
+  });
+}
+
+export function shutdownAndroidDevice(serial: string): void {
+  if (serial.startsWith("emulator-")) {
+    try {
+      adb(["-s", serial, "emu", "kill"], { timeout: 5_000 });
+      return;
+    } catch {}
+  }
+  adb(["-s", serial, "shell", "reboot", "-p"], { timeout: 5_000 });
+}
+
+export function parseWmSize(stdout: string): { width: number; height: number } | null {
+  const match = /(?:Physical|Override) size:\s*(\d+)x(\d+)/i.exec(stdout);
+  if (!match) return null;
+  const width = Number(match[1]);
+  const height = Number(match[2]);
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return null;
+  }
+  return { width, height };
+}
+
+export function androidInputTextArg(text: string): string {
+  return text
+    .replace(/%/g, "%25")
+    .replace(/\s/g, "%s")
+    .replace(/[\\'"`$&|;<>*?()[\]{}]/g, "\\$&");
+}

--- a/packages/serve-sim/src/android-device.ts
+++ b/packages/serve-sim/src/android-device.ts
@@ -4,6 +4,7 @@ import { homedir } from "os";
 import { join } from "path";
 
 export type AndroidTargetState = "Booted" | "Shutdown" | "Offline" | "Unauthorized" | "Unknown";
+export type AndroidBootStatus = "booted" | "not_booted" | "unknown";
 
 export interface AndroidTarget {
   platform: "android";
@@ -196,12 +197,35 @@ export function findBootedAndroidDevice(): string | null {
   return listRunningAndroidDevices().find((device) => device.state === "Booted")?.device ?? null;
 }
 
-export function isAndroidDeviceBooted(serial: string): boolean {
-  try {
-    return adb(["-s", serial, "get-state"], { timeout: 1500 }).trim() === "device";
-  } catch {
-    return false;
+export function androidBootStatusFromAdbGetState(stdout: string): AndroidBootStatus {
+  return stdout.trim() === "device" ? "booted" : "not_booted";
+}
+
+export function androidBootStatusFromAdbError(err: unknown): AndroidBootStatus {
+  const error = err as { message?: unknown; stdout?: unknown; stderr?: unknown };
+  const text = [error.stderr, error.stdout, error.message]
+    .map((value) => Buffer.isBuffer(value) ? value.toString("utf-8") : String(value ?? ""))
+    .join("\n");
+  if (
+    /device ['"]?[^'"\n]+['"]? not found/i.test(text) ||
+    /no devices\/emulators found/i.test(text) ||
+    /\b(device offline|offline|unauthorized)\b/i.test(text)
+  ) {
+    return "not_booted";
   }
+  return "unknown";
+}
+
+export function androidDeviceBootStatus(serial: string): AndroidBootStatus {
+  try {
+    return androidBootStatusFromAdbGetState(adb(["-s", serial, "get-state"], { timeout: 1500 }));
+  } catch (err) {
+    return androidBootStatusFromAdbError(err);
+  }
+}
+
+export function isAndroidDeviceBooted(serial: string): boolean {
+  return androidDeviceBootStatus(serial) === "booted";
 }
 
 export function resolveRunningAndroidDevice(nameOrSerial: string): AndroidTarget | null {

--- a/packages/serve-sim/src/android-helper.ts
+++ b/packages/serve-sim/src/android-helper.ts
@@ -1,0 +1,729 @@
+import { createHash } from "crypto";
+import { spawn, type ChildProcess } from "child_process";
+import { createServer, type IncomingMessage, type ServerResponse } from "http";
+import type { Socket } from "net";
+import { findAdb, parseWmSize } from "./android-device";
+
+type SimulatorOrientation = "portrait" | "portrait_upside_down" | "landscape_left" | "landscape_right";
+
+interface AndroidHelperOptions {
+  serial: string;
+  port: number;
+  maxFps?: number;
+  maxLongEdge?: number;
+}
+
+interface TouchPoint {
+  x: number;
+  y: number;
+}
+
+interface TouchGesture {
+  last: TouchPoint;
+}
+
+interface ScreenConfig {
+  width: number;
+  height: number;
+  orientation: SimulatorOrientation;
+}
+
+const WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+const STREAM_BOUNDARY = "frame";
+const DEFAULT_MAX_FPS = 5;
+const DEFAULT_MAX_LONG_EDGE = 1200;
+const DEFAULT_VIDEO_BIT_RATE = 8_000_000;
+const SCREENRECORD_TIME_LIMIT_SECONDS = 180;
+const MAX_FRAME_BYTES = 32 * 1024 * 1024;
+const TOUCH_MOVE_INTERVAL_MS = 16;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function json(res: ServerResponse, status: number, payload: unknown): void {
+  const body = Buffer.from(JSON.stringify(payload));
+  res.writeHead(status, {
+    "Access-Control-Allow-Origin": "*",
+    "Cache-Control": "no-cache, no-store",
+    "Content-Type": "application/json",
+    "Content-Length": String(body.length),
+  });
+  res.end(body);
+}
+
+function adbBuffer(serial: string, args: string[], timeoutMs = 5_000): Promise<Buffer> {
+  const adb = findAdb();
+  if (!adb) return Promise.reject(new Error("adb not found"));
+  return new Promise((resolve, reject) => {
+    const child = spawn(adb, ["-s", serial, ...args], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    let stdoutBytes = 0;
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill("SIGKILL");
+      reject(new Error(`adb ${args.join(" ")} timed out`));
+    }, timeoutMs);
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdoutBytes += chunk.length;
+      if (stdoutBytes > MAX_FRAME_BYTES) {
+        child.kill("SIGKILL");
+        return;
+      }
+      stdout.push(chunk);
+    });
+    child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+    child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (code === 0) {
+        resolve(Buffer.concat(stdout));
+      } else {
+        const message = Buffer.concat(stderr).toString("utf-8").trim();
+        reject(new Error(message || `adb ${args.join(" ")} exited with code ${code}`));
+      }
+    });
+  });
+}
+
+function adbSpawn(serial: string, args: string[]): ChildProcess {
+  const adb = findAdb();
+  if (!adb) throw new Error("adb not found");
+  return spawn(adb, ["-s", serial, ...args], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function adbShell(serial: string): ChildProcess {
+  const adb = findAdb();
+  if (!adb) throw new Error("adb not found");
+  return spawn(adb, ["-s", serial, "shell"], {
+    stdio: ["pipe", "ignore", "pipe"],
+  });
+}
+
+async function adbText(serial: string, args: string[], timeoutMs = 5_000): Promise<string> {
+  return (await adbBuffer(serial, args, timeoutMs)).toString("utf-8");
+}
+
+export function parsePngDimensions(buffer: Uint8Array): { width: number; height: number } | null {
+  if (buffer.length < 24) return null;
+  const signature = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+  for (let i = 0; i < signature.length; i++) {
+    if (buffer[i] !== signature[i]) return null;
+  }
+  const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+  const width = view.getUint32(16);
+  const height = view.getUint32(20);
+  if (width <= 0 || height <= 0) return null;
+  return { width, height };
+}
+
+function mjpegChunk(frame: Buffer): Buffer {
+  const header =
+    `--${STREAM_BOUNDARY}\r\n` +
+    "Content-Type: image/png\r\n" +
+    `Content-Length: ${frame.length}\r\n\r\n`;
+  return Buffer.concat([Buffer.from(header), frame, Buffer.from("\r\n")]);
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1, value));
+}
+
+class AndroidInputShell {
+  private child: ChildProcess | null = null;
+  private stopped = false;
+
+  constructor(private readonly serial: string) {}
+
+  write(command: string): void {
+    if (this.stopped) return;
+    const child = this.ensureChild();
+    if (!child.stdin?.writable) return;
+    child.stdin.write(`${command}\n`);
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.child && !this.child.killed) this.child.kill("SIGTERM");
+    this.child = null;
+  }
+
+  private ensureChild(): ChildProcess {
+    if (this.child && !this.child.killed && this.child.stdin?.writable) {
+      return this.child;
+    }
+
+    const child = adbShell(this.serial);
+    this.child = child;
+    child.stderr?.on("data", (chunk: Buffer) => {
+      const message = chunk.toString("utf-8").trim();
+      if (message) console.error("[android-input]", message);
+    });
+    child.on("error", (err) => {
+      if (!this.stopped) console.error("[android-input]", err.message);
+    });
+    child.on("close", () => {
+      if (this.child === child) this.child = null;
+    });
+    return child;
+  }
+}
+
+function androidKeyCodeForButton(button: string): number | null {
+  switch (button) {
+    case "home":
+      return 3;
+    case "back":
+      return 4;
+    case "app_switcher":
+    case "recents":
+      return 187;
+    case "lock":
+    case "power":
+      return 26;
+    case "volume_up":
+      return 24;
+    case "volume_down":
+      return 25;
+    case "menu":
+      return 82;
+    default:
+      return null;
+  }
+}
+
+export function androidKeyCodeForHidUsage(usage: number): number | null {
+  if (usage >= 0x04 && usage <= 0x1d) return 29 + (usage - 0x04);
+  if (usage >= 0x1e && usage <= 0x26) return 8 + (usage - 0x1e);
+  if (usage === 0x27) return 7;
+  const map: Record<number, number> = {
+    0x28: 66,
+    0x29: 111,
+    0x2a: 67,
+    0x2b: 61,
+    0x2c: 62,
+    0x2d: 69,
+    0x2e: 70,
+    0x2f: 71,
+    0x30: 72,
+    0x31: 73,
+    0x33: 74,
+    0x34: 75,
+    0x35: 68,
+    0x36: 55,
+    0x37: 56,
+    0x38: 76,
+    0x39: 115,
+    0x4f: 22,
+    0x50: 21,
+    0x51: 20,
+    0x52: 19,
+  };
+  return map[usage] ?? null;
+}
+
+function rotationForOrientation(orientation: SimulatorOrientation): number {
+  switch (orientation) {
+    case "landscape_left":
+      return 1;
+    case "portrait_upside_down":
+      return 2;
+    case "landscape_right":
+      return 3;
+    default:
+      return 0;
+  }
+}
+
+function parseForegroundPackage(dumpsysWindow: string): string | null {
+  const focus = /mCurrentFocus=.*?\s+u\d+\s+([A-Za-z0-9_.]+)\//.exec(dumpsysWindow)
+    ?? /mFocusedApp=.*?\s+u\d+\s+([A-Za-z0-9_.]+)\//.exec(dumpsysWindow);
+  return focus?.[1] ?? null;
+}
+
+function parseWmSizeDetails(stdout: string): {
+  physical: { width: number; height: number } | null;
+  override: { width: number; height: number } | null;
+} {
+  const parse = (label: string) => {
+    const match = new RegExp(`${label} size:\\s*(\\d+)x(\\d+)`, "i").exec(stdout);
+    if (!match) return null;
+    const width = Number(match[1]);
+    const height = Number(match[2]);
+    return Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0
+      ? { width, height }
+      : null;
+  };
+  return {
+    physical: parse("Physical"),
+    override: parse("Override"),
+  };
+}
+
+function scaledSize(
+  size: { width: number; height: number },
+  maxLongEdge: number,
+): { width: number; height: number } | null {
+  const longEdge = Math.max(size.width, size.height);
+  if (!(maxLongEdge > 0) || longEdge <= maxLongEdge) return null;
+  const scale = maxLongEdge / longEdge;
+  const even = (value: number) => Math.max(2, Math.round(value / 2) * 2);
+  return {
+    width: even(size.width * scale),
+    height: even(size.height * scale),
+  };
+}
+
+function websocketAccept(key: string): string {
+  return createHash("sha1").update(key + WS_GUID).digest("base64");
+}
+
+function parseWebSocketFrames(
+  buffer: Buffer<ArrayBufferLike>,
+  onPayload: (payload: Buffer, opcode: number) => void,
+): Buffer<ArrayBufferLike> {
+  let offset = 0;
+  while (buffer.length - offset >= 2) {
+    const first = buffer[offset]!;
+    const second = buffer[offset + 1]!;
+    const opcode = first & 0x0f;
+    const masked = (second & 0x80) !== 0;
+    let length = second & 0x7f;
+    let headerLength = 2;
+    if (length === 126) {
+      if (buffer.length - offset < 4) break;
+      length = buffer.readUInt16BE(offset + 2);
+      headerLength = 4;
+    } else if (length === 127) {
+      if (buffer.length - offset < 10) break;
+      const big = buffer.readBigUInt64BE(offset + 2);
+      if (big > BigInt(Number.MAX_SAFE_INTEGER)) break;
+      length = Number(big);
+      headerLength = 10;
+    }
+    const maskLength = masked ? 4 : 0;
+    const frameLength = headerLength + maskLength + length;
+    if (buffer.length - offset < frameLength) break;
+    const maskOffset = offset + headerLength;
+    const payloadOffset = maskOffset + maskLength;
+    const payload = Buffer.from(buffer.subarray(payloadOffset, payloadOffset + length));
+    if (masked) {
+      const mask = buffer.subarray(maskOffset, maskOffset + 4);
+      for (let i = 0; i < payload.length; i++) payload[i] = payload[i]! ^ mask[i % 4]!;
+    }
+    onPayload(payload, opcode);
+    offset += frameLength;
+  }
+  return buffer.subarray(offset);
+}
+
+export async function runAndroidHelper({
+  serial,
+  port,
+  maxFps = DEFAULT_MAX_FPS,
+  maxLongEdge = DEFAULT_MAX_LONG_EDGE,
+}: AndroidHelperOptions): Promise<void> {
+  const clients = new Set<ServerResponse>();
+  let latestFrame: Buffer | null = null;
+  let captureRunning = false;
+  let stopped = false;
+  let touchGesture: TouchGesture | null = null;
+  let pendingMove: TouchPoint | null = null;
+  let moveTimer: ReturnType<typeof setTimeout> | null = null;
+  let config: ScreenConfig = { width: 0, height: 0, orientation: "portrait" };
+  let inputSize: { width: number; height: number } | null = null;
+  let videoSize: { width: number; height: number } | null = null;
+  const inputShell = new AndroidInputShell(serial);
+
+  const pointFor = (point: TouchPoint) => {
+    const width = inputSize?.width || config.width || 1;
+    const height = inputSize?.height || config.height || 1;
+    return {
+      x: Math.round(clamp01(point.x) * (width - 1)),
+      y: Math.round(clamp01(point.y) * (height - 1)),
+    };
+  };
+
+  const writeMotionEvent = (action: "DOWN" | "MOVE" | "UP", point: TouchPoint) => {
+    const mapped = pointFor(point);
+    inputShell.write(`input motionevent ${action} ${mapped.x} ${mapped.y}`);
+  };
+
+  const flushPendingMove = () => {
+    if (moveTimer) {
+      clearTimeout(moveTimer);
+      moveTimer = null;
+    }
+    if (!pendingMove || !touchGesture) return;
+    writeMotionEvent("MOVE", pendingMove);
+    pendingMove = null;
+  };
+
+  const scheduleMove = (point: TouchPoint) => {
+    pendingMove = point;
+    if (moveTimer) return;
+    moveTimer = setTimeout(() => {
+      moveTimer = null;
+      if (!pendingMove || !touchGesture) return;
+      writeMotionEvent("MOVE", pendingMove);
+      pendingMove = null;
+    }, TOUCH_MOVE_INTERVAL_MS);
+  };
+
+  const refreshConfig = async () => {
+    try {
+      const wm = await adbText(serial, ["shell", "wm", "size"], 2500);
+      const details = parseWmSizeDetails(wm);
+      const size = details.override ?? details.physical ?? parseWmSize(wm);
+      if (size) {
+        inputSize = size;
+        videoSize = scaledSize(size, maxLongEdge) ?? size;
+        config = { ...config, ...videoSize };
+      }
+    } catch {}
+  };
+
+  const captureFrame = async (): Promise<Buffer> => {
+    const frame = await adbBuffer(serial, ["exec-out", "screencap", "-p"], 8_000);
+    const size = parsePngDimensions(frame);
+    if (size) {
+      inputSize = size;
+      config = { ...config, ...size };
+    }
+    return frame;
+  };
+
+  const broadcastFrame = (frame: Buffer) => {
+    latestFrame = frame;
+    if (clients.size === 0) return;
+    const chunk = mjpegChunk(frame);
+    for (const res of [...clients]) {
+      if (res.destroyed || res.writableEnded) {
+        clients.delete(res);
+        continue;
+      }
+      res.write(chunk);
+    }
+  };
+
+  const ensureCaptureLoop = () => {
+    if (captureRunning) return;
+    captureRunning = true;
+    void (async () => {
+      console.log("[android] Capture started");
+      const frameDelay = Math.max(50, Math.round(1000 / Math.max(1, maxFps)));
+      while (!stopped && clients.size > 0) {
+        const started = Date.now();
+        try {
+          broadcastFrame(await captureFrame());
+        } catch (err) {
+          console.error("[android-capture]", err instanceof Error ? err.message : err);
+          await sleep(1000);
+        }
+        await sleep(Math.max(0, frameDelay - (Date.now() - started)));
+      }
+      captureRunning = false;
+    })();
+  };
+
+  await refreshConfig();
+
+  const handleTouch = (payload: any) => {
+    const point = { x: Number(payload.x), y: Number(payload.y) };
+    if (payload.type === "begin") {
+      touchGesture = { last: point };
+      pendingMove = null;
+      writeMotionEvent("DOWN", point);
+      return;
+    }
+    if (!touchGesture) return;
+    if (payload.type === "move") {
+      touchGesture.last = point;
+      scheduleMove(point);
+      return;
+    }
+    if (payload.type !== "end") return;
+    flushPendingMove();
+    touchGesture = null;
+    writeMotionEvent("UP", point);
+  };
+
+  const handleMessage = (payload: Buffer) => {
+    if (payload.length < 1) return;
+    const type = payload[0]!;
+    const body = payload.length > 1
+      ? JSON.parse(payload.subarray(1).toString("utf-8"))
+      : {};
+
+    if (type === 0x03) {
+      handleTouch(body);
+    } else if (type === 0x04) {
+      const keyCode = androidKeyCodeForButton(String(body.button ?? ""));
+      if (keyCode != null) {
+        inputShell.write(`input keyevent ${keyCode}`);
+      }
+    } else if (type === 0x06) {
+      if (body.type !== "down") return;
+      const keyCode = androidKeyCodeForHidUsage(Number(body.usage));
+      if (keyCode != null) {
+        inputShell.write(`input keyevent ${keyCode}`);
+      }
+    } else if (type === 0x07) {
+      const orientation = String(body.orientation ?? "portrait") as SimulatorOrientation;
+      const rotation = rotationForOrientation(orientation);
+      config = { ...config, orientation };
+      inputShell.write("settings put system accelerometer_rotation 0");
+      inputShell.write(`settings put system user_rotation ${rotation}`);
+    } else if (type === 0x09) {
+      inputShell.write("am send-trim-memory com.android.systemui RUNNING_LOW");
+    }
+  };
+
+  const screenrecordArgs = () => {
+    const args = [
+      "exec-out",
+      "screenrecord",
+      "--output-format=h264",
+      "--bit-rate",
+      String(DEFAULT_VIDEO_BIT_RATE),
+      "--time-limit",
+      String(SCREENRECORD_TIME_LIMIT_SECONDS),
+    ];
+    if (videoSize) {
+      args.push("--size", `${videoSize.width}x${videoSize.height}`);
+    }
+    args.push("-");
+    return args;
+  };
+
+  const streamH264 = (req: IncomingMessage, res: ServerResponse) => {
+    void (async () => {
+      await refreshConfig();
+      res.writeHead(200, {
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "no-cache, no-store",
+        "Connection": "keep-alive",
+        "Content-Type": "video/h264",
+        "X-Accel-Buffering": "no",
+      });
+
+      let closed = false;
+      let child: ChildProcess | null = null;
+      let restartTimer: ReturnType<typeof setTimeout> | null = null;
+
+      const stopChild = () => {
+        if (restartTimer) {
+          clearTimeout(restartTimer);
+          restartTimer = null;
+        }
+        if (child && !child.killed) child.kill("SIGTERM");
+        child = null;
+      };
+
+      const start = () => {
+        if (closed || stopped || res.destroyed || res.writableEnded) return;
+        try {
+          child = adbSpawn(serial, screenrecordArgs());
+        } catch (err) {
+          console.error("[android-video]", err instanceof Error ? err.message : err);
+          res.end();
+          return;
+        }
+
+        const current = child;
+        current.stdout?.on("data", (chunk: Buffer) => {
+          if (closed || res.destroyed || res.writableEnded) return;
+          if (!res.write(chunk)) {
+            current.stdout?.pause();
+            res.once("drain", () => current.stdout?.resume());
+          }
+        });
+        current.stderr?.on("data", (chunk: Buffer) => {
+          const message = chunk.toString("utf-8").trim();
+          if (message) console.error("[android-video]", message);
+        });
+        current.on("error", (err) => {
+          if (!closed) console.error("[android-video]", err.message);
+        });
+        current.on("close", () => {
+          if (child === current) child = null;
+          if (closed || stopped || res.destroyed || res.writableEnded) return;
+          restartTimer = setTimeout(start, 150);
+        });
+      };
+
+      req.on("close", () => {
+        closed = true;
+        stopChild();
+      });
+      start();
+    })().catch((err) => {
+      console.error("[android-video]", err instanceof Error ? err.message : err);
+      if (!res.headersSent) {
+        json(res, 503, {
+          error: "video_unavailable",
+          message: err instanceof Error ? err.message : String(err),
+        });
+      } else {
+        res.end();
+      }
+    });
+  };
+
+  const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+    const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "127.0.0.1"}`);
+    if (req.method === "OPTIONS") {
+      res.writeHead(204, {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type",
+      });
+      res.end();
+      return;
+    }
+
+    if (url.pathname === "/health") {
+      json(res, 200, { status: "ok", platform: "android", serial });
+      return;
+    }
+
+    if (url.pathname === "/config") {
+      json(res, 200, config);
+      return;
+    }
+
+    if (url.pathname === "/foreground") {
+      void (async () => {
+        try {
+          const dump = await adbText(serial, ["shell", "dumpsys", "window"], 4000);
+          const bundleId = parseForegroundPackage(dump);
+          let pid: number | undefined;
+          if (bundleId) {
+            try {
+              const rawPid = (await adbText(serial, ["shell", "pidof", bundleId], 1500)).trim().split(/\s+/, 1)[0];
+              pid = rawPid ? Number(rawPid) : undefined;
+            } catch {}
+          }
+          json(res, bundleId ? 200 : 503, bundleId ? { bundleId, pid } : { error: "foreground_unavailable" });
+        } catch (err) {
+          json(res, 503, {
+            error: "foreground_unavailable",
+            message: err instanceof Error ? err.message : String(err),
+          });
+        }
+      })();
+      return;
+    }
+
+    if (url.pathname === "/ax") {
+      json(res, 503, {
+        error: "ax_unavailable",
+        message: "Android accessibility snapshots are not available yet.",
+      });
+      return;
+    }
+
+    if (url.pathname === "/stream.mjpeg") {
+      const raw = url.searchParams.get("raw") === "1";
+      res.writeHead(200, {
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "no-cache, no-store",
+        "Connection": "keep-alive",
+        "Content-Type": raw
+          ? "application/octet-stream"
+          : `multipart/x-mixed-replace; boundary=${STREAM_BOUNDARY}`,
+      });
+      clients.add(res);
+      if (latestFrame) res.write(mjpegChunk(latestFrame));
+      req.on("close", () => {
+        clients.delete(res);
+      });
+      ensureCaptureLoop();
+      return;
+    }
+
+    if (url.pathname === "/stream.h264") {
+      streamH264(req, res);
+      return;
+    }
+
+    res.writeHead(404, { "Content-Type": "text/plain; charset=utf-8" });
+    res.end("Not found");
+  });
+
+  server.on("upgrade", (req, socket: Socket) => {
+    const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "127.0.0.1"}`);
+    if (url.pathname !== "/ws") {
+      socket.destroy();
+      return;
+    }
+    const key = req.headers["sec-websocket-key"];
+    if (typeof key !== "string") {
+      socket.destroy();
+      return;
+    }
+    socket.write(
+      "HTTP/1.1 101 Switching Protocols\r\n" +
+      "Upgrade: websocket\r\n" +
+      "Connection: Upgrade\r\n" +
+      `Sec-WebSocket-Accept: ${websocketAccept(key)}\r\n\r\n`,
+    );
+    let buffer: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+    socket.on("data", (chunk: Buffer | string) => {
+      const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      buffer = Buffer.concat([buffer, bytes]);
+      buffer = parseWebSocketFrames(buffer, (payload, opcode) => {
+        if (opcode === 0x8) {
+          socket.end();
+          return;
+        }
+        if (opcode !== 0x1 && opcode !== 0x2) return;
+        try {
+          handleMessage(payload);
+        } catch (err) {
+          console.error("[android-ws]", err instanceof Error ? err.message : err);
+        }
+      });
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "0.0.0.0", () => {
+      server.off("error", reject);
+      console.log(`[server] Listening on http://0.0.0.0:${port}`);
+      resolve();
+    });
+  });
+
+  process.on("SIGINT", () => {
+    stopped = true;
+    inputShell.stop();
+    server.close();
+    process.exit(0);
+  });
+  process.on("SIGTERM", () => {
+    stopped = true;
+    inputShell.stop();
+    server.close();
+    process.exit(0);
+  });
+
+  await new Promise(() => {});
+}

--- a/packages/serve-sim/src/android-helper.ts
+++ b/packages/serve-sim/src/android-helper.ts
@@ -651,12 +651,14 @@ export async function runAndroidHelper({
     }
 
     if (url.pathname === "/stream.mjpeg") {
-      const raw = url.searchParams.get("raw") === "1";
+      // `raw=1` is a fetch transport mode: keep Content-Length frame
+      // boundaries, but avoid multipart Content-Type handling in browsers.
+      const octetFramed = url.searchParams.get("raw") === "1";
       res.writeHead(200, {
         "Access-Control-Allow-Origin": "*",
         "Cache-Control": "no-cache, no-store",
         "Connection": "keep-alive",
-        "Content-Type": raw
+        "Content-Type": octetFramed
           ? "application/octet-stream"
           : `multipart/x-mixed-replace; boundary=${STREAM_BOUNDARY}`,
       });

--- a/packages/serve-sim/src/android-helper.ts
+++ b/packages/serve-sim/src/android-helper.ts
@@ -251,6 +251,15 @@ function rotationForOrientation(orientation: SimulatorOrientation): number {
   }
 }
 
+function isSimulatorOrientation(value: string): value is SimulatorOrientation {
+  return (
+    value === "portrait" ||
+    value === "portrait_upside_down" ||
+    value === "landscape_left" ||
+    value === "landscape_right"
+  );
+}
+
 function parseForegroundPackage(dumpsysWindow: string): string | null {
   const focus = /mCurrentFocus=.*?\s+u\d+\s+([A-Za-z0-9_.]+)\//.exec(dumpsysWindow)
     ?? /mFocusedApp=.*?\s+u\d+\s+([A-Za-z0-9_.]+)\//.exec(dumpsysWindow);
@@ -485,7 +494,9 @@ export async function runAndroidHelper({
         inputShell.write(`input keyevent ${keyCode}`);
       }
     } else if (type === 0x07) {
-      const orientation = String(body.orientation ?? "portrait") as SimulatorOrientation;
+      const requestedOrientation = String(body.orientation ?? "portrait");
+      if (!isSimulatorOrientation(requestedOrientation)) return;
+      const orientation = requestedOrientation;
       const rotation = rotationForOrientation(orientation);
       config = { ...config, orientation };
       inputShell.write("settings put system accelerometer_rotation 0");

--- a/packages/serve-sim/src/client/client.tsx
+++ b/packages/serve-sim/src/client/client.tsx
@@ -360,6 +360,9 @@ function AppWithConfig({
   const frameAspectRatioValue = frameDisplayConfig
     ? frameDisplayConfig.width / frameDisplayConfig.height
     : 1;
+  // Android input is sent over the control WebSocket, so keep emulator-style
+  // buttons available while the video decoder is still catching up.
+  const toolbarStreaming = isAndroid ? !!config.device : streaming;
 
   // Touch/button relay via direct WebSocket
   const wsRef = useRef<WebSocket | null>(null);
@@ -723,7 +726,7 @@ function AppWithConfig({
           deviceUdid={config.device}
           deviceName={selectedDevice?.name ?? null}
           deviceRuntime={selectedDevice?.runtime ?? null}
-          streaming={streaming}
+          streaming={toolbarStreaming}
         >
           <DevicePicker
             devices={devices}

--- a/packages/serve-sim/src/client/client.tsx
+++ b/packages/serve-sim/src/client/client.tsx
@@ -351,7 +351,8 @@ function AppWithConfig({
   const h264 = useH264Stream(config.streamUrl, androidVideoEnabled);
   const mjpeg = useMjpegStream(config.streamUrl, !androidVideoEnabled || h264.supported === false);
   const [liveStreamConfig, setLiveStreamConfig] = useState<StreamConfig | null>(null);
-  const activeStreamConfig = liveStreamConfig ?? h264.config ?? mjpeg.config ?? fallbackScreenSize(deviceType, selectedDevice?.name);
+  const confirmedStreamConfig = h264.config ?? mjpeg.config;
+  const activeStreamConfig = liveStreamConfig ?? confirmedStreamConfig ?? fallbackScreenSize(deviceType, selectedDevice?.name);
   const imgBorderRadius = screenBorderRadius(deviceType, activeStreamConfig);
   const frameMaxWidth = simulatorMaxWidth(deviceType, activeStreamConfig);
   const frameAspectRatio = simulatorAspectRatio(activeStreamConfig);
@@ -443,17 +444,21 @@ function AppWithConfig({
   }, [config.streamUrl]);
 
   useEffect(() => {
-    const confirmedConfig = mjpeg.config;
-    if (!confirmedConfig) return;
+    if (!confirmedStreamConfig) return;
     setLiveStreamConfig((prev) =>
       prev &&
-      prev.width === confirmedConfig.width &&
-      prev.height === confirmedConfig.height &&
-      prev.orientation === confirmedConfig.orientation
+      prev.width === confirmedStreamConfig.width &&
+      prev.height === confirmedStreamConfig.height &&
+      prev.orientation === confirmedStreamConfig.orientation
         ? prev
         : null,
     );
-  }, [mjpeg.config, mjpeg.config?.width, mjpeg.config?.height, mjpeg.config?.orientation]);
+  }, [
+    confirmedStreamConfig,
+    confirmedStreamConfig?.width,
+    confirmedStreamConfig?.height,
+    confirmedStreamConfig?.orientation,
+  ]);
 
   const sendKey = useCallback((type: "down" | "up", usage: number) => {
     sendWs(0x06, { type, usage });

--- a/packages/serve-sim/src/client/client.tsx
+++ b/packages/serve-sim/src/client/client.tsx
@@ -21,12 +21,14 @@ import {
 } from "serve-sim-client/simulator";
 
 import { ReloadIcon } from "./icons";
+import { AndroidDeviceControls } from "./components/android-device-controls";
 import { AxDomOverlay } from "./components/ax-dom-overlay";
 import { AxStateProvider } from "./components/ax-state-provider";
 import { AxToolbarButton } from "./components/ax-toolbar-button";
 import { BootEmptyState } from "./components/boot-empty-state";
 import { DevicePicker } from "./components/device-picker";
 import { GridPanel } from "./components/grid-panel";
+import { PlatformBadge } from "./components/platform-badge";
 import { ResizeHandle } from "./components/resize-handle";
 import { SimulatorResizeCornerHandle } from "./components/simulator-resize-corner-handle";
 import { SimulatorResizeSizeBadge } from "./components/simulator-resize-size-badge";
@@ -310,27 +312,42 @@ function AppWithConfig({
         }
       : null
   );
+  const platform = selectedDevice?.platform ?? config.platform ?? "ios";
+  const isAndroid = platform === "android";
+  const supportsAx = !isAndroid;
+  const supportsWebKitDevtools = !isAndroid;
 
   useEffect(() => {
     document.title = selectedDevice?.name
-      ? `${selectedDevice.platform === "android" ? "Android" : "Simulator"} - ${selectedDevice.name}`
+      ? `${platform === "android" ? "Android" : "Simulator"} - ${selectedDevice.name}`
       : "Device Preview";
-  }, [selectedDevice?.name, selectedDevice?.platform]);
+  }, [selectedDevice?.name, platform]);
 
   const deviceType: DeviceType = getDeviceType(selectedDevice?.name);
-  const devtools = useWebKitDevtools(config.devtoolsEndpoint ?? simEndpoint("devtools"), devtoolsOpen);
+  const effectiveDevtoolsOpen = supportsWebKitDevtools && devtoolsOpen;
+  const devtools = useWebKitDevtools(
+    supportsWebKitDevtools ? (config.devtoolsEndpoint ?? simEndpoint("devtools")) : undefined,
+    effectiveDevtoolsOpen,
+  );
 
   useEffect(() => {
-    if (!devtoolsOpen) return;
+    if (!effectiveDevtoolsOpen) return;
     if (selectedDevtoolsTargetId && devtools.targets.some((target) => target.id === selectedDevtoolsTargetId)) return;
     setSelectedDevtoolsTargetId(devtools.targets.length === 1 ? devtools.targets[0]!.id : null);
-  }, [devtoolsOpen, devtools.targets, selectedDevtoolsTargetId, setSelectedDevtoolsTargetId]);
+  }, [effectiveDevtoolsOpen, devtools.targets, selectedDevtoolsTargetId, setSelectedDevtoolsTargetId]);
 
   useEffect(() => {
     setSelectedDevtoolsTargetId(null);
   }, [config.device, setSelectedDevtoolsTargetId]);
 
-  const androidVideoEnabled = config.platform === "android";
+  useEffect(() => {
+    if (!isAndroid) return;
+    setAxOverlayEnabled(false);
+    setDevtoolsOpen(false);
+    setSelectedDevtoolsTargetId(null);
+  }, [isAndroid, setAxOverlayEnabled, setDevtoolsOpen, setSelectedDevtoolsTargetId]);
+
+  const androidVideoEnabled = isAndroid;
   const h264 = useH264Stream(config.streamUrl, androidVideoEnabled);
   const mjpeg = useMjpegStream(config.streamUrl, !androidVideoEnabled || h264.supported === false);
   const [liveStreamConfig, setLiveStreamConfig] = useState<StreamConfig | null>(null);
@@ -555,7 +572,7 @@ function AppWithConfig({
         }
         return;
       }
-      if ((config.platform ?? "ios") === "ios" && e.code === "KeyA" && e.metaKey && e.shiftKey) {
+      if (platform === "ios" && e.code === "KeyA" && e.metaKey && e.shiftKey) {
         e.preventDefault();
         if (type === "down" && !e.repeat) {
           execOnHost(`xcrun simctl ui ${config.device} appearance`).then((r) => {
@@ -580,7 +597,7 @@ function AppWithConfig({
       window.removeEventListener("keydown", down);
       window.removeEventListener("keyup", up);
     };
-  }, [sendWs, config.device, config.platform, rotateBy]);
+  }, [sendWs, config.device, platform, rotateBy]);
 
   const switchToDevice = useCallback(async (d: SimDevice) => {
     if (switching || d.udid === config.device) return;
@@ -606,7 +623,7 @@ function AppWithConfig({
   const mediaDrop = useMediaDrop({
     exec: execOnHost,
     udid: config.device,
-    platform: config.platform ?? "ios",
+    platform,
     enabled: streaming,
     onUploadStart: uploads.add,
     onUploadProgress: uploads.setProgress,
@@ -650,7 +667,7 @@ function AppWithConfig({
   });
 
   // Only shift the simulator when the panel would otherwise collide with it.
-  const panelWidthPx = devtoolsOpen
+  const panelWidthPx = effectiveDevtoolsOpen
     ? devtoolsPanelWidth
     : gridOpen
     ? gridPanelWidth
@@ -675,7 +692,7 @@ function AppWithConfig({
   }
 
   return (
-    <AxStateProvider endpoint={axOverlayEnabled ? config?.axEndpoint : undefined}>
+    <AxStateProvider endpoint={supportsAx && axOverlayEnabled ? config?.axEndpoint : undefined}>
     <div
       className="flex flex-col items-center justify-center h-screen bg-page py-6 pl-6 gap-3 font-system box-border"
       style={{
@@ -712,7 +729,18 @@ function AppWithConfig({
             onRefresh={fetchDevices}
             onSelect={switchToDevice}
             onStop={stopDevice}
-            trigger={<SimulatorToolbar.Title />}
+            trigger={
+              <SimulatorToolbar.Title
+                name={(
+                  <span className="inline-flex min-w-0 items-center gap-1.5">
+                    <PlatformBadge platform={platform} compact />
+                    <span className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">
+                      {selectedDevice?.name ?? "Device"}
+                    </span>
+                  </span>
+                )}
+              />
+            }
           />
           <SimulatorToolbar.Actions>
             {currentApp?.isReactNative && (
@@ -724,14 +752,20 @@ function AppWithConfig({
                 <ReloadIcon />
               </SimulatorToolbar.Button>
             )}
-            <SimulatorToolbar.HomeButton
-              onClick={(e) => { e.preventDefault(); onStreamButton("home"); }}
-            />
-            <AxToolbarButton
-              overlayEnabled={axOverlayEnabled}
-              streaming={streaming}
-              onToggleOverlay={() => setAxOverlayEnabled((enabled) => !enabled)}
-            />
+            {isAndroid ? (
+              <AndroidDeviceControls onButton={onStreamButton} />
+            ) : (
+              <SimulatorToolbar.HomeButton
+                onClick={(e) => { e.preventDefault(); onStreamButton("home"); }}
+              />
+            )}
+            {supportsAx && (
+              <AxToolbarButton
+                overlayEnabled={axOverlayEnabled}
+                streaming={streaming}
+                onToggleOverlay={() => setAxOverlayEnabled((enabled) => !enabled)}
+              />
+            )}
             <SimulatorToolbar.RotateButton title="Rotate device" />
           </SimulatorToolbar.Actions>
         </SimulatorToolbar>
@@ -779,7 +813,7 @@ function AppWithConfig({
             enableDigitalCrown={deviceType === "watch"}
             onScreenConfigChange={onScreenConfigChange}
           />
-          {axOverlayEnabled && <AxDomOverlay />}
+          {supportsAx && axOverlayEnabled && <AxDomOverlay />}
           {mediaDrop.isDragOver && (
             <div
               className="absolute inset-0 flex flex-col items-center justify-center gap-2 border-2 border-dashed border-accent bg-[rgba(99,102,241,0.12)] backdrop-blur-[2px] text-accent pointer-events-none z-20"
@@ -790,7 +824,7 @@ function AppWithConfig({
                 <polyline points="17 8 12 3 7 8" />
                 <line x1="12" y1="3" x2="12" y2="15" />
               </svg>
-              <span className="text-[13px] font-medium">Drop media or {config.platform === "android" ? ".apk" : ".ipa"}</span>
+              <span className="text-[13px] font-medium">Drop media or {platform === "android" ? ".apk" : ".ipa"}</span>
             </div>
           )}
           <SimulatorResizeCornerHandle
@@ -865,7 +899,7 @@ function AppWithConfig({
 
       {/* Right-edge sidebar rail. */}
       <div
-        className={`fixed top-3 right-3 flex flex-col gap-1 p-1 bg-panel-bg border border-white/8 rounded-[10px] backdrop-blur-[12px] [-webkit-backdrop-filter:blur(12px)] [transition:opacity_0.18s_ease] z-40 ${(panelOpen || devtoolsOpen || gridOpen) ? "opacity-0 pointer-events-none" : "opacity-100 pointer-events-auto"}`}
+        className={`fixed top-3 right-3 flex flex-col gap-1 p-1 bg-panel-bg border border-white/8 rounded-[10px] backdrop-blur-[12px] [-webkit-backdrop-filter:blur(12px)] [transition:opacity_0.18s_ease] z-40 ${(panelOpen || effectiveDevtoolsOpen || gridOpen) ? "opacity-0 pointer-events-none" : "opacity-100 pointer-events-auto"}`}
       >
         <button
           onClick={() => {
@@ -883,23 +917,25 @@ function AppWithConfig({
             <line x1="15" y1="4" x2="15" y2="20" />
           </svg>
         </button>
-        <button
-          onClick={() => {
-            setPanelOpen(false);
-            setGridOpen(false);
-            setDevtoolsOpen((o) => !o);
-          }}
-          className="w-[30px] h-[30px] flex items-center justify-center bg-transparent border-none rounded-md text-[#8e8e93] cursor-pointer [transition:background_0.15s_ease,color_0.15s_ease] hover:bg-white/8 hover:text-white"
-          aria-label="Open WebKit DevTools"
-          aria-pressed={devtoolsOpen}
-          title="WebKit DevTools"
-        >
-          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
-            <circle cx="12" cy="12" r="10" />
-            <path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20" />
-            <path d="M2 12h20" />
-          </svg>
-        </button>
+        {supportsWebKitDevtools && (
+          <button
+            onClick={() => {
+              setPanelOpen(false);
+              setGridOpen(false);
+              setDevtoolsOpen((o) => !o);
+            }}
+            className="w-[30px] h-[30px] flex items-center justify-center bg-transparent border-none rounded-md text-[#8e8e93] cursor-pointer [transition:background_0.15s_ease,color_0.15s_ease] hover:bg-white/8 hover:text-white"
+            aria-label="Open WebKit DevTools"
+            aria-pressed={effectiveDevtoolsOpen}
+            title="WebKit DevTools"
+          >
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="10" />
+              <path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20" />
+              <path d="M2 12h20" />
+            </svg>
+          </button>
+        )}
         <button
           onClick={() => {
             setPanelOpen(false);
@@ -925,6 +961,7 @@ function AppWithConfig({
         onClose={() => setPanelOpen(false)}
         udid={config.device}
         currentApp={currentApp}
+        platform={platform}
         axOverlayEnabled={axOverlayEnabled}
         onToggleAxOverlay={() => setAxOverlayEnabled((enabled) => !enabled)}
         width={toolsPanelWidth}
@@ -946,27 +983,31 @@ function AppWithConfig({
         panelWidth={gridPanelWidth}
         visible={gridOpen}
         onPointerDown={onGridResize}
-        ariaLabel="Resize simulators panel"
+        ariaLabel="Resize devices panel"
       />
 
-      <WebKitDevtoolsPanel
-        open={devtoolsOpen}
-        onClose={() => setDevtoolsOpen(false)}
-        udid={config.device}
-        targets={devtools.targets}
-        selectedTargetId={selectedDevtoolsTargetId}
-        onSelectTarget={setSelectedDevtoolsTargetId}
-        loading={devtools.loading}
-        error={devtools.error}
-        onRefresh={() => void devtools.refresh()}
-        width={devtoolsPanelWidth}
-      />
-      <ResizeHandle
-        panelWidth={devtoolsPanelWidth}
-        visible={devtoolsOpen}
-        onPointerDown={onDevtoolsResize}
-        ariaLabel="Resize WebKit DevTools panel"
-      />
+      {supportsWebKitDevtools && (
+        <>
+          <WebKitDevtoolsPanel
+            open={effectiveDevtoolsOpen}
+            onClose={() => setDevtoolsOpen(false)}
+            udid={config.device}
+            targets={devtools.targets}
+            selectedTargetId={selectedDevtoolsTargetId}
+            onSelectTarget={setSelectedDevtoolsTargetId}
+            loading={devtools.loading}
+            error={devtools.error}
+            onRefresh={() => void devtools.refresh()}
+            width={devtoolsPanelWidth}
+          />
+          <ResizeHandle
+            panelWidth={devtoolsPanelWidth}
+            visible={effectiveDevtoolsOpen}
+            onPointerDown={onDevtoolsResize}
+            ariaLabel="Resize WebKit DevTools panel"
+          />
+        </>
+      )}
 
       {/* Status bar */}
       <div className="flex items-center gap-2.5 text-[12px] font-mono text-white/40">

--- a/packages/serve-sim/src/client/client.tsx
+++ b/packages/serve-sim/src/client/client.tsx
@@ -33,6 +33,7 @@ import { SimulatorResizeSizeBadge } from "./components/simulator-resize-size-bad
 import { ToolsPanel } from "./components/tools-panel";
 import { WebKitDevtoolsPanel } from "./components/webkit-devtools-panel";
 import { useMediaDrop } from "./hooks/use-media-drop";
+import { useH264Stream } from "./hooks/use-h264-stream";
 import { useMjpegStream } from "./hooks/use-mjpeg-stream";
 import { useResizableWidth } from "./hooks/use-resizable-width";
 import { useSimulatorResize } from "./hooks/use-simulator-resize";
@@ -95,6 +96,20 @@ function App() {
     setDevicesLoading(true);
     setDevicesError(null);
     try {
+      const gridRes = await fetch(simEndpoint("grid/api"), { cache: "no-store" });
+      if (gridRes.ok) {
+        const grid = await gridRes.json() as {
+          devices?: Array<{ device: string; platform?: "ios" | "android"; name: string; state: string; runtime: string }>;
+        };
+        setDevices((grid.devices ?? []).map((d) => ({
+          udid: d.device,
+          platform: d.platform ?? "ios",
+          name: d.name,
+          state: d.state,
+          runtime: d.runtime,
+        })));
+        return;
+      }
       const res = await execOnHost("xcrun simctl list devices available -j");
       if (res.exitCode !== 0) throw new Error(res.stderr || "simctl list failed");
       setDevices(parseSimctlList(res.stdout));
@@ -284,13 +299,23 @@ function AppWithConfig({
   setStreaming,
   fetchDevices,
 }: AppWithConfigProps) {
-  const selectedDevice = devices.find((d) => d.udid === config.device) ?? null;
+  const selectedDevice = devices.find((d) => d.udid === config.device) ?? (
+    config.name
+      ? {
+          udid: config.device,
+          platform: config.platform ?? "ios",
+          name: config.name,
+          runtime: config.runtime ?? (config.platform === "android" ? "Android" : ""),
+          state: "Booted",
+        }
+      : null
+  );
 
   useEffect(() => {
     document.title = selectedDevice?.name
-      ? `Simulator - ${selectedDevice.name}`
-      : "Simulator Preview";
-  }, [selectedDevice?.name]);
+      ? `${selectedDevice.platform === "android" ? "Android" : "Simulator"} - ${selectedDevice.name}`
+      : "Device Preview";
+  }, [selectedDevice?.name, selectedDevice?.platform]);
 
   const deviceType: DeviceType = getDeviceType(selectedDevice?.name);
   const devtools = useWebKitDevtools(config.devtoolsEndpoint ?? simEndpoint("devtools"), devtoolsOpen);
@@ -305,9 +330,11 @@ function AppWithConfig({
     setSelectedDevtoolsTargetId(null);
   }, [config.device, setSelectedDevtoolsTargetId]);
 
-  const mjpeg = useMjpegStream(config.streamUrl);
+  const androidVideoEnabled = config.platform === "android";
+  const h264 = useH264Stream(config.streamUrl, androidVideoEnabled);
+  const mjpeg = useMjpegStream(config.streamUrl, !androidVideoEnabled || h264.supported === false);
   const [liveStreamConfig, setLiveStreamConfig] = useState<StreamConfig | null>(null);
-  const activeStreamConfig = liveStreamConfig ?? mjpeg.config ?? fallbackScreenSize(deviceType, selectedDevice?.name);
+  const activeStreamConfig = liveStreamConfig ?? h264.config ?? mjpeg.config ?? fallbackScreenSize(deviceType, selectedDevice?.name);
   const imgBorderRadius = screenBorderRadius(deviceType, activeStreamConfig);
   const frameMaxWidth = simulatorMaxWidth(deviceType, activeStreamConfig);
   const frameAspectRatio = simulatorAspectRatio(activeStreamConfig);
@@ -528,7 +555,7 @@ function AppWithConfig({
         }
         return;
       }
-      if (e.code === "KeyA" && e.metaKey && e.shiftKey) {
+      if ((config.platform ?? "ios") === "ios" && e.code === "KeyA" && e.metaKey && e.shiftKey) {
         e.preventDefault();
         if (type === "down" && !e.repeat) {
           execOnHost(`xcrun simctl ui ${config.device} appearance`).then((r) => {
@@ -553,19 +580,22 @@ function AppWithConfig({
       window.removeEventListener("keydown", down);
       window.removeEventListener("keyup", up);
     };
-  }, [sendWs, config.device, rotateBy]);
+  }, [sendWs, config.device, config.platform, rotateBy]);
 
   const switchToDevice = useCallback(async (d: SimDevice) => {
     if (switching || d.udid === config.device) return;
     setSwitching(true);
     try {
-      if (d.state !== "Booted") {
-        await execOnHost(`xcrun simctl boot ${d.udid}`);
-      }
-      const detach = await execOnHost(`bunx serve-sim --detach ${d.udid}`);
-      if (detach.exitCode !== 0) throw new Error(detach.stderr || "Failed to start serve-sim");
+      const startEndpoint = window.__SIM_PREVIEW__?.gridStartEndpoint ?? simEndpoint("grid/api/start");
+      const res = await fetch(startEndpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ udid: d.udid, platform: d.platform ?? "ios" }),
+      });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || !json.ok) throw new Error(json.error || "Failed to start serve-sim");
       const nextUrl = new URL(window.location.href);
-      nextUrl.searchParams.set("device", d.udid);
+      nextUrl.searchParams.set("device", json.device ?? d.udid);
       window.location.assign(nextUrl.toString());
     } catch {
       setSwitching(false);
@@ -576,6 +606,7 @@ function AppWithConfig({
   const mediaDrop = useMediaDrop({
     exec: execOnHost,
     udid: config.device,
+    platform: config.platform ?? "ios",
     enabled: streaming,
     onUploadStart: uploads.add,
     onUploadProgress: uploads.setProgress,
@@ -593,7 +624,13 @@ function AppWithConfig({
   const stopDevice = useCallback(async (udid: string) => {
     setStoppingUdids((prev) => new Set(prev).add(udid));
     try {
-      await execOnHost(`xcrun simctl shutdown ${udid}`);
+      const device = devices.find((d) => d.udid === udid);
+      const shutdownEndpoint = window.__SIM_PREVIEW__?.gridShutdownEndpoint ?? simEndpoint("grid/api/shutdown");
+      await fetch(shutdownEndpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ udid, platform: device?.platform ?? "ios" }),
+      });
       await fetchDevices();
     } finally {
       setStoppingUdids((prev) => {
@@ -602,7 +639,7 @@ function AppWithConfig({
         return next;
       });
     }
-  }, [fetchDevices, setStoppingUdids]);
+  }, [devices, fetchDevices, setStoppingUdids]);
 
   const simulatorResize = useSimulatorResize({
     defaultWidth: frameMaxWidth,
@@ -736,6 +773,7 @@ function AppWithConfig({
             onStreamButton={onStreamButton}
             onStreamDigitalCrown={onStreamDigitalCrown}
             subscribeFrame={mjpeg.subscribeFrame}
+            subscribeVideoFrame={androidVideoEnabled && h264.supported !== false ? h264.subscribeVideoFrame : undefined}
             streamFrame={mjpeg.frame}
             streamConfig={activeStreamConfig}
             enableDigitalCrown={deviceType === "watch"}
@@ -752,7 +790,7 @@ function AppWithConfig({
                 <polyline points="17 8 12 3 7 8" />
                 <line x1="12" y1="3" x2="12" y2="15" />
               </svg>
-              <span className="text-[13px] font-medium">Drop media or .ipa</span>
+              <span className="text-[13px] font-medium">Drop media or {config.platform === "android" ? ".apk" : ".ipa"}</span>
             </div>
           )}
           <SimulatorResizeCornerHandle
@@ -801,9 +839,9 @@ function AppWithConfig({
                     {isUploading && transferring &&
                       `Uploading ${t.name}… ${pct}%`}
                     {isUploading && !transferring &&
-                      (t.kind === "ipa" ? `Installing ${t.name}…` : `Adding ${t.name}…`)}
+                      (t.kind === "ipa" || t.kind === "apk" ? `Installing ${t.name}…` : `Adding ${t.name}…`)}
                     {t.status === "success" &&
-                      (t.kind === "ipa" ? `Installed ${t.name}` : `Added ${t.name} to Photos`)}
+                      (t.kind === "ipa" || t.kind === "apk" ? `Installed ${t.name}` : `Added ${t.name}`)}
                     {isError && `${t.name}: ${t.message ?? "Upload failed"}`}
                   </span>
                 </div>
@@ -869,9 +907,9 @@ function AppWithConfig({
             setGridOpen((o) => !o);
           }}
           className="w-[30px] h-[30px] flex items-center justify-center bg-transparent border-none rounded-md text-[#8e8e93] cursor-pointer [transition:background_0.15s_ease,color_0.15s_ease] hover:bg-white/8 hover:text-white"
-          aria-label="Open simulator grid"
+          aria-label="Open device grid"
           aria-pressed={gridOpen}
-          title="Simulators"
+          title="Devices"
         >
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round">
             <rect x="3" y="3" width="7" height="7" rx="1.5" />

--- a/packages/serve-sim/src/client/client.tsx
+++ b/packages/serve-sim/src/client/client.tsx
@@ -651,12 +651,18 @@ function AppWithConfig({
     try {
       const device = devices.find((d) => d.udid === udid);
       const shutdownEndpoint = window.__SIM_PREVIEW__?.gridShutdownEndpoint ?? simEndpoint("grid/api/shutdown");
-      await fetch(shutdownEndpoint, {
+      const res = await fetch(shutdownEndpoint, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ udid, platform: device?.platform ?? "ios" }),
       });
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || !json.ok) {
+        throw new Error(json.error || `Failed to stop device (${res.status})`);
+      }
       await fetchDevices();
+    } catch (err) {
+      console.error("[serve-sim] Failed to stop device", err);
     } finally {
       setStoppingUdids((prev) => {
         const next = new Set(prev);

--- a/packages/serve-sim/src/client/components/android-device-controls.tsx
+++ b/packages/serve-sim/src/client/components/android-device-controls.tsx
@@ -1,0 +1,103 @@
+import { SimulatorToolbar } from "serve-sim-client/simulator";
+import type { ReactElement } from "react";
+
+type AndroidButton =
+  | "back"
+  | "home"
+  | "recents"
+  | "volume_down"
+  | "volume_up"
+  | "power";
+
+const CONTROLS: Array<{
+  button: AndroidButton;
+  label: string;
+  title: string;
+  icon: ReactElement;
+}> = [
+  {
+    button: "back",
+    label: "Android Back",
+    title: "Back",
+    icon: (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <path d="M15 6 8 12l7 6V6Z" fill="currentColor" />
+      </svg>
+    ),
+  },
+  {
+    button: "home",
+    label: "Android Home",
+    title: "Home",
+    icon: (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <circle cx="12" cy="12" r="5.5" stroke="currentColor" strokeWidth="2" />
+      </svg>
+    ),
+  },
+  {
+    button: "recents",
+    label: "Android Recents",
+    title: "Recents",
+    icon: (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <rect x="6.5" y="6.5" width="11" height="11" rx="1.5" stroke="currentColor" strokeWidth="2" />
+      </svg>
+    ),
+  },
+  {
+    button: "volume_down",
+    label: "Android Volume Down",
+    title: "Volume Down",
+    icon: (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <path d="M4 10v4h4l5 4V6l-5 4H4Z" stroke="currentColor" strokeWidth="2" strokeLinejoin="round" />
+        <path d="M17 12h4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      </svg>
+    ),
+  },
+  {
+    button: "volume_up",
+    label: "Android Volume Up",
+    title: "Volume Up",
+    icon: (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <path d="M4 10v4h4l5 4V6l-5 4H4Z" stroke="currentColor" strokeWidth="2" strokeLinejoin="round" />
+        <path d="M18.5 9.5v5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+        <path d="M16 12h5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      </svg>
+    ),
+  },
+  {
+    button: "power",
+    label: "Android Power",
+    title: "Power",
+    icon: (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <path d="M12 3v8" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+        <path d="M7.5 6.7a7 7 0 1 0 9 0" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      </svg>
+    ),
+  },
+];
+
+export function AndroidDeviceControls({
+  onButton,
+}: {
+  onButton: (button: AndroidButton) => void;
+}) {
+  return (
+    <>
+      {CONTROLS.map((control) => (
+        <SimulatorToolbar.Button
+          key={control.button}
+          aria-label={control.label}
+          title={control.title}
+          onClick={() => onButton(control.button)}
+        >
+          {control.icon}
+        </SimulatorToolbar.Button>
+      ))}
+    </>
+  );
+}

--- a/packages/serve-sim/src/client/components/app-detection-tool.tsx
+++ b/packages/serve-sim/src/client/components/app-detection-tool.tsx
@@ -2,13 +2,16 @@ import { useEffect, useState, type ReactNode } from "react";
 import { type AppDetails, fetchAppDetails } from "../utils/app-icon";
 import { execOnHost, shellEscape } from "../utils/exec";
 import { Chevron } from "../icons";
+import { PlatformBadge, platformLabel, type DevicePlatform } from "./platform-badge";
 
 export function AppDetectionTool({
   udid,
   currentApp,
+  platform = "ios",
 }: {
   udid: string;
   currentApp: { bundleId: string; isReactNative: boolean; pid?: number } | null;
+  platform?: DevicePlatform;
 }) {
   const [details, setDetails] = useState<AppDetails | null>(null);
   const [open, setOpen] = useState(false);
@@ -16,12 +19,14 @@ export function AppDetectionTool({
   useEffect(() => {
     if (!currentApp) { setDetails(null); return; }
     let cancelled = false;
-    setDetails({
+    const baseDetails: AppDetails = {
       bundleId: currentApp.bundleId,
       isReactNative: currentApp.isReactNative,
       pid: currentApp.pid,
-      loading: true,
-    });
+      loading: platform === "ios",
+    };
+    setDetails(baseDetails);
+    if (platform === "android") return () => { cancelled = true; };
     fetchAppDetails(execOnHost, udid, currentApp.bundleId).then((extra) => {
       if (cancelled) return;
       setDetails({
@@ -33,7 +38,7 @@ export function AppDetectionTool({
       });
     });
     return () => { cancelled = true; };
-  }, [udid, currentApp, currentApp?.bundleId, currentApp?.pid, currentApp?.isReactNative]);
+  }, [udid, currentApp, currentApp?.bundleId, currentApp?.pid, currentApp?.isReactNative, platform]);
 
   if (!details) {
     return (
@@ -57,13 +62,18 @@ export function AppDetectionTool({
             className="w-10 h-10 rounded-[8px] shrink-0 object-cover border border-white/8"
             alt=""
           />
+        ) : platform === "android" ? (
+          <div className="w-10 h-10 rounded-[8px] shrink-0 border border-white/8 bg-[#052e24] text-[#bbf7d0] flex items-center justify-center text-[10px] font-mono">
+            APK
+          </div>
         ) : (
           <div className="w-10 h-10 rounded-[8px] shrink-0 border border-white/8 bg-white/[0.04]" />
         )}
         <div className="min-w-0 flex-1 leading-tight">
-          <div className="text-[13px] font-semibold text-white/90 truncate">
-            {details.displayName ?? details.bundleId}
-            {details.loading && <span className="text-white/45 font-normal"> …</span>}
+          <div className="text-[13px] font-semibold text-white/90 truncate flex items-center gap-1.5">
+            <span className="truncate">{details.displayName ?? appTitle(details.bundleId, platform)}</span>
+            <PlatformBadge platform={platform} compact />
+            {details.loading && <span className="text-white/45 font-normal">...</span>}
           </div>
           <div className="text-[11px] text-white/55 font-mono truncate" title={details.bundleId}>
             {details.bundleId}
@@ -81,35 +91,52 @@ export function AppDetectionTool({
           )}
 
           <dl className="m-0 flex flex-col gap-1.5">
-            <Row label="Version" value={details.shortVersion ? `${details.shortVersion} (${details.bundleVersion ?? "—"})` : details.loading ? "…" : "—"} />
-            <Row label="Min iOS" value={details.minOS ?? (details.loading ? "…" : "—")} />
-            <Row label="Executable" value={details.executable ?? (details.loading ? "…" : "—")} />
-            <Row label="PID" value={details.pid != null ? String(details.pid) : "—"} />
-            {details.isReactNative && <Row label="React Native" value="Yes" />}
-            <Row
-              label="App path"
-              value={details.appPath ?? (details.loading ? "…" : "—")}
-              mono
-              action={
-                details.appPath
-                  ? {
-                      title: "Reveal in Finder",
-                      onClick: () => { execOnHost(`open -R ${shellEscape(details.appPath!)}`); },
-                      icon: (
-                        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
-                          <line x1="7" y1="17" x2="17" y2="7" />
-                          <polyline points="10 7 17 7 17 14" />
-                        </svg>
-                      ),
-                    }
-                  : undefined
-              }
-            />
+            <Row label="Platform" value={platformLabel(platform)} />
+            {platform === "android" ? (
+              <>
+                <Row label="Package" value={details.bundleId} mono />
+                <Row label="PID" value={details.pid != null ? String(details.pid) : "—"} />
+                {details.isReactNative && <Row label="React Native" value="Yes" />}
+              </>
+            ) : (
+              <>
+                <Row label="Version" value={details.shortVersion ? `${details.shortVersion} (${details.bundleVersion ?? "—"})` : details.loading ? "..." : "—"} />
+                <Row label="Min iOS" value={details.minOS ?? (details.loading ? "..." : "—")} />
+                <Row label="Executable" value={details.executable ?? (details.loading ? "..." : "—")} />
+                <Row label="PID" value={details.pid != null ? String(details.pid) : "—"} />
+                {details.isReactNative && <Row label="React Native" value="Yes" />}
+                <Row
+                  label="App path"
+                  value={details.appPath ?? (details.loading ? "..." : "—")}
+                  mono
+                  action={
+                    details.appPath
+                      ? {
+                          title: "Reveal in Finder",
+                          onClick: () => { execOnHost(`open -R ${shellEscape(details.appPath!)}`); },
+                          icon: (
+                            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+                              <line x1="7" y1="17" x2="17" y2="7" />
+                              <polyline points="10 7 17 7 17 14" />
+                            </svg>
+                          ),
+                        }
+                      : undefined
+                  }
+                />
+              </>
+            )}
           </dl>
         </>
       )}
     </div>
   );
+}
+
+function appTitle(bundleId: string, platform: DevicePlatform): string {
+  if (platform === "ios") return bundleId;
+  const last = bundleId.split(".").filter(Boolean).at(-1);
+  return last || bundleId;
 }
 
 function Row({

--- a/packages/serve-sim/src/client/components/boot-empty-state.tsx
+++ b/packages/serve-sim/src/client/components/boot-empty-state.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
 import { deviceKind, runtimeOrder, type SimDevice } from "../utils/devices";
+import { canStartDevice } from "../utils/grid";
 import { simEndpoint } from "../utils/sim-endpoint";
 import { PlatformBadge } from "./platform-badge";
 
@@ -117,15 +118,21 @@ export function BootEmptyState({
           {error && <div className="px-2.5 py-1.5 text-danger text-[11px]">{error}</div>}
           {startError && <div className="px-2.5 py-1.5 text-danger text-[11px]">{startError}</div>}
           {!loading && !error && devices.length === 0 && (
-          <div className="p-3 text-white/40 text-[11px] text-center">No available simulators or Android emulators found</div>
+            <div className="p-3 text-white/40 text-[11px] text-center">No available simulators or Android devices found</div>
           )}
           {sortedGroups.map(([runtime, devs]) => (
             <div key={runtime}>
               <div className="px-2.5 pt-1.5 pb-0.5 text-[10px] font-semibold text-white/40 uppercase tracking-[0.08em]">{runtime}</div>
               {devs.map((d) => {
                 const isStarting = startingUdid === d.udid;
-                const disabled = startingUdid !== null && !isStarting;
+                const canStart = canStartDevice(d);
+                const disabled = !canStart || (startingUdid !== null && !isStarting);
                 const isBooted = d.state === "Booted";
+                const actionLabel = !canStart
+                  ? d.state === "Unauthorized" ? "Unauthorized" : "Unavailable"
+                  : isStarting
+                  ? (isBooted ? "Starting..." : "Booting...")
+                  : (isBooted ? "Start stream" : "Boot & stream");
                 return (
                   <div
                     key={d.udid}
@@ -139,9 +146,7 @@ export function BootEmptyState({
                     <PlatformBadge platform={d.platform} compact />
                     <span className="flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-left">{d.name}</span>
                     <span className={`text-[10px] ${isStarting ? "text-accent" : "text-white/55"}`}>
-                      {isStarting
-                        ? (isBooted ? "Starting..." : "Booting...")
-                        : (isBooted ? "Start stream" : "Boot & stream")}
+                      {actionLabel}
                     </span>
                   </div>
                 );

--- a/packages/serve-sim/src/client/components/boot-empty-state.tsx
+++ b/packages/serve-sim/src/client/components/boot-empty-state.tsx
@@ -49,21 +49,28 @@ export function BootEmptyState({
       const startReq = fetch(startUrl, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ udid: d.udid }),
+        body: JSON.stringify({ udid: d.udid, platform: d.platform ?? "ios" }),
       })
         .then(async (res) => {
           const json = await res.json().catch(() => ({} as any));
           if (!res.ok || !json.ok) {
             throw new Error(json.error ?? `HTTP ${res.status}`);
           }
+          return json.device as string | undefined;
         });
 
       const navigated = await Promise.race([
         navigateWhenReady,
-        startReq.then(() => "started" as const),
+        startReq.then((device) => device ?? ("started" as const)),
       ]);
 
       if (navigated === true) return;
+      if (typeof navigated === "string" && navigated !== "started" && navigated !== d.udid) {
+        const nextUrl = new URL(window.location.href);
+        nextUrl.searchParams.set("device", navigated);
+        window.location.assign(nextUrl.toString());
+        return;
+      }
       const ready = await navigateWhenReady;
       if (ready) return;
       throw new Error("serve-sim started but no stream state appeared");
@@ -96,7 +103,7 @@ export function BootEmptyState({
       <div className="flex flex-col items-center gap-3 text-center">
         <h1 className="text-[18px] m-0 text-white/90">No serve-sim stream running</h1>
         <p className="text-white/55 text-[14px] max-w-120">
-          Pick a simulator to boot, or start one yourself with{" "}
+          Pick a device to boot, or start one yourself with{" "}
           <code className="bg-[#222] px-1.5 py-0.5 rounded text-[13px]">bunx serve-sim --detach</code>.
         </p>
         <div className="w-full max-w-90 mt-2 bg-panel border border-white/12 rounded-[10px] p-1 font-mono text-[13px] text-white/90 text-left max-h-[70vh] overflow-y-auto min-h-0">
@@ -109,7 +116,7 @@ export function BootEmptyState({
           {error && <div className="px-2.5 py-1.5 text-danger text-[11px]">{error}</div>}
           {startError && <div className="px-2.5 py-1.5 text-danger text-[11px]">{startError}</div>}
           {!loading && !error && devices.length === 0 && (
-            <div className="p-3 text-white/40 text-[11px] text-center">No available simulators found</div>
+          <div className="p-3 text-white/40 text-[11px] text-center">No available simulators or Android emulators found</div>
           )}
           {sortedGroups.map(([runtime, devs]) => (
             <div key={runtime}>

--- a/packages/serve-sim/src/client/components/boot-empty-state.tsx
+++ b/packages/serve-sim/src/client/components/boot-empty-state.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
 import { deviceKind, runtimeOrder, type SimDevice } from "../utils/devices";
 import { simEndpoint } from "../utils/sim-endpoint";
+import { PlatformBadge } from "./platform-badge";
 
 // ─── Empty state: pick a simulator to boot ───
 //
@@ -108,7 +109,7 @@ export function BootEmptyState({
         </p>
         <div className="w-full max-w-90 mt-2 bg-panel border border-white/12 rounded-[10px] p-1 font-mono text-[13px] text-white/90 text-left max-h-[70vh] overflow-y-auto min-h-0">
           <div className="flex items-center justify-between px-2.5 py-1.5 text-[11px] text-white/65">
-            <span className="font-semibold">Simulators</span>
+            <span className="font-semibold">Devices</span>
             <button onClick={onRefresh} disabled={loading} className="bg-transparent border-none text-accent text-[11px] cursor-pointer p-0">
               {loading ? "..." : "Refresh"}
             </button>
@@ -135,7 +136,8 @@ export function BootEmptyState({
                       className="size-1.5 rounded-full shrink-0"
                       style={{ background: isBooted ? "#4ade80" : "#444" }}
                     />
-                    <span className="flex-1 text-left">{d.name}</span>
+                    <PlatformBadge platform={d.platform} compact />
+                    <span className="flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-left">{d.name}</span>
                     <span className={`text-[10px] ${isStarting ? "text-accent" : "text-white/55"}`}>
                       {isStarting
                         ? (isBooted ? "Starting..." : "Booting...")

--- a/packages/serve-sim/src/client/components/device-picker.tsx
+++ b/packages/serve-sim/src/client/components/device-picker.tsx
@@ -64,7 +64,7 @@ export function DevicePicker({
       {open && (
         <div className="absolute top-[calc(100%+6px)] left-0 min-w-65 max-h-90 overflow-y-auto bg-panel border border-white/12 rounded-[10px] p-1 shadow-[0_8px_24px_rgba(0,0,0,0.5)] font-mono text-[13px] text-white/90 z-20">
           <div className="flex items-center justify-between px-2.5 py-1.5 text-[11px] text-white/65">
-            <span className="font-semibold">Simulators</span>
+            <span className="font-semibold">Devices</span>
             <button
               onClick={(e) => { e.stopPropagation(); onRefresh(); }}
               disabled={loading}
@@ -87,7 +87,7 @@ export function DevicePicker({
             </>
           )}
           {devices.length === 0 && !loading && !error && (
-            <div className="p-3 text-white/40 text-[11px] text-center">No available simulators found</div>
+            <div className="p-3 text-white/40 text-[11px] text-center">No available devices found</div>
           )}
           {sortedGroups.map(([runtime, devs]) => (
             <div key={runtime}>

--- a/packages/serve-sim/src/client/components/device-picker.tsx
+++ b/packages/serve-sim/src/client/components/device-picker.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { deviceKind, runtimeOrder, type SimDevice } from "../utils/devices";
+import { canShutdownDevice } from "../utils/grid";
 import { PlatformBadge } from "./platform-badge";
 
 // Inline dropdown — no shadcn / hugeicons dependency so the serve-sim client
@@ -97,6 +98,7 @@ export function DevicePicker({
               {devs.map((d) => {
                 const isStopping = stoppingUdids.has(d.udid);
                 const isBooted = d.state === "Booted";
+                const canStop = canShutdownDevice(d.platform, d.udid);
                 return (
                   <div
                     key={d.udid}
@@ -109,7 +111,7 @@ export function DevicePicker({
                     />
                     <PlatformBadge platform={d.platform} compact />
                     <span className="flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">{d.name}</span>
-                    {isBooted && (
+                    {isBooted && canStop && (
                       <span
                         role="button"
                         onClick={(e) => { e.stopPropagation(); if (!isStopping) onStop(d.udid); }}

--- a/packages/serve-sim/src/client/components/device-picker.tsx
+++ b/packages/serve-sim/src/client/components/device-picker.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { deviceKind, runtimeOrder, type SimDevice } from "../utils/devices";
+import { PlatformBadge } from "./platform-badge";
 
 // Inline dropdown — no shadcn / hugeicons dependency so the serve-sim client
 // stays self-contained.
@@ -81,7 +82,8 @@ export function DevicePicker({
                   className="size-1.5 rounded-full shrink-0"
                   style={{ background: selected.state === "Booted" ? "#4ade80" : "#444" }}
                 />
-                <span className="flex-1">{selected.name}</span>
+                <PlatformBadge platform={selected.platform} compact />
+                <span className="flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">{selected.name}</span>
               </div>
               <div className="h-px bg-white/8 my-1" />
             </>
@@ -105,7 +107,8 @@ export function DevicePicker({
                       className="size-1.5 rounded-full shrink-0"
                       style={{ background: isBooted ? "#4ade80" : "#444" }}
                     />
-                    <span className="flex-1">{d.name}</span>
+                    <PlatformBadge platform={d.platform} compact />
+                    <span className="flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">{d.name}</span>
                     {isBooted && (
                       <span
                         role="button"

--- a/packages/serve-sim/src/client/components/grid-capacity-banner.tsx
+++ b/packages/serve-sim/src/client/components/grid-capacity-banner.tsx
@@ -12,7 +12,7 @@ export function GridCapacityBanner({ report }: { report: MemoryReport | null }) 
   return (
     <div className="inline-flex items-center gap-1.5 px-2 py-[3px] rounded-full bg-[#101010] border border-[#222] font-mono text-[11px] text-white/70 leading-none">
       <span className="size-1.5 rounded-[3px] shrink-0" style={{ background: dotColor }} />
-      <span>{runningSimulators}/{capacity} devices</span>
+      <span>{runningSimulators}/{capacity} iOS sims</span>
       <span className="text-white/40">·</span>
       <span className="text-white/55">{formatGridBytes(availableBytes)} free</span>
       <span aria-hidden className="ml-0.5 w-7 h-[3px] bg-[#1c1c1c] rounded-[2px] overflow-hidden inline-block">

--- a/packages/serve-sim/src/client/components/grid-capacity-banner.tsx
+++ b/packages/serve-sim/src/client/components/grid-capacity-banner.tsx
@@ -12,7 +12,7 @@ export function GridCapacityBanner({ report }: { report: MemoryReport | null }) 
   return (
     <div className="inline-flex items-center gap-1.5 px-2 py-[3px] rounded-full bg-[#101010] border border-[#222] font-mono text-[11px] text-white/70 leading-none">
       <span className="size-1.5 rounded-[3px] shrink-0" style={{ background: dotColor }} />
-      <span>{runningSimulators}/{capacity} sims</span>
+      <span>{runningSimulators}/{capacity} devices</span>
       <span className="text-white/40">·</span>
       <span className="text-white/55">{formatGridBytes(availableBytes)} free</span>
       <span aria-hidden className="ml-0.5 w-7 h-[3px] bg-[#1c1c1c] rounded-[2px] overflow-hidden inline-block">

--- a/packages/serve-sim/src/client/components/grid-panel.tsx
+++ b/packages/serve-sim/src/client/components/grid-panel.tsx
@@ -53,24 +53,26 @@ export function GridPanel({
   );
 
   const start = useCallback(
-    async (udid: string) => {
+    async (device: GridDevice) => {
       if (!startEndpoint) return;
+      const udid = device.device;
       setPending((p) => ({ ...p, [udid]: true }));
       setErrors((e) => ({ ...e, [udid]: null }));
       try {
         const res = await fetch(startEndpoint, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ udid }),
+          body: JSON.stringify({ udid, platform: device.platform ?? "ios" }),
         });
         const json = await res.json().catch(() => ({}));
         if (!res.ok || !json.ok) {
           setErrors((e) => ({ ...e, [udid]: json.error ?? `HTTP ${res.status}` }));
           return;
         }
-        const ready = await waitForHelper(udid);
+        const startedDevice = json.device ?? udid;
+        const ready = await waitForHelper(startedDevice);
         if (ready) {
-          window.location.assign(gridPreviewHref(previewEndpoint, udid));
+          window.location.assign(gridPreviewHref(previewEndpoint, startedDevice));
           return;
         }
         setErrors((e) => ({ ...e, [udid]: "Helper did not register in time" }));
@@ -97,15 +99,16 @@ export function GridPanel({
   }, [devices, currentUdid, previewEndpoint]);
 
   const shutdown = useCallback(
-    async (udid: string) => {
+    async (device: GridDevice) => {
       if (!shutdownEndpoint) return;
+      const udid = device.device;
       setShuttingDown((s) => ({ ...s, [udid]: true }));
       setErrors((e) => ({ ...e, [udid]: null }));
       try {
         const res = await fetch(shutdownEndpoint, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ udid }),
+          body: JSON.stringify({ udid, platform: device.platform ?? "ios" }),
         });
         const json = await res.json().catch(() => ({}));
         if (!res.ok || !json.ok) {
@@ -124,7 +127,7 @@ export function GridPanel({
   return (
     <Panel open={open} width={width}>
       <PanelHeader>
-        <PanelTitle>Simulators</PanelTitle>
+        <PanelTitle>Devices</PanelTitle>
         <div className="flex items-center gap-2">
           <GridCapacityBanner report={memory} />
           <PanelCloseButton onClick={onClose} />
@@ -132,7 +135,7 @@ export function GridPanel({
       </PanelHeader>
       <div className="flex-1 min-h-0 overflow-y-auto p-3.5 grid auto-rows-[minmax(300px,auto)] gap-3 content-start grid-cols-[repeat(auto-fill,minmax(200px,1fr))]">
         {devices === null ? null : devices.length === 0 ? (
-          <div className="col-span-full bg-panel border border-dashed border-white/10 rounded-[10px] p-4 text-white/50 text-[12px] text-center">No iOS simulators available.</div>
+          <div className="col-span-full bg-panel border border-dashed border-white/10 rounded-[10px] p-4 text-white/50 text-[12px] text-center">No simulators or Android emulators available.</div>
         ) : (
           devices.map((d) => (
             <GridTile
@@ -143,8 +146,8 @@ export function GridPanel({
               starting={!!pending[d.device]}
               shuttingDown={!!shuttingDown[d.device]}
               error={errors[d.device] ?? null}
-              onStart={() => start(d.device)}
-              onShutdown={() => shutdown(d.device)}
+              onStart={() => start(d)}
+              onShutdown={() => shutdown(d)}
             />
           ))
         )}

--- a/packages/serve-sim/src/client/components/grid-panel.tsx
+++ b/packages/serve-sim/src/client/components/grid-panel.tsx
@@ -86,8 +86,8 @@ export function GridPanel({
     [startEndpoint, refresh, waitForHelper, previewEndpoint],
   );
 
-  // If the currently-focused simulator's helper disappears from the API,
-  // hop to another live helper.
+  // If the currently-focused device's helper disappears from the API, hop to
+  // another live helper.
   useEffect(() => {
     if (!devices || !currentUdid) return;
     const current = devices.find((d) => d.device === currentUdid);
@@ -135,7 +135,7 @@ export function GridPanel({
       </PanelHeader>
       <div className="flex-1 min-h-0 overflow-y-auto p-3.5 grid auto-rows-[minmax(300px,auto)] gap-3 content-start grid-cols-[repeat(auto-fill,minmax(200px,1fr))]">
         {devices === null ? null : devices.length === 0 ? (
-          <div className="col-span-full bg-panel border border-dashed border-white/10 rounded-[10px] p-4 text-white/50 text-[12px] text-center">No simulators or Android emulators available.</div>
+          <div className="col-span-full bg-panel border border-dashed border-white/10 rounded-[10px] p-4 text-white/50 text-[12px] text-center">No iOS simulators or Android emulators available.</div>
         ) : (
           devices.map((d) => (
             <GridTile

--- a/packages/serve-sim/src/client/components/grid-tile.tsx
+++ b/packages/serve-sim/src/client/components/grid-tile.tsx
@@ -1,4 +1,4 @@
-import { type GridDevice, gridPreviewHref } from "../utils/grid";
+import { canShutdownDevice, canStartDevice, type GridDevice, gridPreviewHref } from "../utils/grid";
 import { PlatformBadge } from "./platform-badge";
 
 export function GridTile({
@@ -23,6 +23,17 @@ export function GridTile({
   const helper = device.helper;
   const isBooted = device.state === "Booted";
   const platform = device.platform ?? "ios";
+  const canPowerOff = canShutdownDevice(platform, device.device);
+  const canStopOrShutdown = !!helper || (canPowerOff && isBooted);
+  const canStart = canStartDevice(device);
+  const stopLabel = platform === "android" && !canPowerOff
+    ? "Stop Android stream"
+    : `Shutdown ${platform === "android" ? "Android emulator" : "simulator"}`;
+  const startLabel = !canStart
+    ? device.state === "Unauthorized" ? "Unauthorized" : "Unavailable"
+    : starting
+    ? (isBooted ? "Starting..." : "Booting...")
+    : (isBooted ? "Start stream" : "Boot & start");
   const status = helper
     ? "● live"
     : starting
@@ -44,11 +55,11 @@ export function GridTile({
       className="grid-tile relative flex flex-col bg-[#111] rounded-[10px] overflow-hidden no-underline text-inherit border border-[#2a2a2a] [transition:border-color_120ms]"
       style={{ outline: `1px solid ${ringColor}` }}
     >
-      {(helper || isBooted) && (
+      {canStopOrShutdown && (
         <button
           type="button"
-          title={shuttingDown ? "Shutting down…" : `Shutdown ${platform === "android" ? "Android device" : "simulator"}`}
-          aria-label={`Shutdown ${platform === "android" ? "Android device" : "simulator"}`}
+          title={shuttingDown ? "Stopping..." : stopLabel}
+          aria-label={stopLabel}
           onClick={(e) => {
             e.preventDefault();
             e.stopPropagation();
@@ -83,16 +94,16 @@ export function GridTile({
               style={{ borderTopColor: "rgba(155,201,155,0.95)" }}
             />
           ) : (
-            <div className="text-[28px] opacity-50">{isBooted ? "▣" : "▢"}</div>
+            <div className="text-[28px] text-[#777]">{isBooted ? "▣" : "▢"}</div>
           )}
           {error ? <div className="text-danger text-[11px] font-mono">{error}</div> : null}
           <button
             type="button"
             onClick={(e) => { e.preventDefault(); e.stopPropagation(); onStart(); }}
-            disabled={starting}
-            className={`px-3 py-1.5 rounded-md border border-[#333] text-[11px] font-mono ${starting ? "bg-[#1a1a1a] text-white/55 cursor-default" : "bg-[#1d2a1d] text-success cursor-pointer"}`}
+            disabled={starting || !canStart}
+            className={`px-3 py-1.5 rounded-md border border-[#333] text-[11px] font-mono ${starting || !canStart ? "bg-[#1a1a1a] text-white/55 cursor-default" : "bg-[#1d2a1d] text-success cursor-pointer"}`}
           >
-            {starting ? (isBooted ? "Starting…" : "Booting…") : (isBooted ? "Start stream" : "Boot & start")}
+            {startLabel}
           </button>
         </div>
       )}

--- a/packages/serve-sim/src/client/components/grid-tile.tsx
+++ b/packages/serve-sim/src/client/components/grid-tile.tsx
@@ -1,4 +1,5 @@
 import { type GridDevice, gridPreviewHref } from "../utils/grid";
+import { PlatformBadge } from "./platform-badge";
 
 export function GridTile({
   device,
@@ -95,8 +96,11 @@ export function GridTile({
           </button>
         </div>
       )}
-      <div className="px-2.5 py-1.5 border-t border-[#222] text-[11px] font-mono text-white/70 flex justify-between gap-2">
-        <span className="overflow-hidden text-ellipsis whitespace-nowrap">{device.name}</span>
+      <div className="px-2.5 py-1.5 border-t border-[#222] text-[11px] font-mono text-white/70 flex items-center justify-between gap-2">
+        <span className="flex min-w-0 items-center gap-1.5">
+          <PlatformBadge platform={platform} compact />
+          <span className="overflow-hidden text-ellipsis whitespace-nowrap">{device.name}</span>
+        </span>
         <span className="whitespace-nowrap" style={{ color: statusColor }}>
           {status}
           {helper ? <span className="text-white/40"> :{helper.port}</span> : null}

--- a/packages/serve-sim/src/client/components/grid-tile.tsx
+++ b/packages/serve-sim/src/client/components/grid-tile.tsx
@@ -21,6 +21,7 @@ export function GridTile({
 }) {
   const helper = device.helper;
   const isBooted = device.state === "Booted";
+  const platform = device.platform ?? "ios";
   const status = helper
     ? "● live"
     : starting
@@ -45,8 +46,8 @@ export function GridTile({
       {(helper || isBooted) && (
         <button
           type="button"
-          title={shuttingDown ? "Shutting down…" : "Shutdown simulator"}
-          aria-label="Shutdown simulator"
+          title={shuttingDown ? "Shutting down…" : `Shutdown ${platform === "android" ? "Android device" : "simulator"}`}
+          aria-label={`Shutdown ${platform === "android" ? "Android device" : "simulator"}`}
           onClick={(e) => {
             e.preventDefault();
             e.stopPropagation();
@@ -58,7 +59,12 @@ export function GridTile({
           ×
         </button>
       )}
-      {helper ? (
+      {helper && platform === "android" ? (
+        <div className="flex-1 min-h-0 flex items-center justify-center p-3 flex-col gap-2 text-white/70 text-[12px] text-center bg-black pointer-events-none">
+          <div className="text-[24px] text-white">▣</div>
+          <div className="font-mono">H.264 stream</div>
+        </div>
+      ) : helper ? (
         <div className="flex-1 min-h-0 flex items-center justify-center p-2 bg-black pointer-events-none">
           <img
             src={helper.streamUrl}

--- a/packages/serve-sim/src/client/components/platform-badge.tsx
+++ b/packages/serve-sim/src/client/components/platform-badge.tsx
@@ -1,0 +1,24 @@
+export type DevicePlatform = "ios" | "android";
+
+export function platformLabel(platform?: DevicePlatform): string {
+  return platform === "android" ? "Android" : "iOS";
+}
+
+export function PlatformBadge({
+  platform,
+  compact = false,
+  className = "",
+}: {
+  platform?: DevicePlatform;
+  compact?: boolean;
+  className?: string;
+}) {
+  const android = platform === "android";
+  return (
+    <span
+      className={`inline-flex shrink-0 items-center justify-center rounded-[5px] border font-mono uppercase ${compact ? "h-[18px] px-1.5 text-[9px]" : "h-[20px] px-2 text-[10px]"} ${android ? "border-[#22c55e] bg-[#052e24] text-[#bbf7d0]" : "border-[#60a5fa] bg-[#0b1f3a] text-[#dbeafe]"} ${className}`}
+    >
+      {android ? "Android" : "iOS"}
+    </span>
+  );
+}

--- a/packages/serve-sim/src/client/components/tools-panel.tsx
+++ b/packages/serve-sim/src/client/components/tools-panel.tsx
@@ -5,12 +5,14 @@ import { AppDetectionTool } from "./app-detection-tool";
 import { AppPermissionsTool } from "./app-permissions-tool";
 import { AxTreeTool } from "./ax-tree-tool";
 import { CameraTool } from "./camera-tool";
+import type { DevicePlatform } from "./platform-badge";
 
 export function ToolsPanel({
   open,
   onClose,
   udid,
   currentApp,
+  platform = "ios",
   axOverlayEnabled,
   onToggleAxOverlay,
   width,
@@ -19,10 +21,14 @@ export function ToolsPanel({
   onClose: () => void;
   udid: string;
   currentApp: { bundleId: string; isReactNative: boolean; pid?: number } | null;
+  platform?: DevicePlatform;
   axOverlayEnabled: boolean;
   onToggleAxOverlay: () => void;
   width: number;
 }) {
+  const isAndroid = platform === "android";
+  const supportsLocation = platform === "ios" || udid.startsWith("emulator-");
+
   return (
     <Panel open={open} width={width}>
       <PanelHeader>
@@ -32,14 +38,16 @@ export function ToolsPanel({
 
       {open && (
         <div className="p-3.5 overflow-y-auto flex-1 flex flex-col gap-3">
-          <AppDetectionTool udid={udid} currentApp={currentApp} />
-          <AxTreeTool
-            overlayEnabled={axOverlayEnabled}
-            onToggleOverlay={onToggleAxOverlay}
-          />
-          <CameraTool udid={udid} bundleId={currentApp?.bundleId ?? null} />
-          <LocationEmulationTool udid={udid} exec={execOnHost} />
-          <AppPermissionsTool udid={udid} bundleId={currentApp?.bundleId ?? null} />
+          <AppDetectionTool udid={udid} currentApp={currentApp} platform={platform} />
+          {!isAndroid && (
+            <AxTreeTool
+              overlayEnabled={axOverlayEnabled}
+              onToggleOverlay={onToggleAxOverlay}
+            />
+          )}
+          {!isAndroid && <CameraTool udid={udid} bundleId={currentApp?.bundleId ?? null} />}
+          {supportsLocation && <LocationEmulationTool udid={udid} exec={execOnHost} platform={platform} />}
+          {!isAndroid && <AppPermissionsTool udid={udid} bundleId={currentApp?.bundleId ?? null} />}
         </div>
       )}
     </Panel>

--- a/packages/serve-sim/src/client/hooks/use-h264-stream.ts
+++ b/packages/serve-sim/src/client/hooks/use-h264-stream.ts
@@ -8,6 +8,9 @@ const FRAME_DURATION_US = 16_667;
 const MAX_DECODE_QUEUE = 2;
 const RETRY_DELAY_MS = 500;
 const STREAM_STALL_MS = 5000;
+const STARTUP_BYTE_TIMEOUT_MS = 3000;
+const STARTUP_FRAME_TIMEOUT_MS = 6000;
+const STARTUP_FAILURE_LIMIT = 3;
 
 function videoStreamUrl(streamUrl: string): string {
   const url = new URL(streamUrl);
@@ -65,6 +68,8 @@ export function useH264Stream(streamUrl: string | null, enabled = true) {
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
     let decoder: any = null;
     let activeReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+    let startupFailures = 0;
+    let hasDecodedFrame = false;
     const baseUrl = streamUrl.replace(/\/stream\.mjpeg$/, "");
 
     const applyConfig = (next: StreamConfig) => {
@@ -112,6 +117,16 @@ export function useH264Stream(streamUrl: string | null, enabled = true) {
       void closeDecoder();
     };
 
+    const recordStartupFailure = () => {
+      if (stopped || controller.signal.aborted) return true;
+      startupFailures++;
+      if (startupFailures >= STARTUP_FAILURE_LIMIT) {
+        markUnsupported();
+        return true;
+      }
+      return false;
+    };
+
     const scheduleRetry = (delayMs = RETRY_DELAY_MS) => {
       if (stopped || controller.signal.aborted || retryTimer) return;
       retryTimer = setTimeout(() => {
@@ -128,6 +143,8 @@ export function useH264Stream(streamUrl: string | null, enabled = true) {
     };
 
     const emitFrame = (frame: any) => {
+      hasDecodedFrame = true;
+      startupFailures = 0;
       const width = Number(frame.displayWidth || frame.codedWidth || 0);
       const height = Number(frame.displayHeight || frame.codedHeight || 0);
       if (width > 0 && height > 0) {
@@ -148,14 +165,25 @@ export function useH264Stream(streamUrl: string | null, enabled = true) {
       let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
       let readDecoder: any = null;
       let lastByteAt = Date.now();
+      let sawBytes = false;
+      let startupFailureRecorded = false;
+      let startupByteTimer: ReturnType<typeof setTimeout> | null = null;
+      let startupFrameTimer: ReturnType<typeof setTimeout> | null = null;
       let stallTimer: ReturnType<typeof setInterval> | null = null;
       await closeDecoder();
+
+      const recordReadStartupFailure = () => {
+        if (startupFailureRecorded) return stopped || controller.signal.aborted;
+        startupFailureRecorded = true;
+        return recordStartupFailure();
+      };
 
       try {
         decoder = new VideoDecoderCtor({
           output: emitFrame,
           error: (err: unknown) => {
             console.warn("[android-video]", err);
+            if (!hasDecodedFrame && recordReadStartupFailure()) return;
             restartStream();
           },
         });
@@ -195,20 +223,36 @@ export function useH264Stream(streamUrl: string | null, enabled = true) {
 
         const res = await fetch(videoStreamUrl(streamUrl), { signal: controller.signal });
         if (!res.ok || !res.body) {
-          if (res.status === 404 || res.status === 415) markUnsupported();
-          scheduleRetry();
+          if (res.status === 404 || res.status === 415) {
+            markUnsupported();
+          } else if (!recordReadStartupFailure()) {
+            scheduleRetry();
+          }
           return;
         }
 
         reader = res.body.getReader();
         activeReader = reader;
+        startupByteTimer = setTimeout(() => {
+          if (sawBytes || stopped || controller.signal.aborted) return;
+          if (!recordReadStartupFailure()) restartStream();
+        }, STARTUP_BYTE_TIMEOUT_MS);
+        startupFrameTimer = setTimeout(() => {
+          if (hasDecodedFrame || stopped || controller.signal.aborted) return;
+          if (!recordReadStartupFailure()) restartStream();
+        }, STARTUP_FRAME_TIMEOUT_MS);
         stallTimer = setInterval(() => {
           if (Date.now() - lastByteAt > STREAM_STALL_MS) restartStream();
         }, 1000);
         while (true) {
           const { done, value } = await reader.read();
           if (done) break;
-          if (value) {
+          if (value?.byteLength) {
+            sawBytes = true;
+            if (startupByteTimer) {
+              clearTimeout(startupByteTimer);
+              startupByteTimer = null;
+            }
             lastByteAt = Date.now();
             parser.push(value);
           }
@@ -217,7 +261,10 @@ export function useH264Stream(streamUrl: string | null, enabled = true) {
         parser.flush();
       } catch {
         // Aborted or network error; retry below unless cleanup is in progress.
+        if (!sawBytes) recordReadStartupFailure();
       } finally {
+        if (startupByteTimer) clearTimeout(startupByteTimer);
+        if (startupFrameTimer) clearTimeout(startupFrameTimer);
         if (stallTimer) clearInterval(stallTimer);
         if (reader && activeReader === reader) activeReader = null;
         await closeDecoder(readDecoder);

--- a/packages/serve-sim/src/client/hooks/use-h264-stream.ts
+++ b/packages/serve-sim/src/client/hooks/use-h264-stream.ts
@@ -6,6 +6,8 @@ type VideoFrameSubscriber = (frame: any) => void;
 
 const FRAME_DURATION_US = 16_667;
 const MAX_DECODE_QUEUE = 2;
+const RETRY_DELAY_MS = 500;
+const STREAM_STALL_MS = 5000;
 
 function videoStreamUrl(streamUrl: string): string {
   const url = new URL(streamUrl);
@@ -52,6 +54,7 @@ export function useH264Stream(streamUrl: string | null, enabled = true) {
     let stopped = false;
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
     let decoder: any = null;
+    let activeReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
     const baseUrl = streamUrl.replace(/\/stream\.mjpeg$/, "");
 
     const applyConfig = (next: StreamConfig) => {
@@ -78,10 +81,10 @@ export function useH264Stream(streamUrl: string | null, enabled = true) {
     fetchConfig();
     const configInterval = setInterval(fetchConfig, 1000);
 
-    const closeDecoder = async () => {
-      if (!decoder) return;
-      const current = decoder;
-      decoder = null;
+    const closeDecoder = async (target?: any) => {
+      const current = target ?? decoder;
+      if (!current) return;
+      if (!target || decoder === target) decoder = null;
       try {
         if (current.state !== "closed") current.close();
       } catch {}
@@ -98,12 +101,19 @@ export function useH264Stream(streamUrl: string | null, enabled = true) {
       void closeDecoder();
     };
 
-    const scheduleRetry = () => {
+    const scheduleRetry = (delayMs = RETRY_DELAY_MS) => {
       if (stopped || controller.signal.aborted || retryTimer) return;
       retryTimer = setTimeout(() => {
         retryTimer = null;
         void readStream();
-      }, 250);
+      }, delayMs);
+    };
+
+    const restartStream = () => {
+      if (stopped || controller.signal.aborted) return;
+      void activeReader?.cancel().catch(() => {});
+      void closeDecoder();
+      scheduleRetry();
     };
 
     const emitFrame = (frame: any) => {
@@ -124,6 +134,10 @@ export function useH264Stream(streamUrl: string | null, enabled = true) {
     const readStream = async () => {
       let timestamp = 0;
       let sawKeyFrame = false;
+      let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+      let readDecoder: any = null;
+      let lastByteAt = Date.now();
+      let stallTimer: ReturnType<typeof setInterval> | null = null;
       await closeDecoder();
 
       try {
@@ -131,9 +145,10 @@ export function useH264Stream(streamUrl: string | null, enabled = true) {
           output: emitFrame,
           error: (err: unknown) => {
             console.warn("[android-video]", err);
-            markUnsupported();
+            restartStream();
           },
         });
+        readDecoder = decoder;
         try {
           decoder.configure({
             codec: "avc1.42E01E",
@@ -152,7 +167,8 @@ export function useH264Stream(streamUrl: string | null, enabled = true) {
           sawKeyFrame = true;
           const chunkTimestamp = timestamp;
           timestamp += FRAME_DURATION_US;
-          if (decoder?.decodeQueueSize >= MAX_DECODE_QUEUE && accessUnit.type !== "key") return;
+          if (!decoder || decoder.state === "closed") return;
+          if (decoder.decodeQueueSize >= MAX_DECODE_QUEUE && accessUnit.type !== "key") return;
           try {
             decoder.decode(new EncodedVideoChunkCtor({
               type: accessUnit.type,
@@ -162,7 +178,7 @@ export function useH264Stream(streamUrl: string | null, enabled = true) {
             }));
           } catch (err) {
             console.warn("[android-video]", err);
-            markUnsupported();
+            restartStream();
           }
         });
 
@@ -173,17 +189,27 @@ export function useH264Stream(streamUrl: string | null, enabled = true) {
           return;
         }
 
-        const reader = res.body.getReader();
+        reader = res.body.getReader();
+        activeReader = reader;
+        stallTimer = setInterval(() => {
+          if (Date.now() - lastByteAt > STREAM_STALL_MS) restartStream();
+        }, 1000);
         while (true) {
           const { done, value } = await reader.read();
           if (done) break;
-          if (value) parser.push(value);
+          if (value) {
+            lastByteAt = Date.now();
+            parser.push(value);
+          }
         }
+        if (activeReader === reader) activeReader = null;
         parser.flush();
       } catch {
         // Aborted or network error; retry below unless cleanup is in progress.
       } finally {
-        await closeDecoder();
+        if (stallTimer) clearInterval(stallTimer);
+        if (reader && activeReader === reader) activeReader = null;
+        await closeDecoder(readDecoder);
         scheduleRetry();
       }
     };

--- a/packages/serve-sim/src/client/hooks/use-h264-stream.ts
+++ b/packages/serve-sim/src/client/hooks/use-h264-stream.ts
@@ -1,0 +1,203 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { StreamConfig } from "serve-sim-client/simulator";
+import { H264AnnexBAccessUnitParser } from "../utils/h264-annex-b";
+
+type VideoFrameSubscriber = (frame: any) => void;
+
+const FRAME_DURATION_US = 16_667;
+const MAX_DECODE_QUEUE = 2;
+
+function videoStreamUrl(streamUrl: string): string {
+  const url = new URL(streamUrl);
+  url.pathname = url.pathname.replace(/\/stream\.mjpeg$/, "/stream.h264");
+  url.search = "";
+  return url.toString();
+}
+
+export function useH264Stream(streamUrl: string | null, enabled = true) {
+  const [config, setConfig] = useState<StreamConfig | null>(null);
+  const [supported, setSupported] = useState<boolean | null>(null);
+  const subscribersRef = useRef<Set<VideoFrameSubscriber>>(new Set());
+  const configRef = useRef<StreamConfig | null>(null);
+
+  const subscribeVideoFrame = useCallback((cb: VideoFrameSubscriber) => {
+    subscribersRef.current.add(cb);
+    return () => {
+      subscribersRef.current.delete(cb);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!enabled || !streamUrl) {
+      setSupported(null);
+      setConfig(null);
+      configRef.current = null;
+      return;
+    }
+
+    const VideoDecoderCtor = (window as any).VideoDecoder;
+    const EncodedVideoChunkCtor = (window as any).EncodedVideoChunk;
+    if (!VideoDecoderCtor || !EncodedVideoChunkCtor) {
+      setSupported(false);
+      setConfig(null);
+      configRef.current = null;
+      return;
+    }
+
+    configRef.current = null;
+    setConfig(null);
+    setSupported(true);
+
+    const controller = new AbortController();
+    let stopped = false;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    let decoder: any = null;
+    const baseUrl = streamUrl.replace(/\/stream\.mjpeg$/, "");
+
+    const applyConfig = (next: StreamConfig) => {
+      if (next.width <= 0 || next.height <= 0) return;
+      const prev = configRef.current;
+      if (
+        prev &&
+        prev.width === next.width &&
+        prev.height === next.height &&
+        prev.orientation === next.orientation
+      ) {
+        return;
+      }
+      configRef.current = next;
+      setConfig(next);
+    };
+
+    const fetchConfig = () => {
+      fetch(`${baseUrl}/config`, { signal: controller.signal })
+        .then((r) => r.json())
+        .then(applyConfig)
+        .catch(() => {});
+    };
+    fetchConfig();
+    const configInterval = setInterval(fetchConfig, 1000);
+
+    const closeDecoder = async () => {
+      if (!decoder) return;
+      const current = decoder;
+      decoder = null;
+      try {
+        if (current.state !== "closed") current.close();
+      } catch {}
+    };
+
+    const markUnsupported = () => {
+      setSupported(false);
+      stopped = true;
+      if (retryTimer) {
+        clearTimeout(retryTimer);
+        retryTimer = null;
+      }
+      controller.abort();
+      void closeDecoder();
+    };
+
+    const scheduleRetry = () => {
+      if (stopped || controller.signal.aborted || retryTimer) return;
+      retryTimer = setTimeout(() => {
+        retryTimer = null;
+        void readStream();
+      }, 250);
+    };
+
+    const emitFrame = (frame: any) => {
+      const width = Number(frame.displayWidth || frame.codedWidth || 0);
+      const height = Number(frame.displayHeight || frame.codedHeight || 0);
+      if (width > 0 && height > 0) {
+        applyConfig({ width, height });
+      }
+
+      const subscribers = [...subscribersRef.current];
+      try {
+        for (const subscriber of subscribers) subscriber(frame);
+      } finally {
+        frame.close?.();
+      }
+    };
+
+    const readStream = async () => {
+      let timestamp = 0;
+      let sawKeyFrame = false;
+      await closeDecoder();
+
+      try {
+        decoder = new VideoDecoderCtor({
+          output: emitFrame,
+          error: (err: unknown) => {
+            console.warn("[android-video]", err);
+            markUnsupported();
+          },
+        });
+        try {
+          decoder.configure({
+            codec: "avc1.42E01E",
+            hardwareAcceleration: "prefer-hardware",
+            optimizeForLatency: true,
+            avc: { format: "annexb" },
+          });
+        } catch (err) {
+          console.warn("[android-video]", err);
+          markUnsupported();
+          return;
+        }
+
+        const parser = new H264AnnexBAccessUnitParser((accessUnit) => {
+          if (!sawKeyFrame && accessUnit.type !== "key") return;
+          sawKeyFrame = true;
+          const chunkTimestamp = timestamp;
+          timestamp += FRAME_DURATION_US;
+          if (decoder?.decodeQueueSize >= MAX_DECODE_QUEUE && accessUnit.type !== "key") return;
+          try {
+            decoder.decode(new EncodedVideoChunkCtor({
+              type: accessUnit.type,
+              timestamp: chunkTimestamp,
+              duration: FRAME_DURATION_US,
+              data: accessUnit.data,
+            }));
+          } catch (err) {
+            console.warn("[android-video]", err);
+            markUnsupported();
+          }
+        });
+
+        const res = await fetch(videoStreamUrl(streamUrl), { signal: controller.signal });
+        if (!res.ok || !res.body) {
+          if (res.status === 404 || res.status === 415) markUnsupported();
+          scheduleRetry();
+          return;
+        }
+
+        const reader = res.body.getReader();
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          if (value) parser.push(value);
+        }
+        parser.flush();
+      } catch {
+        // Aborted or network error; retry below unless cleanup is in progress.
+      } finally {
+        await closeDecoder();
+        scheduleRetry();
+      }
+    };
+
+    void readStream();
+
+    return () => {
+      stopped = true;
+      if (retryTimer) clearTimeout(retryTimer);
+      controller.abort();
+      clearInterval(configInterval);
+      void closeDecoder();
+    };
+  }, [enabled, streamUrl]);
+
+  return { config, subscribeVideoFrame, supported };
+}

--- a/packages/serve-sim/src/client/hooks/use-h264-stream.ts
+++ b/packages/serve-sim/src/client/hooks/use-h264-stream.ts
@@ -16,6 +16,16 @@ function videoStreamUrl(streamUrl: string): string {
   return url.toString();
 }
 
+export function preserveStreamOrientation(
+  prev: StreamConfig | null,
+  next: StreamConfig,
+): StreamConfig {
+  if (next.orientation === undefined && prev?.orientation) {
+    return { ...next, orientation: prev.orientation };
+  }
+  return next;
+}
+
 export function useH264Stream(streamUrl: string | null, enabled = true) {
   const [config, setConfig] = useState<StreamConfig | null>(null);
   const [supported, setSupported] = useState<boolean | null>(null);
@@ -60,16 +70,17 @@ export function useH264Stream(streamUrl: string | null, enabled = true) {
     const applyConfig = (next: StreamConfig) => {
       if (next.width <= 0 || next.height <= 0) return;
       const prev = configRef.current;
+      const normalized = preserveStreamOrientation(prev, next);
       if (
         prev &&
-        prev.width === next.width &&
-        prev.height === next.height &&
-        prev.orientation === next.orientation
+        prev.width === normalized.width &&
+        prev.height === normalized.height &&
+        prev.orientation === normalized.orientation
       ) {
         return;
       }
-      configRef.current = next;
-      setConfig(next);
+      configRef.current = normalized;
+      setConfig(normalized);
     };
 
     const fetchConfig = () => {

--- a/packages/serve-sim/src/client/hooks/use-media-drop.ts
+++ b/packages/serve-sim/src/client/hooks/use-media-drop.ts
@@ -5,6 +5,7 @@ import type { ExecResult } from "../utils/exec";
 export function useMediaDrop({
   exec,
   udid,
+  platform = "ios",
   enabled,
   onUploadStart,
   onUploadProgress,
@@ -13,6 +14,7 @@ export function useMediaDrop({
 }: {
   exec: (command: string) => Promise<ExecResult>;
   udid: string | undefined;
+  platform?: "ios" | "android";
   enabled: boolean;
   onUploadStart: (name: string, kind: DropKind) => string;
   onUploadProgress: (id: string, progress: number | null) => void;
@@ -36,19 +38,19 @@ export function useMediaDrop({
 
       for (const file of files) {
         const kind = dropKindFor(file);
-        if (!kind) {
+        if (!kind || (platform === "ios" && kind === "apk") || (platform === "android" && kind === "ipa")) {
           onUnsupported(file);
           continue;
         }
         const id = onUploadStart(file.name, kind);
-        uploadDroppedFile(file, kind, exec, udid, (p) => onUploadProgress(id, p))
+        uploadDroppedFile(file, kind, exec, udid, platform, (p) => onUploadProgress(id, p))
           .then(() => onUploadEnd(id, true))
           .catch((err) =>
             onUploadEnd(id, false, err instanceof Error ? err.message : "Upload failed"),
           );
       }
     },
-    [enabled, udid, exec, onUploadStart, onUploadProgress, onUploadEnd, onUnsupported],
+    [enabled, udid, platform, exec, onUploadStart, onUploadProgress, onUploadEnd, onUnsupported],
   );
 
   const onDragOver = useCallback(

--- a/packages/serve-sim/src/client/hooks/use-mjpeg-stream.ts
+++ b/packages/serve-sim/src/client/hooks/use-mjpeg-stream.ts
@@ -6,7 +6,7 @@ import type { StreamConfig } from "serve-sim-client/simulator";
  * Chrome doesn't support multipart/x-mixed-replace in <img> tags,
  * so we manually read the stream and extract JPEG boundaries.
  */
-export function useMjpegStream(streamUrl: string | null) {
+export function useMjpegStream(streamUrl: string | null, enabled = true) {
   const [config, setConfig] = useState<StreamConfig | null>(null);
   const subscribersRef = useRef<Set<(blobUrl: string) => void>>(new Set());
 
@@ -19,7 +19,10 @@ export function useMjpegStream(streamUrl: string | null) {
   );
 
   useEffect(() => {
-    if (!streamUrl) return;
+    if (!enabled || !streamUrl) {
+      setConfig(null);
+      return;
+    }
     const controller = new AbortController();
     let stopped = false;
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
@@ -70,6 +73,32 @@ export function useMjpegStream(streamUrl: string | null) {
         }
 
         let buffer = new Uint8Array(0);
+        const headerTerminator = new TextEncoder().encode("\r\n\r\n");
+
+        const indexOfBytes = (haystack: Uint8Array, needle: Uint8Array) => {
+          outer:
+          for (let i = 0; i <= haystack.length - needle.length; i++) {
+            for (let j = 0; j < needle.length; j++) {
+              if (haystack[i + j] !== needle[j]) continue outer;
+            }
+            return i;
+          }
+          return -1;
+        };
+
+        const emitFrame = (bytes: Uint8Array, type: string) => {
+          const copy: Uint8Array<ArrayBuffer> = new Uint8Array(bytes.length);
+          copy.set(bytes);
+          const blob = new Blob([copy], { type });
+          const blobUrl = URL.createObjectURL(blob);
+          if (subscribersRef.current.size === 0) {
+            URL.revokeObjectURL(blobUrl);
+            return;
+          }
+          for (const cb of subscribersRef.current) {
+            cb(blobUrl);
+          }
+        };
 
         while (true) {
           const { done, value } = await reader.read();
@@ -81,9 +110,28 @@ export function useMjpegStream(streamUrl: string | null) {
           newBuf.set(value, buffer.length);
           buffer = newBuf;
 
-          // Look for JPEG frames: find Content-Length or JPEG markers (FFD8...FFD9)
-          // Simpler approach: split on boundary markers and extract JPEG data
+          // Prefer the multipart headers so Android's PNG screencap stream
+          // and iOS's JPEG stream share the same client path.
           while (true) {
+            const headerEnd = indexOfBytes(buffer, headerTerminator);
+            if (headerEnd !== -1) {
+              const header = new TextDecoder().decode(buffer.slice(0, headerEnd));
+              const length = Number(/Content-Length:\s*(\d+)/i.exec(header)?.[1]);
+              if (Number.isFinite(length) && length > 0) {
+                const frameStart = headerEnd + headerTerminator.length;
+                const frameEnd = frameStart + length;
+                if (buffer.length < frameEnd) break;
+                const contentType =
+                  /Content-Type:\s*([^\r\n]+)/i.exec(header)?.[1]?.trim() || "image/jpeg";
+                emitFrame(buffer.slice(frameStart, frameEnd), contentType);
+                buffer = buffer.slice(frameEnd);
+                continue;
+              }
+              buffer = buffer.slice(headerEnd + headerTerminator.length);
+              continue;
+            }
+
+            // Fallback for older helpers: find JPEG markers (FFD8...FFD9).
             // Find first JPEG start (FF D8)
             let jpegStart = -1;
             for (let i = 0; i < buffer.length - 1; i++) {
@@ -108,15 +156,7 @@ export function useMjpegStream(streamUrl: string | null) {
             const jpeg = buffer.slice(jpegStart, jpegEnd);
             buffer = buffer.slice(jpegEnd);
 
-            const blob = new Blob([jpeg], { type: "image/jpeg" });
-            const blobUrl = URL.createObjectURL(blob);
-            if (subscribersRef.current.size === 0) {
-              URL.revokeObjectURL(blobUrl);
-              continue;
-            }
-            for (const cb of subscribersRef.current) {
-              cb(blobUrl);
-            }
+            emitFrame(jpeg, "image/jpeg");
           }
         }
       } catch {
@@ -133,7 +173,7 @@ export function useMjpegStream(streamUrl: string | null) {
       controller.abort();
       clearInterval(configInterval);
     };
-  }, [streamUrl]);
+  }, [enabled, streamUrl]);
 
   return { subscribeFrame, frame: null, config };
 }

--- a/packages/serve-sim/src/client/hooks/use-mjpeg-stream.ts
+++ b/packages/serve-sim/src/client/hooks/use-mjpeg-stream.ts
@@ -50,9 +50,9 @@ export function useMjpegStream(streamUrl: string | null, enabled = true) {
     const configInterval = setInterval(fetchConfig, 1000);
 
     // Read the MJPEG stream and extract JPEG frames.
-    // ?raw=1 tells the server to use Content-Type application/octet-stream
-    // instead of multipart/x-mixed-replace; WebKit refuses to expose
-    // multipart bodies to fetch()'s ReadableStream.
+    // ?raw=1 requests application/octet-stream transport while preserving
+    // Content-Length frame boundaries; WebKit refuses to expose multipart
+    // bodies to fetch()'s ReadableStream.
     const fetchUrlObj = new URL(streamUrl);
     fetchUrlObj.searchParams.set("raw", "1");
     const fetchUrl = fetchUrlObj.toString();

--- a/packages/serve-sim/src/client/location-emulation-tool.tsx
+++ b/packages/serve-sim/src/client/location-emulation-tool.tsx
@@ -297,10 +297,14 @@ export function LocationEmulationTool({
       setError(null);
       return;
     }
-    void exec(cmd).then((res) => {
-      if (res.exitCode !== 0) setError(parseLocationError(res.stderr) || null);
-      else setError(null);
-    });
+    void exec(cmd)
+      .then((res) => {
+        if (res.exitCode !== 0) setError(parseLocationError(res.stderr) || null);
+        else setError(null);
+      })
+      .catch((err: unknown) => {
+        setError(parseLocationError(locationErrorText(err)) || null);
+      });
   }, [exec, udid, platform]);
 
   const onTrailChange = useCallback((id: string) => {
@@ -909,4 +913,9 @@ function parseLocationError(stderr: string): string {
   const m = trimmed.match(/Reason:\s*(.+)$/m);
   if (m) return m[1]!;
   return trimmed.split("\n").slice(-1)[0] ?? trimmed;
+}
+
+function locationErrorText(err: unknown): string {
+  const value = err as { stderr?: unknown; message?: unknown };
+  return String(value?.stderr || value?.message || err || "");
 }

--- a/packages/serve-sim/src/client/location-emulation-tool.tsx
+++ b/packages/serve-sim/src/client/location-emulation-tool.tsx
@@ -1,11 +1,9 @@
 // Location emulation panel + lightweight 3D trail viz.
 //
-// Drives `xcrun simctl location <udid> set <lat>,<lng>` on a fixed cadence
-// while a requestAnimationFrame loop advances the player position along a
-// pre-densified route. The route is rendered to a 2D canvas with a manual
-// orbiting orthographic camera — same family as Any Distance's RouteScene
-// (extruded ribbon + ground plane shadow) but flat-shaded so we don't pull
-// in WebGL or a 3D library.
+// Drives the platform-specific location command on a fixed cadence while a
+// requestAnimationFrame loop advances the player position along a pre-densified
+// route. The route is rendered to a 2D canvas with a manual orbiting
+// orthographic camera.
 
 import {
   memo,
@@ -38,6 +36,11 @@ import {
   StopGlyph,
   WalkGlyph,
 } from "./icons";
+import {
+  locationClearCommand,
+  locationSetCommand,
+  type LocationPlatform,
+} from "./utils/location-commands";
 
 const TRAIL_MORPH_MS = 650;
 
@@ -83,9 +86,11 @@ const INITIAL_PLAYBACK: PlaybackState = { status: "idle", arc: 0, elapsedMs: 0 }
 export function LocationEmulationTool({
   udid,
   exec,
+  platform = "ios",
 }: {
   udid: string;
   exec: ExecFn;
+  platform?: LocationPlatform;
 }) {
   const [open, setOpen] = useState(false);
   const [trailId, setTrailId] = useState<string>(DEFAULT_TRAILS[0]!.id);
@@ -214,10 +219,12 @@ export function LocationEmulationTool({
     return () => clearInterval(id);
   }, []);
 
-  // ── simctl bridge ────────────────────────────────────────────────────────
-  // Push the current lat/lng to the simulator on a fixed cadence whenever
-  // we're playing. Skipped while paused/idle so the simulator can hold its
-  // last position. On stop we run `... clear`.
+  // ── Host location bridge ────────────────────────────────────────────────
+  // Push the current lat/lng to the device on a fixed cadence whenever we're
+  // playing. Skipped while paused/idle so the device can hold its last
+  // position. On stop, iOS can clear the override; Android emulator location
+  // has no matching clear command, so we restore the session origin when we
+  // have one.
   useEffect(() => {
     if (playback.status !== "playing") return;
     let cancelled = false;
@@ -230,11 +237,11 @@ export function LocationEmulationTool({
       if (now - lastPushed < LOCATION_PUSH_INTERVAL_MS) return;
       lastPushed = now;
       const pt = pointAtDistance(trailRef.current, arcRef.current);
-      const cmd = `xcrun simctl location ${udid} set ${pt.lat.toFixed(7)},${pt.lng.toFixed(7)}`;
+      const cmd = locationSetCommand(platform, udid, pt);
       inflight = exec(cmd).then((res) => {
         if (cancelled) return;
         if (res.exitCode !== 0) {
-          setError(parseSimctlError(res.stderr) || "simctl location set failed");
+          setError(parseLocationError(res.stderr) || "Location update failed");
         } else {
           setError(null);
         }
@@ -249,7 +256,7 @@ export function LocationEmulationTool({
       cancelled = true;
       clearInterval(id);
     };
-  }, [playback.status, udid, exec]);
+  }, [playback.status, udid, exec, platform]);
 
   // ── Controls ─────────────────────────────────────────────────────────────
   const onPlayPause = useCallback(() => {
@@ -284,13 +291,17 @@ export function LocationEmulationTool({
     const origin = sessionOriginRef.current;
     sessionOriginRef.current = null;
     const cmd = origin
-      ? `xcrun simctl location ${udid} set ${origin.lat.toFixed(7)},${origin.lng.toFixed(7)}`
-      : `xcrun simctl location ${udid} clear`;
+      ? locationSetCommand(platform, udid, origin)
+      : locationClearCommand(platform, udid);
+    if (!cmd) {
+      setError(null);
+      return;
+    }
     void exec(cmd).then((res) => {
-      if (res.exitCode !== 0) setError(parseSimctlError(res.stderr) || null);
+      if (res.exitCode !== 0) setError(parseLocationError(res.stderr) || null);
       else setError(null);
     });
-  }, [exec, udid]);
+  }, [exec, udid, platform]);
 
   const onTrailChange = useCallback((id: string) => {
     setTrailId(id);
@@ -305,10 +316,11 @@ export function LocationEmulationTool({
     if (statusRef.current === "idle") return;
     const origin = sessionOriginRef.current;
     const cmd = origin
-      ? `xcrun simctl location ${udid} set ${origin.lat.toFixed(7)},${origin.lng.toFixed(7)}`
-      : `xcrun simctl location ${udid} clear`;
+      ? locationSetCommand(platform, udid, origin)
+      : locationClearCommand(platform, udid);
+    if (!cmd) return;
     void exec(cmd).catch(() => {});
-  }, [exec, udid]);
+  }, [exec, udid, platform]);
 
   // ── Render ───────────────────────────────────────────────────────────────
   const playing = playback.status === "playing";
@@ -387,7 +399,7 @@ export function LocationEmulationTool({
               onClick={onStop}
               className="lem-ghost flex items-center justify-center gap-1.5 py-2 px-3 border border-white/12 rounded-[7px] text-[12px] font-medium bg-transparent text-white/85 cursor-pointer font-[inherit]"
               disabled={playback.status === "idle" && playback.arc === 0}
-              title="Stop and clear simulated location"
+              title={platform === "android" ? "Stop simulated location" : "Stop and clear simulated location"}
             >
               <StopGlyph />
               <span>Stop</span>
@@ -890,7 +902,7 @@ function formatElevation(meters: number): string {
   return `${meters.toFixed(0)} m`;
 }
 
-function parseSimctlError(stderr: string): string {
+function parseLocationError(stderr: string): string {
   const trimmed = stderr.trim();
   if (!trimmed) return "";
   // Strip the leading "An error was encountered processing the command" noise.
@@ -898,4 +910,3 @@ function parseSimctlError(stderr: string): string {
   if (m) return m[1]!;
   return trimmed.split("\n").slice(-1)[0] ?? trimmed;
 }
-

--- a/packages/serve-sim/src/client/utils/devices.ts
+++ b/packages/serve-sim/src/client/utils/devices.ts
@@ -1,5 +1,6 @@
 export interface SimDevice {
   udid: string;
+  platform?: "ios" | "android";
   name: string;
   state: string;
   runtime: string;
@@ -15,7 +16,7 @@ export function parseSimctlList(stdout: string): SimDevice[] {
         .replace(/-/g, ".");
       for (const d of devs) {
         if (d.isAvailable) {
-          out.push({ udid: d.udid, name: d.name, state: d.state, runtime: runtimeName });
+          out.push({ udid: d.udid, platform: "ios", name: d.name, state: d.state, runtime: runtimeName });
         }
       }
     }
@@ -30,8 +31,9 @@ export function deviceKind(name: string): number {
   if (n.includes("iphone")) return 0;
   if (n.includes("ipad")) return 1;
   if (n.includes("watch")) return 2;
-  if (n.includes("vision")) return 3;
-  return 4;
+  if (n.includes("pixel") || n.includes("android") || n.includes("sdk")) return 3;
+  if (n.includes("vision")) return 4;
+  return 5;
 }
 
 export function runtimeOrder(runtime: string): number {
@@ -39,6 +41,7 @@ export function runtimeOrder(runtime: string): number {
   if (r.startsWith("ios")) return 0;
   if (r.startsWith("ipados")) return 1;
   if (r.startsWith("watchos")) return 2;
-  if (r.startsWith("visionos") || r.startsWith("xros")) return 3;
-  return 4;
+  if (r.startsWith("android")) return 3;
+  if (r.startsWith("visionos") || r.startsWith("xros")) return 4;
+  return 5;
 }

--- a/packages/serve-sim/src/client/utils/drop.ts
+++ b/packages/serve-sim/src/client/utils/drop.ts
@@ -2,8 +2,8 @@ import type { ExecResult } from "./exec";
 
 // ─── File drop (drag media/ipa onto the simulator) ───
 //
-// Media → `xcrun simctl addmedia`   (Photos)
-// .ipa  → `xcrun simctl install`    (install app on simulator)
+// Media → `xcrun simctl addmedia` / Android Downloads + media scan
+// .ipa/.apk → app install on simulator/emulator
 //
 // Files are streamed to /tmp over /exec in base64-chunked bash `echo | base64 -d`
 // calls. No sonner dep here, so uploads surface in an inline toast list.
@@ -25,7 +25,7 @@ export const DROP_MEDIA_MIME_TYPES = new Set([
 export const DROP_CHUNK_SIZE = 262144;
 export const DROP_MAX_FILE_SIZE = 500 * 1024 * 1024;
 
-export type DropKind = "media" | "ipa";
+export type DropKind = "media" | "ipa" | "apk";
 
 export function fileExtension(file: File): string {
   const name = file.name;
@@ -36,7 +36,9 @@ export function fileExtension(file: File): string {
 }
 
 export function dropKindFor(file: File): DropKind | null {
-  if (fileExtension(file) === "ipa") return "ipa";
+  const ext = fileExtension(file);
+  if (ext === "ipa") return "ipa";
+  if (ext === "apk") return "apk";
   if (DROP_MEDIA_MIME_TYPES.has(file.type)) return "media";
   return null;
 }
@@ -79,14 +81,15 @@ export async function uploadDroppedFile(
   kind: DropKind,
   exec: (command: string) => Promise<ExecResult>,
   udid: string,
+  platform: "ios" | "android",
   onProgress: (progress: number | null) => void,
 ) {
   if (file.size > DROP_MAX_FILE_SIZE) {
     throw new Error("File too large (max 500MB)");
   }
 
-  const ext = kind === "ipa" ? "ipa" : fileExtension(file);
-  const prefix = kind === "ipa" ? "serve-sim-install" : "serve-sim-upload";
+  const ext = kind === "ipa" || kind === "apk" ? kind : fileExtension(file);
+  const prefix = kind === "ipa" || kind === "apk" ? "serve-sim-install" : "serve-sim-upload";
   const tmpPath = `/tmp/${prefix}-${crypto.randomUUID()}.${ext}`;
 
   try {
@@ -112,12 +115,16 @@ export async function uploadDroppedFile(
 
     // install/addmedia gives no progress signal — flip to indeterminate.
     onProgress(null);
-    const cmd = kind === "ipa"
-      ? `xcrun simctl install ${udid} ${tmpPath}`
-      : `xcrun simctl addmedia ${udid} ${tmpPath}`;
+    const cmd = platform === "android"
+      ? kind === "apk"
+        ? `adb -s ${udid} install -r ${tmpPath}`
+        : `bash -c 'adb -s ${udid} push ${tmpPath} /sdcard/Download/ && adb -s ${udid} shell am broadcast -a android.intent.action.MEDIA_SCANNER_SCAN_FILE -d file:///sdcard/Download/${tmpPath.split("/").pop()}'`
+      : kind === "ipa"
+        ? `xcrun simctl install ${udid} ${tmpPath}`
+        : `xcrun simctl addmedia ${udid} ${tmpPath}`;
     const result = await exec(cmd);
     if (result.exitCode !== 0) {
-      const label = kind === "ipa" ? "install" : "addmedia";
+      const label = kind === "ipa" || kind === "apk" ? "install" : "addmedia";
       throw new Error(result.stderr || `${label} failed (exit ${result.exitCode})`);
     }
   } finally {

--- a/packages/serve-sim/src/client/utils/drop.ts
+++ b/packages/serve-sim/src/client/utils/drop.ts
@@ -88,6 +88,10 @@ export async function uploadDroppedFile(
   platform: "ios" | "android",
   onProgress: (progress: number | null) => void,
 ) {
+  if ((platform === "ios" && kind === "apk") || (platform === "android" && kind === "ipa")) {
+    throw new Error(`${kind.toUpperCase()} files are not supported on ${platform}`);
+  }
+
   if (file.size > DROP_MAX_FILE_SIZE) {
     throw new Error("File too large (max 500MB)");
   }

--- a/packages/serve-sim/src/client/utils/drop.ts
+++ b/packages/serve-sim/src/client/utils/drop.ts
@@ -1,4 +1,4 @@
-import type { ExecResult } from "./exec";
+import { shellEscape, type ExecResult } from "./exec";
 
 // ─── File drop (drag media/ipa onto the simulator) ───
 //
@@ -50,6 +50,10 @@ export function arrayBufferToBase64(buffer: ArrayBuffer): string {
   return btoa(binary);
 }
 
+function base64WriteCommand(chunk: string, op: ">" | ">>", path: string): string {
+  return `bash -c ${shellEscape(`echo ${chunk} | base64 -d ${op} ${shellEscape(path)}`)}`;
+}
+
 // Stream a file to /tmp via the /exec base64 chunk loop. Used by the camera
 // panel to stage image/video sources for `serve-sim camera --file`.
 // Caller is responsible for the lifetime of the temp file.
@@ -68,7 +72,7 @@ export async function uploadFileToTmp(
   for (let offset = 0; offset < b64.length; offset += DROP_CHUNK_SIZE) {
     const chunk = b64.slice(offset, offset + DROP_CHUNK_SIZE);
     const op = offset === 0 ? ">" : ">>";
-    const result = await exec(`bash -c 'echo ${chunk} | base64 -d ${op} ${tmpPath}'`);
+    const result = await exec(base64WriteCommand(chunk, op, tmpPath));
     if (result.exitCode !== 0) {
       throw new Error(result.stderr || `Write failed (exit ${result.exitCode})`);
     }
@@ -101,7 +105,7 @@ export async function uploadDroppedFile(
     for (let offset = 0; offset < b64.length; offset += DROP_CHUNK_SIZE) {
       const chunk = b64.slice(offset, offset + DROP_CHUNK_SIZE);
       const op = offset === 0 ? ">" : ">>";
-      const result = await exec(`bash -c 'echo ${chunk} | base64 -d ${op} ${tmpPath}'`);
+      const result = await exec(base64WriteCommand(chunk, op, tmpPath));
       if (result.exitCode !== 0) {
         throw new Error(result.stderr || `Write failed (exit ${result.exitCode})`);
       }
@@ -115,19 +119,34 @@ export async function uploadDroppedFile(
 
     // install/addmedia gives no progress signal — flip to indeterminate.
     onProgress(null);
-    const cmd = platform === "android"
-      ? kind === "apk"
-        ? `adb -s ${udid} install -r ${tmpPath}`
-        : `bash -c 'adb -s ${udid} push ${tmpPath} /sdcard/Download/ && adb -s ${udid} shell am broadcast -a android.intent.action.MEDIA_SCANNER_SCAN_FILE -d file:///sdcard/Download/${tmpPath.split("/").pop()}'`
-      : kind === "ipa"
-        ? `xcrun simctl install ${udid} ${tmpPath}`
-        : `xcrun simctl addmedia ${udid} ${tmpPath}`;
-    const result = await exec(cmd);
-    if (result.exitCode !== 0) {
+    const runCommand = async (cmd: string) => {
+      const result = await exec(cmd);
+      if (result.exitCode === 0) return;
       const label = kind === "ipa" || kind === "apk" ? "install" : "addmedia";
       throw new Error(result.stderr || `${label} failed (exit ${result.exitCode})`);
+    };
+
+    const escapedUdid = shellEscape(udid);
+    const escapedTmpPath = shellEscape(tmpPath);
+    if (platform === "android") {
+      if (kind === "apk") {
+        await runCommand(`adb -s ${escapedUdid} install -r ${escapedTmpPath}`);
+      } else {
+        const basename = tmpPath.split("/").pop()!;
+        const devicePath = `/sdcard/Download/${basename}`;
+        await runCommand(`adb -s ${escapedUdid} push ${escapedTmpPath} ${shellEscape(devicePath)}`);
+        await runCommand(
+          `adb -s ${escapedUdid} shell am broadcast -a android.intent.action.MEDIA_SCANNER_SCAN_FILE -d ${shellEscape(`file://${devicePath}`)}`,
+        );
+      }
+    } else {
+      await runCommand(
+        kind === "ipa"
+          ? `xcrun simctl install ${escapedUdid} ${escapedTmpPath}`
+          : `xcrun simctl addmedia ${escapedUdid} ${escapedTmpPath}`,
+      );
     }
   } finally {
-    exec(`bash -c 'rm -f ${tmpPath}'`).catch(() => {});
+    exec(`rm -f ${shellEscape(tmpPath)}`).catch(() => {});
   }
 }

--- a/packages/serve-sim/src/client/utils/grid.ts
+++ b/packages/serve-sim/src/client/utils/grid.ts
@@ -16,6 +16,18 @@ export interface MemoryReport {
   estimatedAdditional: number;
 }
 
+type DeviceActionTarget = Pick<GridDevice, "platform" | "state" | "runtime">;
+
+export function canStartDevice(device: DeviceActionTarget): boolean {
+  if ((device.platform ?? "ios") !== "android") return true;
+  if (device.state === "Booted") return true;
+  return device.state === "Shutdown" && /Android Emulator/i.test(device.runtime);
+}
+
+export function canShutdownDevice(platform: GridDevice["platform"], deviceId: string): boolean {
+  return (platform ?? "ios") !== "android" || deviceId.startsWith("emulator-");
+}
+
 export function formatGridBytes(n: number): string {
   if (!Number.isFinite(n) || n <= 0) return "0 B";
   const gb = n / (1024 * 1024 * 1024);

--- a/packages/serve-sim/src/client/utils/grid.ts
+++ b/packages/serve-sim/src/client/utils/grid.ts
@@ -1,5 +1,6 @@
 export interface GridDevice {
   device: string;
+  platform?: "ios" | "android";
   name: string;
   runtime: string;
   state: string;

--- a/packages/serve-sim/src/client/utils/h264-annex-b.ts
+++ b/packages/serve-sim/src/client/utils/h264-annex-b.ts
@@ -1,0 +1,199 @@
+export interface H264AccessUnit {
+  data: Uint8Array<ArrayBufferLike>;
+  type: "key" | "delta";
+}
+
+interface NalUnit {
+  bytes: Uint8Array<ArrayBufferLike>;
+  type: number;
+  isVcl: boolean;
+  firstMbInSlice: number | null;
+}
+
+function concatBytes(parts: Uint8Array<ArrayBufferLike>[]): Uint8Array<ArrayBufferLike> {
+  const total = parts.reduce((sum, part) => sum + part.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+function startCodeLength(bytes: Uint8Array<ArrayBufferLike>, offset: number): number {
+  if (bytes[offset] !== 0 || bytes[offset + 1] !== 0) return 0;
+  if (bytes[offset + 2] === 1) return 3;
+  if (bytes[offset + 2] === 0 && bytes[offset + 3] === 1) return 4;
+  return 0;
+}
+
+function findStartCode(
+  bytes: Uint8Array<ArrayBufferLike>,
+  from: number,
+): { index: number; length: number } | null {
+  for (let i = Math.max(0, from); i <= bytes.length - 3; i++) {
+    const length = startCodeLength(bytes, i);
+    if (length) return { index: i, length };
+  }
+  return null;
+}
+
+function nalHeaderOffset(bytes: Uint8Array<ArrayBufferLike>): number {
+  const length = startCodeLength(bytes, 0);
+  return length ? length : 0;
+}
+
+function nalType(bytes: Uint8Array<ArrayBufferLike>): number {
+  const offset = nalHeaderOffset(bytes);
+  return offset < bytes.length ? bytes[offset]! & 0x1f : 0;
+}
+
+function rbspFromNal(bytes: Uint8Array<ArrayBufferLike>): Uint8Array<ArrayBufferLike> {
+  const headerOffset = nalHeaderOffset(bytes);
+  const escaped = bytes.slice(headerOffset + 1);
+  const out: number[] = [];
+  for (let i = 0; i < escaped.length; i++) {
+    if (i >= 2 && escaped[i] === 0x03 && escaped[i - 1] === 0x00 && escaped[i - 2] === 0x00) {
+      continue;
+    }
+    out.push(escaped[i]!);
+  }
+  return new Uint8Array(out);
+}
+
+class BitReader {
+  private bitOffset = 0;
+
+  constructor(private readonly bytes: Uint8Array) {}
+
+  readBit(): number | null {
+    if (this.bitOffset >= this.bytes.length * 8) return null;
+    const byte = this.bytes[this.bitOffset >> 3]!;
+    const bit = (byte >> (7 - (this.bitOffset & 7))) & 1;
+    this.bitOffset++;
+    return bit;
+  }
+
+  readBits(count: number): number | null {
+    let value = 0;
+    for (let i = 0; i < count; i++) {
+      const bit = this.readBit();
+      if (bit == null) return null;
+      value = (value << 1) | bit;
+    }
+    return value;
+  }
+
+  readUnsignedExpGolomb(): number | null {
+    let leadingZeroes = 0;
+    while (true) {
+      const bit = this.readBit();
+      if (bit == null) return null;
+      if (bit === 1) break;
+      leadingZeroes++;
+      if (leadingZeroes > 31) return null;
+    }
+    const suffix = leadingZeroes === 0 ? 0 : this.readBits(leadingZeroes);
+    if (suffix == null) return null;
+    return (1 << leadingZeroes) - 1 + suffix;
+  }
+}
+
+function firstMbInSlice(bytes: Uint8Array<ArrayBufferLike>): number | null {
+  const type = nalType(bytes);
+  if (type !== 1 && type !== 5) return null;
+  return new BitReader(rbspFromNal(bytes)).readUnsignedExpGolomb();
+}
+
+function makeNalUnit(bytes: Uint8Array<ArrayBufferLike>): NalUnit {
+  const type = nalType(bytes);
+  return {
+    bytes,
+    type,
+    isVcl: type >= 1 && type <= 5,
+    firstMbInSlice: firstMbInSlice(bytes),
+  };
+}
+
+export class H264AnnexBAccessUnitParser {
+  private pendingBytes: Uint8Array<ArrayBufferLike> = new Uint8Array(0);
+  private pendingNals: NalUnit[] = [];
+  private readonly onAccessUnit: (accessUnit: H264AccessUnit) => void;
+
+  constructor(onAccessUnit: (accessUnit: H264AccessUnit) => void) {
+    this.onAccessUnit = onAccessUnit;
+  }
+
+  push(chunk: Uint8Array<ArrayBufferLike>): void {
+    this.pendingBytes = concatBytes([this.pendingBytes, chunk]);
+    for (const unit of this.extractCompleteNals(false)) {
+      this.pushNal(makeNalUnit(unit));
+    }
+  }
+
+  flush(): void {
+    for (const unit of this.extractCompleteNals(true)) {
+      this.pushNal(makeNalUnit(unit));
+    }
+    this.flushAccessUnit();
+  }
+
+  private extractCompleteNals(flush: boolean): Uint8Array<ArrayBufferLike>[] {
+    const out: Uint8Array<ArrayBufferLike>[] = [];
+    let first = findStartCode(this.pendingBytes, 0);
+    if (!first) {
+      this.pendingBytes = this.pendingBytes.slice(Math.max(0, this.pendingBytes.length - 3));
+      return out;
+    }
+
+    if (first.index > 0) {
+      this.pendingBytes = this.pendingBytes.slice(first.index);
+      first = { index: 0, length: first.length };
+    }
+
+    let searchFrom = first.index + first.length;
+    while (true) {
+      const next = findStartCode(this.pendingBytes, searchFrom);
+      if (!next) break;
+      out.push(this.pendingBytes.slice(first.index, next.index));
+      first = next;
+      searchFrom = next.index + next.length;
+    }
+
+    if (flush && this.pendingBytes.length > first.index + first.length) {
+      out.push(this.pendingBytes.slice(first.index));
+      this.pendingBytes = new Uint8Array(0);
+    } else {
+      this.pendingBytes = this.pendingBytes.slice(first.index);
+    }
+    return out;
+  }
+
+  private pushNal(nal: NalUnit): void {
+    if (nal.type === 9) {
+      this.flushAccessUnit();
+      this.pendingNals.push(nal);
+      return;
+    }
+
+    const hasVcl = this.pendingNals.some((unit) => unit.isVcl);
+    if (nal.isVcl && hasVcl && (nal.firstMbInSlice === null || nal.firstMbInSlice === 0)) {
+      this.flushAccessUnit();
+    }
+
+    this.pendingNals.push(nal);
+  }
+
+  private flushAccessUnit(): void {
+    if (!this.pendingNals.some((unit) => unit.isVcl)) {
+      this.pendingNals = [];
+      return;
+    }
+    this.onAccessUnit({
+      data: concatBytes(this.pendingNals.map((unit) => unit.bytes)),
+      type: this.pendingNals.some((unit) => unit.type === 5) ? "key" : "delta",
+    });
+    this.pendingNals = [];
+  }
+}

--- a/packages/serve-sim/src/client/utils/location-commands.ts
+++ b/packages/serve-sim/src/client/utils/location-commands.ts
@@ -1,0 +1,33 @@
+import { shellEscape } from "./exec";
+
+export type LocationPlatform = "ios" | "android";
+
+export interface LocationPoint {
+  lat: number;
+  lng: number;
+}
+
+function coord(value: number): string {
+  return value.toFixed(7);
+}
+
+export function locationSetCommand(
+  platform: LocationPlatform,
+  udid: string,
+  point: LocationPoint,
+): string {
+  const lat = coord(point.lat);
+  const lng = coord(point.lng);
+  if (platform === "android") {
+    return `adb -s ${shellEscape(udid)} emu geo fix ${lng} ${lat}`;
+  }
+  return `xcrun simctl location ${shellEscape(udid)} set ${lat},${lng}`;
+}
+
+export function locationClearCommand(
+  platform: LocationPlatform,
+  udid: string,
+): string | null {
+  if (platform === "android") return null;
+  return `xcrun simctl location ${shellEscape(udid)} clear`;
+}

--- a/packages/serve-sim/src/client/utils/sim-endpoint.ts
+++ b/packages/serve-sim/src/client/utils/sim-endpoint.ts
@@ -7,6 +7,9 @@ declare global {
       pid: number;
       port: number;
       device: string;
+      platform?: "ios" | "android";
+      name?: string;
+      runtime?: string;
       basePath: string;
       logsEndpoint?: string;
       axEndpoint?: string;

--- a/packages/serve-sim/src/device.ts
+++ b/packages/serve-sim/src/device.ts
@@ -1,5 +1,9 @@
 import { execSync } from "child_process";
 
+export function isIosUdid(value: string): boolean {
+  return /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i.test(value);
+}
+
 /**
  * UDID of a booted simulator, or null if none is booted. Prefers an iOS device
  * — a machine may also have a booted watchOS/tvOS sim, which `serve-sim`'s
@@ -26,11 +30,10 @@ export function findBootedDevice(): string | null {
 
 /**
  * Resolve a device name or UDID to a UDID. A UDID is returned as-is; a name is
- * matched case-insensitively against `simctl list devices`. Exits the process
- * with a clear error when the name cannot be resolved.
+ * matched case-insensitively against `simctl list devices`.
  */
-export function resolveDevice(nameOrUDID: string): string {
-  if (/^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i.test(nameOrUDID)) {
+export function tryResolveDevice(nameOrUDID: string): string | null {
+  if (isIosUdid(nameOrUDID)) {
     return nameOrUDID;
   }
   try {
@@ -44,6 +47,16 @@ export function resolveDevice(nameOrUDID: string): string {
       }
     }
   } catch {}
+  return null;
+}
+
+/**
+ * Resolve a device name or UDID to a UDID. Exits the process with a clear
+ * error when the name cannot be resolved.
+ */
+export function resolveDevice(nameOrUDID: string): string {
+  const resolved = tryResolveDevice(nameOrUDID);
+  if (resolved) return resolved;
   console.error(`Could not resolve device: ${nameOrUDID}`);
   process.exit(1);
 }

--- a/packages/serve-sim/src/index.ts
+++ b/packages/serve-sim/src/index.ts
@@ -12,9 +12,9 @@ import { findBootedDevice, resolveDevice, tryResolveDevice } from "./device";
 import {
   adb,
   androidInputTextArg,
+  androidDeviceBootStatus,
   ensureAndroidBooted,
   findBootedAndroidDevice,
-  isAndroidDeviceBooted,
   pickDefaultAndroidTarget,
   resolveAndroidTarget,
   resolveRunningAndroidDevice,
@@ -132,7 +132,7 @@ function readStateFile(file: string): ServerState | null {
     // recycle here so --detach / --list always return a working stream.
     const platform = state.platform ?? "ios";
     const booted = platform === "ios" ? getBootedUdids() : null;
-    const androidGone = platform === "android" && !isAndroidDeviceBooted(state.device);
+    const androidGone = platform === "android" && androidDeviceBootStatus(state.device) === "not_booted";
     if ((booted && !booted.has(state.device)) || androidGone) {
       debugState(
         "helper pid %d bound to non-booted device %s — killing stale helper",
@@ -459,12 +459,13 @@ function resolveSelfCommand(): { command: string; baseArgs: string[] } {
   return { command: process.execPath, baseArgs: [] };
 }
 
-/** Wait for the helper to become ready (health check + capture started). */
+/** Wait for the helper to become ready (health check + optional capture start). */
 async function waitForHelperReady(
   pid: number,
   url: string,
   logFile: string,
   isAlive: () => boolean,
+  opts: { waitForCapture?: boolean } = {},
 ): Promise<{ ready: boolean; log: string }> {
   let ready = false;
   const startedAt = Date.now();
@@ -491,7 +492,7 @@ async function waitForHelperReady(
     debugHelper("helper pid=%d /health never responded (%dms)", pid, Date.now() - startedAt);
   }
 
-  if (ready) {
+  if (ready && opts.waitForCapture !== false) {
     // Wait for capture to start or process to exit
     const captureStartedAt = Date.now();
     const captureDeadline = captureStartedAt + 8_000;
@@ -680,6 +681,7 @@ async function startAndroidHelper(
 ): Promise<{ pid: number; child?: ChildProcess; target: StreamTarget }> {
   debugHelper("startAndroidHelper target=%s port=%d detach=%s", target.device, port, opts.detach);
   const host = "127.0.0.1";
+  ensureStateDir();
   const bootLogFile = join(STATE_DIR, `android-boot-${target.device.replace(/[^A-Za-z0-9_.-]/g, "_")}.log`);
   const booted = await ensureAndroidBooted(
     target.android ?? {
@@ -697,7 +699,6 @@ async function startAndroidHelper(
   const logFile = join(STATE_DIR, `server-${serial}.log`);
   const url = `http://${host}:${port}`;
   const { command, baseArgs } = resolveSelfCommand();
-  ensureStateDir();
 
   const spawnOnce = async (): Promise<{ ready: boolean; pid: number; child?: ChildProcess; log: string }> => {
     const logFd = openSync(logFile, "w");
@@ -719,6 +720,7 @@ async function startAndroidHelper(
       url,
       logFile,
       () => !childExited && isProcessAlive(childPid),
+      { waitForCapture: false },
     );
     return { ready, pid: childPid, child: opts.detach ? undefined : child, log };
   };

--- a/packages/serve-sim/src/index.ts
+++ b/packages/serve-sim/src/index.ts
@@ -163,6 +163,10 @@ function readAllStates(): ServerState[] {
   return states;
 }
 
+function stateMatchesPlatform(state: ServerState, platform: Platform | "auto"): boolean {
+  return platform === "auto" || (state.platform ?? "ios") === platform;
+}
+
 function writeState(state: ServerState) {
   ensureStateDir();
   writeFileSync(stateFileForDevice(state.device), JSON.stringify(state, null, 2));
@@ -1195,8 +1199,8 @@ async function typeText(
     console.error("       serve-sim type --stdin [-d udid]");
     console.error("       serve-sim type --file <path> [-d udid]");
     console.error("");
-    console.error("Only US-keyboard ASCII characters are supported (A-Z, a-z, 0-9,");
-    console.error("space, newline, tab, and standard punctuation).");
+    console.error("iOS typing supports US-keyboard ASCII characters (A-Z, a-z, 0-9,");
+    console.error("space, newline, tab, and standard punctuation). Android uses adb input text.");
     process.exit(1);
   }
 
@@ -1214,18 +1218,6 @@ async function typeText(
     text = positional.join(" ");
   }
 
-  let events;
-  try {
-    events = textToKeyEvents(text);
-  } catch (err) {
-    if (err instanceof UnsupportedCharacterError) {
-      console.error(err.message);
-      console.error("Supported: A-Z, a-z, 0-9, space, newline, tab, and standard punctuation.");
-      process.exit(1);
-    }
-    throw err;
-  }
-
   const state = readStateForDeviceArg(deviceArg);
   if (!state) {
     console.error("No serve-sim server running. Run `serve-sim` first.");
@@ -1235,6 +1227,18 @@ async function typeText(
   if ((state.platform ?? "ios") === "android") {
     adb(["-s", state.device, "shell", "input", "text", androidInputTextArg(text)], { timeout: 15_000 });
     return;
+  }
+
+  let events;
+  try {
+    events = textToKeyEvents(text);
+  } catch (err) {
+    if (err instanceof UnsupportedCharacterError) {
+      console.error(err.message);
+      console.error("Supported on iOS: A-Z, a-z, 0-9, space, newline, tab, and standard punctuation.");
+      process.exit(1);
+    }
+    throw err;
   }
 
   await sendKeyEventsToWs(state.wsUrl, events);
@@ -2058,9 +2062,9 @@ async function serve(
     targetDevice = states[0]?.device;
   } else {
     // Ensure a serve-sim stream is running (start one if not)
-    const existing = readAllStates();
-    if (existing.length > 0) {
-      targetDevice = existing[0]?.device;
+    const existing = readAllStates().find((state) => stateMatchesPlatform(state, platform));
+    if (existing) {
+      targetDevice = existing.device;
     } else {
       console.log(platform === "android" ? "Starting Android stream..." : "Starting simulator stream...");
       const states = await detach(devices, 3100, platform);

--- a/packages/serve-sim/src/index.ts
+++ b/packages/serve-sim/src/index.ts
@@ -8,7 +8,18 @@ import { join, resolve } from "path";
 import { STATE_DIR, stateFileForDevice, listStateFiles } from "./state";
 import { textToKeyEvents, UnsupportedCharacterError, sendKeyEventsToWs } from "./text-to-keys";
 import { dirnameOf, sleepSync, isPortFree, servePreview } from "./runtime";
-import { findBootedDevice, resolveDevice } from "./device";
+import { findBootedDevice, resolveDevice, tryResolveDevice } from "./device";
+import {
+  adb,
+  androidInputTextArg,
+  ensureAndroidBooted,
+  findBootedAndroidDevice,
+  isAndroidDeviceBooted,
+  pickDefaultAndroidTarget,
+  resolveAndroidTarget,
+  resolveRunningAndroidDevice,
+  type AndroidTarget,
+} from "./android-device";
 import { permissions } from "./permissions";
 import { debugCli, debugHelper, debugState } from "./debug";
 
@@ -26,9 +37,22 @@ interface ServerState {
   pid: number;
   port: number;
   device: string;
+  platform?: "ios" | "android";
+  name?: string;
+  runtime?: string;
   url: string;
   streamUrl: string;
   wsUrl: string;
+}
+
+type Platform = "ios" | "android";
+
+interface StreamTarget {
+  platform: Platform;
+  device: string;
+  name?: string;
+  runtime?: string;
+  android?: AndroidTarget;
 }
 
 function ensureStateDir() {
@@ -106,8 +130,10 @@ function readStateFile(file: string): ServerState | null {
     // When that happens the helper keeps accepting /stream.mjpeg connections
     // but never emits frames, so clients hang on "Connecting...". Detect and
     // recycle here so --detach / --list always return a working stream.
-    const booted = getBootedUdids();
-    if (booted && !booted.has(state.device)) {
+    const platform = state.platform ?? "ios";
+    const booted = platform === "ios" ? getBootedUdids() : null;
+    const androidGone = platform === "android" && !isAndroidDeviceBooted(state.device);
+    if ((booted && !booted.has(state.device)) || androidGone) {
       debugState(
         "helper pid %d bound to non-booted device %s — killing stale helper",
         state.pid,
@@ -153,6 +179,20 @@ function clearState(udid?: string) {
       try { unlinkSync(file); } catch {}
     }
   }
+}
+
+function resolveStateDeviceArg(deviceArg?: string): string | undefined {
+  if (!deviceArg) return undefined;
+  const direct = readState(deviceArg);
+  if (direct) return direct.device;
+  const ios = tryResolveDevice(deviceArg);
+  if (ios) return ios;
+  const android = resolveRunningAndroidDevice(deviceArg);
+  return android?.device ?? deviceArg;
+}
+
+function readStateForDeviceArg(deviceArg?: string): ServerState | null {
+  return readState(resolveStateDeviceArg(deviceArg));
 }
 
 function findHelperBinary(): string {
@@ -237,6 +277,14 @@ function pickDefaultDevice(): { udid: string; name: string } | null {
   return null;
 }
 
+function platformFromOptions(opts: { platform?: string; android?: boolean }): Platform | "auto" {
+  if (opts.android) return "android";
+  const raw = (opts.platform ?? "auto").toLowerCase();
+  if (raw === "ios" || raw === "android" || raw === "auto") return raw;
+  console.error("Invalid --platform. Expected ios, android, or auto.");
+  process.exit(1);
+}
+
 function getDeviceName(udid: string): string | null {
   try {
     const output = execSync("xcrun simctl list devices -j", { encoding: "utf-8" });
@@ -250,6 +298,14 @@ function getDeviceName(udid: string): string | null {
     }
   } catch {}
   return null;
+}
+
+function getTargetName(target: StreamTarget): string | null {
+  if (target.name) return target.name;
+  if (target.platform === "android") {
+    return resolveRunningAndroidDevice(target.device)?.name ?? target.device;
+  }
+  return getDeviceName(target.device);
 }
 
 function isDeviceBooted(udid: string): boolean {
@@ -387,6 +443,16 @@ interface SpawnHelperOptions {
   port: number;
   host: string;
   logFile: string;
+}
+
+function resolveSelfCommand(): { command: string; baseArgs: string[] } {
+  if (process.argv[0] && /(^|\/)serve-sim$/.test(process.argv[0])) {
+    return { command: process.argv[0], baseArgs: [] };
+  }
+  if (process.argv[1]) {
+    return { command: process.argv[0]!, baseArgs: [process.argv[1]!] };
+  }
+  return { command: process.execPath, baseArgs: [] };
 }
 
 /** Wait for the helper to become ready (health check + capture started). */
@@ -603,38 +669,209 @@ async function startHelper(
   process.exit(1);
 }
 
+async function startAndroidHelper(
+  target: StreamTarget,
+  port: number,
+  opts: { detach: boolean },
+): Promise<{ pid: number; child?: ChildProcess; target: StreamTarget }> {
+  debugHelper("startAndroidHelper target=%s port=%d detach=%s", target.device, port, opts.detach);
+  const host = "127.0.0.1";
+  const bootLogFile = join(STATE_DIR, `android-boot-${target.device.replace(/[^A-Za-z0-9_.-]/g, "_")}.log`);
+  const booted = await ensureAndroidBooted(
+    target.android ?? {
+      platform: "android",
+      device: target.device,
+      name: target.name ?? target.device,
+      runtime: target.runtime ?? "Android",
+      state: "Shutdown",
+      avdName: target.device,
+      isEmulator: true,
+    },
+    bootLogFile,
+  );
+  const serial = booted.device;
+  const logFile = join(STATE_DIR, `server-${serial}.log`);
+  const url = `http://${host}:${port}`;
+  const { command, baseArgs } = resolveSelfCommand();
+  ensureStateDir();
+
+  const spawnOnce = async (): Promise<{ ready: boolean; pid: number; child?: ChildProcess; log: string }> => {
+    const logFd = openSync(logFile, "w");
+    const child = nodeSpawn(
+      command,
+      [...baseArgs, "android-helper", serial, "--port", String(port)],
+      {
+        detached: opts.detach,
+        stdio: ["ignore", logFd, logFd],
+      },
+    );
+    if (opts.detach) child.unref();
+    closeSync(logFd);
+    const childPid = child.pid!;
+    let childExited = false;
+    child.once("exit", () => { childExited = true; });
+    const { ready, log } = await waitForHelperReady(
+      childPid,
+      url,
+      logFile,
+      () => !childExited && isProcessAlive(childPid),
+    );
+    return { ready, pid: childPid, child: opts.detach ? undefined : child, log };
+  };
+
+  let lastLog = "";
+  const MAX_ATTEMPTS = 2;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    killPortHolder(port);
+    const result = await spawnOnce();
+    if (result.ready) {
+      const state: ServerState = {
+        pid: result.pid,
+        port,
+        device: serial,
+        platform: "android",
+        name: booted.name,
+        runtime: booted.runtime,
+        url,
+        streamUrl: `${url}/stream.mjpeg`,
+        wsUrl: `ws://${host}:${port}/ws`,
+      };
+      writeState(state);
+      return {
+        pid: result.pid,
+        child: result.child,
+        target: {
+          platform: "android",
+          device: serial,
+          name: booted.name,
+          runtime: booted.runtime,
+          android: booted,
+        },
+      };
+    }
+    stopProcess(result.pid);
+    lastLog = result.log;
+    if (attempt < MAX_ATTEMPTS) await new Promise((r) => setTimeout(r, 500));
+  }
+
+  const reason = lastLog ? `Android helper failed:\n${lastLog}` : "Android helper process failed to start";
+  console.error(reason);
+  process.exit(1);
+}
+
 // ─── Commands ───
 
+function resolveExplicitTarget(deviceArg: string, platform: Platform | "auto"): StreamTarget {
+  const androidPrefixed = deviceArg.startsWith("android:");
+  const raw = androidPrefixed ? deviceArg.slice("android:".length) : deviceArg;
+
+  if (platform === "android" || androidPrefixed) {
+    const android = resolveAndroidTarget(raw);
+    if (!android) {
+      console.error(`Could not resolve Android device or AVD: ${raw}`);
+      process.exit(1);
+    }
+    return {
+      platform: "android",
+      device: android.device,
+      name: android.name,
+      runtime: android.runtime,
+      android,
+    };
+  }
+
+  if (platform === "ios") {
+    return { platform: "ios", device: resolveDevice(raw) };
+  }
+
+  const ios = tryResolveDevice(raw);
+  if (ios) return { platform: "ios", device: ios };
+  const android = resolveAndroidTarget(raw);
+  if (android) {
+    return {
+      platform: "android",
+      device: android.device,
+      name: android.name,
+      runtime: android.runtime,
+      android,
+    };
+  }
+  console.error(`Could not resolve device: ${deviceArg}`);
+  process.exit(1);
+}
+
+function defaultTargets(platform: Platform | "auto", quiet: boolean): StreamTarget[] {
+  if (platform === "ios" || platform === "auto") {
+    const booted = findBootedDevice();
+    if (booted) return [{ platform: "ios", device: booted }];
+  }
+
+  if (platform === "android" || platform === "auto") {
+    const androidBooted = findBootedAndroidDevice();
+    if (androidBooted) {
+      const android = resolveRunningAndroidDevice(androidBooted);
+      return [{
+        platform: "android",
+        device: androidBooted,
+        name: android?.name,
+        runtime: android?.runtime,
+        android: android ?? undefined,
+      }];
+    }
+  }
+
+  if (platform === "ios" || platform === "auto") {
+    const fallback = pickDefaultDevice();
+    if (fallback) {
+      if (!quiet) console.log(`No booted simulator — booting ${fallback.name}...`);
+      return [{ platform: "ios", device: fallback.udid, name: fallback.name }];
+    }
+  }
+
+  if (platform === "android" || platform === "auto") {
+    const android = pickDefaultAndroidTarget();
+    if (android) {
+      if (!quiet && android.state !== "Booted") {
+        console.log(`No booted Android emulator — booting ${android.name}...`);
+      }
+      return [{
+        platform: "android",
+        device: android.device,
+        name: android.name,
+        runtime: android.runtime,
+        android,
+      }];
+    }
+  }
+
+  console.error(
+    platform === "android"
+      ? "No Android device or AVD found."
+      : platform === "ios"
+      ? "No device specified and no available iOS simulator found."
+      : "No device specified and no available iOS simulator or Android emulator found.",
+  );
+  process.exit(1);
+}
+
 /** Foreground follow mode (default). Stays attached, cleans up on Ctrl+C. */
-async function follow(devices: string[], startPort: number, quiet: boolean) {
+async function follow(devices: string[], startPort: number, quiet: boolean, platform: Platform | "auto") {
   debugCli("follow devices=%o startPort=%d", devices, startPort);
-  const udids = devices.length > 0
-    ? devices.map(resolveDevice)
-    : (() => {
-        const booted = findBootedDevice();
-        if (booted) return [booted];
-        const fallback = pickDefaultDevice();
-        if (!fallback) {
-          console.error("No device specified and no available iOS simulator found.");
-          process.exit(1);
-        }
-        if (!quiet) {
-          console.log(`No booted simulator — booting ${fallback.name}...`);
-        }
-        return [fallback.udid];
-      })();
+  const targets = devices.length > 0
+    ? devices.map((device) => resolveExplicitTarget(device, platform))
+    : defaultTargets(platform, quiet);
 
   const children = new Map<string, ChildProcess>();
   const states: ServerState[] = [];
   let port = startPort;
 
-  for (const udid of udids) {
+  for (const target of targets) {
     // Return existing server if already running
-    const existing = readState(udid);
+    const existing = readState(target.device);
     if (existing) {
       if (!quiet) {
-        const name = getDeviceName(udid) ?? udid;
-        if (udids.length > 1) console.log(`\n==> ${name} (${udid}) <==`);
+        const name = getTargetName(target) ?? target.device;
+        if (targets.length > 1) console.log(`\n==> ${name} (${target.device}) <==`);
         console.log(`  Already running on port ${existing.port}`);
         console.log(`  Stream:    ${existing.streamUrl}`);
         console.log(`  WebSocket: ${existing.wsUrl}`);
@@ -644,17 +881,24 @@ async function follow(devices: string[], startPort: number, quiet: boolean) {
     }
 
     port = await findAvailablePort(port);
-    const { pid, child } = await startHelper(udid, port, { detach: false });
+    const started = target.platform === "android"
+      ? await startAndroidHelper(target, port, { detach: false })
+      : { ...(await startHelper(target.device, port, { detach: false })), target };
+    const { pid, child } = started;
+    const activeTarget = started.target;
 
     if (child) {
-      children.set(udid, child);
+      children.set(activeTarget.device, child);
     }
 
     const host = "127.0.0.1";
     const state: ServerState = {
       pid,
       port,
-      device: udid,
+      device: activeTarget.device,
+      platform: activeTarget.platform,
+      name: activeTarget.name,
+      runtime: activeTarget.runtime,
       url: `http://${host}:${port}`,
       streamUrl: `http://${host}:${port}/stream.mjpeg`,
       wsUrl: `ws://${host}:${port}/ws`,
@@ -662,8 +906,8 @@ async function follow(devices: string[], startPort: number, quiet: boolean) {
     states.push(state);
 
     if (!quiet) {
-      const name = getDeviceName(udid) ?? udid;
-      if (udids.length > 1) console.log(`\n==> ${name} (${udid}) <==`);
+      const name = getTargetName(activeTarget) ?? activeTarget.device;
+      if (targets.length > 1) console.log(`\n==> ${name} (${activeTarget.device}) <==`);
       console.log(`  Stream:    ${state.streamUrl}`);
       console.log(`  WebSocket: ${state.wsUrl}`);
       console.log(`  Port:      ${port}`);
@@ -677,11 +921,13 @@ async function follow(devices: string[], startPort: number, quiet: boolean) {
     const s = states[0]!;
     console.log(JSON.stringify({
       url: s.url, streamUrl: s.streamUrl, wsUrl: s.wsUrl, port: s.port, device: s.device,
+      platform: s.platform ?? "ios", name: s.name, runtime: s.runtime,
     }));
   } else {
     console.log(JSON.stringify({
       devices: states.map((s) => ({
         url: s.url, streamUrl: s.streamUrl, wsUrl: s.wsUrl, port: s.port, device: s.device,
+        platform: s.platform ?? "ios", name: s.name, runtime: s.runtime,
       })),
     }));
   }
@@ -734,39 +980,37 @@ async function follow(devices: string[], startPort: number, quiet: boolean) {
 }
 
 /** Detach mode (--detach). Spawns helpers and returns their states. */
-async function detach(devices: string[], startPort: number): Promise<ServerState[]> {
+async function detach(devices: string[], startPort: number, platform: Platform | "auto" = "auto"): Promise<ServerState[]> {
   debugCli("detach devices=%o startPort=%d", devices, startPort);
-  const udids = devices.length > 0
-    ? devices.map(resolveDevice)
-    : (() => {
-        const booted = findBootedDevice();
-        if (booted) return [booted];
-        const fallback = pickDefaultDevice();
-        if (!fallback) {
-          console.error("No device specified and no available iOS simulator found.");
-          process.exit(1);
-        }
-        return [fallback.udid];
-      })();
+  const targets = devices.length > 0
+    ? devices.map((device) => resolveExplicitTarget(device, platform))
+    : defaultTargets(platform, true);
 
   const states: ServerState[] = [];
   let port = startPort;
 
-  for (const udid of udids) {
-    const existing = readState(udid);
+  for (const target of targets) {
+    const existing = readState(target.device);
     if (existing) {
       states.push(existing);
       continue;
     }
 
     port = await findAvailablePort(port);
-    await startHelper(udid, port, { detach: true });
+    const started = target.platform === "android"
+      ? await startAndroidHelper(target, port, { detach: true })
+      : { ...(await startHelper(target.device, port, { detach: true })), target };
+    const activeTarget = started.target;
 
     const host = "127.0.0.1";
+    const state = readState(activeTarget.device);
     states.push({
-      pid: readState(udid)!.pid,
+      pid: state?.pid ?? started.pid,
       port,
-      device: udid,
+      device: activeTarget.device,
+      platform: activeTarget.platform,
+      name: activeTarget.name,
+      runtime: activeTarget.runtime,
       url: `http://${host}:${port}`,
       streamUrl: `http://${host}:${port}/stream.mjpeg`,
       wsUrl: `ws://${host}:${port}/ws`,
@@ -783,11 +1027,13 @@ function printStatesJSON(states: ServerState[]) {
     const s = states[0]!;
     console.log(JSON.stringify({
       url: s.url, streamUrl: s.streamUrl, wsUrl: s.wsUrl, port: s.port, device: s.device,
+      platform: s.platform ?? "ios", name: s.name, runtime: s.runtime,
     }));
   } else {
     console.log(JSON.stringify({
       devices: states.map((s) => ({
         url: s.url, streamUrl: s.streamUrl, wsUrl: s.wsUrl, port: s.port, device: s.device,
+        platform: s.platform ?? "ios", name: s.name, runtime: s.runtime,
       })),
     }));
   }
@@ -796,15 +1042,16 @@ function printStatesJSON(states: ServerState[]) {
 /** List running streams (--list). */
 function listStreams(deviceArg?: string) {
   if (deviceArg) {
-    const udid = resolveDevice(deviceArg);
-    const state = readState(udid);
+    const resolved = resolveStateDeviceArg(deviceArg);
+    const state = readState(resolved);
     if (!state) {
-      console.log(JSON.stringify({ running: false, device: udid }));
+      console.log(JSON.stringify({ running: false, device: resolved ?? deviceArg }));
     } else {
       console.log(JSON.stringify({
         running: true,
         url: state.url, streamUrl: state.streamUrl, wsUrl: state.wsUrl,
         port: state.port, device: state.device, pid: state.pid,
+        platform: state.platform ?? "ios", name: state.name, runtime: state.runtime,
       }));
     }
     return;
@@ -819,6 +1066,7 @@ function listStreams(deviceArg?: string) {
       running: true,
       url: s.url, streamUrl: s.streamUrl, wsUrl: s.wsUrl,
       port: s.port, device: s.device, pid: s.pid,
+      platform: s.platform ?? "ios", name: s.name, runtime: s.runtime,
     }));
   } else {
     console.log(JSON.stringify({
@@ -826,6 +1074,7 @@ function listStreams(deviceArg?: string) {
       streams: states.map((s) => ({
         url: s.url, streamUrl: s.streamUrl, wsUrl: s.wsUrl,
         port: s.port, device: s.device, pid: s.pid,
+        platform: s.platform ?? "ios", name: s.name, runtime: s.runtime,
       })),
     }));
   }
@@ -834,14 +1083,14 @@ function listStreams(deviceArg?: string) {
 /** Kill running streams (--kill). */
 function killStreams(deviceArg?: string) {
   if (deviceArg) {
-    const udid = resolveDevice(deviceArg);
-    const state = readState(udid);
+    const resolved = resolveStateDeviceArg(deviceArg);
+    const state = readState(resolved);
     if (!state) {
-      console.log(JSON.stringify({ disconnected: true, device: udid }));
+      console.log(JSON.stringify({ disconnected: true, device: resolved ?? deviceArg }));
       return;
     }
     try { process.kill(state.pid, "SIGTERM"); } catch {}
-    clearState(udid);
+    clearState(state.device);
     console.log(JSON.stringify({ disconnected: true, device: state.device }));
   } else {
     const states = readAllStates();
@@ -860,7 +1109,7 @@ function killStreams(deviceArg?: string) {
 }
 
 async function gesture(jsonStr: string, deviceArg?: string) {
-  const state = readState(deviceArg);
+  const state = readStateForDeviceArg(deviceArg);
   if (!state) {
     console.error("No serve-sim server running. Run `serve-sim` first.");
     process.exit(1);
@@ -903,7 +1152,7 @@ async function tap(xArg: string, yArg: string, deviceArg?: string) {
     console.error("  Example: serve-sim tap 0.5 0.9   # near bottom-center");
     process.exit(1);
   }
-  const state = readState(deviceArg);
+  const state = readStateForDeviceArg(deviceArg);
   if (!state) {
     console.error("No serve-sim server running. Run `serve-sim` first.");
     process.exit(1);
@@ -977,17 +1226,22 @@ async function typeText(
     throw err;
   }
 
-  const state = readState(deviceArg);
+  const state = readStateForDeviceArg(deviceArg);
   if (!state) {
     console.error("No serve-sim server running. Run `serve-sim` first.");
     process.exit(1);
+  }
+
+  if ((state.platform ?? "ios") === "android") {
+    adb(["-s", state.device, "shell", "input", "text", androidInputTextArg(text)], { timeout: 15_000 });
+    return;
   }
 
   await sendKeyEventsToWs(state.wsUrl, events);
 }
 
 async function rotate(orientation: string, deviceArg?: string) {
-  const state = readState(deviceArg);
+  const state = readStateForDeviceArg(deviceArg);
   if (!state) {
     console.error("No serve-sim server running. Run `serve-sim` first.");
     process.exit(1);
@@ -1027,7 +1281,7 @@ async function rotate(orientation: string, deviceArg?: string) {
 }
 
 async function button(buttonName = "home", deviceArg?: string) {
-  const state = readState(deviceArg);
+  const state = readStateForDeviceArg(deviceArg);
   if (!state) {
     console.error("No serve-sim server running. Run `serve-sim` first.");
     process.exit(1);
@@ -1076,7 +1330,7 @@ async function caDebug(option: string, stateRaw: string, deviceArg?: string) {
     process.exit(1);
   }
 
-  const stateFile = readState(deviceArg);
+  const stateFile = readStateForDeviceArg(deviceArg);
   if (!stateFile) {
     console.error("No serve-sim server running. Run `serve-sim` first.");
     process.exit(1);
@@ -1102,7 +1356,7 @@ async function caDebug(option: string, stateRaw: string, deviceArg?: string) {
 
 // Ask the helper to invoke -[SimDevice simulateMemoryWarning].
 async function memoryWarning(deviceArg?: string) {
-  const stateFile = readState(deviceArg);
+  const stateFile = readStateForDeviceArg(deviceArg);
   if (!stateFile) {
     console.error("No serve-sim server running. Run `serve-sim` first.");
     process.exit(1);
@@ -1790,11 +2044,17 @@ Examples:
 
 // ─── Serve preview ───
 
-async function serve(servePort: number, devices: string[], portExplicit: boolean, host: string) {
+async function serve(
+  servePort: number,
+  devices: string[],
+  portExplicit: boolean,
+  host: string,
+  platform: Platform | "auto",
+) {
   let targetDevice: string | undefined;
 
   if (devices.length > 0) {
-    const states = await detach(devices, 3100);
+    const states = await detach(devices, 3100, platform);
     targetDevice = states[0]?.device;
   } else {
     // Ensure a serve-sim stream is running (start one if not)
@@ -1802,8 +2062,8 @@ async function serve(servePort: number, devices: string[], portExplicit: boolean
     if (existing.length > 0) {
       targetDevice = existing[0]?.device;
     } else {
-      console.log("Starting simulator stream...");
-      const states = await detach(devices, 3100);
+      console.log(platform === "android" ? "Starting Android stream..." : "Starting simulator stream...");
+      const states = await detach(devices, 3100, platform);
       targetDevice = states[0]?.device;
     }
   }
@@ -1870,10 +2130,10 @@ const program = new Command();
 
 program
   .name("serve-sim")
-  .description("Stream iOS Simulator to the browser")
+  .description("Stream iOS Simulator or Android Emulator to the browser")
   .helpOption("-h, --help", "Show this help")
   // The default command: start the preview server (or stream / list / kill).
-  .argument("[devices...]", "Simulator(s) to target (udid or name; default: booted)")
+  .argument("[devices...]", "Device(s) to target (UDID, serial, or name; default: booted)")
   .option("-p, --port <port>", "Starting port (preview default: 3200, stream default: 3100)", (v) => parseInt(v, 10))
   .option(
     "--host <addr>",
@@ -1883,6 +2143,8 @@ program
     "127.0.0.1",
   )
   .option("--detach", "Spawn helper and exit (daemon mode)")
+  .option("--platform <platform>", "Target platform: auto, ios, or android", "auto")
+  .option("--android", "Shortcut for --platform android")
   .option("-q, --quiet", "Suppress human-readable output, JSON only")
   .option("--no-preview", "Skip the web preview server; stream in foreground only")
   .option("-l, --list [device]", "List running streams")
@@ -1895,11 +2157,14 @@ Examples:
   serve-sim -p 8080                      Preview on a custom port
   serve-sim --no-preview                 Auto-detect booted sim, stream in foreground
   serve-sim --no-preview "iPhone 16 Pro" Stream a specific device (no preview)
+  serve-sim --android                    Stream a booted Android emulator/device
+  serve-sim --android Pixel_8_API_35     Boot and stream a specific Android AVD
   serve-sim --detach                     Start streaming in background (daemon)
   serve-sim --list                       Show all running streams
   serve-sim --kill                       Stop all streams`,
   )
   .action(async (devices: string[], opts) => {
+    const platform = platformFromOptions(opts);
     if (opts.list !== undefined) {
       listStreams(typeof opts.list === "string" ? opts.list : undefined);
       return;
@@ -1910,16 +2175,16 @@ Examples:
     }
     const startPort: number | undefined = opts.port;
     if (opts.detach) {
-      const states = await detach(devices, startPort ?? 3100);
+      const states = await detach(devices, startPort ?? 3100, platform);
       printStatesJSON(states);
     } else if (opts.preview === false) {
-      await follow(devices, startPort ?? 3100, !!opts.quiet);
+      await follow(devices, startPort ?? 3100, !!opts.quiet, platform);
     } else {
-      await serve(startPort ?? 3200, devices, startPort !== undefined, opts.host);
+      await serve(startPort ?? 3200, devices, startPort !== undefined, opts.host, platform);
     }
   });
 
-const deviceOpt = ["-d, --device <udid>", "Target a specific simulator (udid or name)"] as const;
+const deviceOpt = ["-d, --device <udid>", "Target a specific device (UDID, serial, or name)"] as const;
 
 program
   .command("gesture")
@@ -1980,6 +2245,21 @@ program
   .description("Simulate a memory warning on the device")
   .option(...deviceOpt)
   .action((opts) => memoryWarning(opts.device));
+
+program
+  .command("android-helper", { hidden: true })
+  .description("Internal Android stream helper")
+  .argument("<serial>")
+  .option("--port <port>", "Port to listen on", (v: string) => parseInt(v, 10), 3100)
+  .allowUnknownOption(true)
+  .action(async (serial: string, opts: { port: number }) => {
+    const { runAndroidHelper } = await import("./android-helper");
+    const portFlagIndex = process.argv.lastIndexOf("--port");
+    const port = portFlagIndex >= 0 && process.argv[portFlagIndex + 1]
+      ? parseInt(process.argv[portFlagIndex + 1]!, 10)
+      : opts.port;
+    await runAndroidHelper({ serial, port });
+  });
 
 // `camera` and `permissions` keep their own dedicated argument parsers (the
 // camera verb has nested sub-verbs and source flags; permissions has a

--- a/packages/serve-sim/src/middleware.ts
+++ b/packages/serve-sim/src/middleware.ts
@@ -8,9 +8,9 @@ import type { IncomingMessage, ServerResponse } from "http";
 import { createAxStreamerCache } from "./ax";
 import { debugMw } from "./debug";
 import {
+  androidDeviceBootStatus,
   findAdb,
   listAndroidTargets,
-  isAndroidDeviceBooted,
   shutdownAndroidDevice,
 } from "./android-device";
 
@@ -235,7 +235,7 @@ function readServeSimStates(): ServeSimState[] {
       // preview stuck on "Connecting...". Recycle the stale state so the
       // caller can spawn a fresh helper bound to whatever is booted.
       const platform = state.platform ?? "ios";
-      const androidGone = platform === "android" && !isAndroidDeviceBooted(state.device);
+      const androidGone = platform === "android" && androidDeviceBootStatus(state.device) === "not_booted";
       if ((platform === "ios" && booted && !booted.has(state.device)) || androidGone) {
         debugMw(
           "recycling stale helper pid=%d (device %s no longer booted)",

--- a/packages/serve-sim/src/middleware.ts
+++ b/packages/serve-sim/src/middleware.ts
@@ -252,6 +252,11 @@ function readServeSimStates(): ServeSimState[] {
   return states;
 }
 
+function stopServeSimState(state: ServeSimState): void {
+  try { process.kill(state.pid, "SIGTERM"); } catch {}
+  try { unlinkSync(join(STATE_DIR, `server-${state.device}.json`)); } catch {}
+}
+
 export function selectServeSimState(
   states: ServeSimState[],
   device?: string | null,
@@ -858,9 +863,8 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
       return;
     }
 
-    // Shutdown a booted simulator. Any running helper for the device is reaped
-    // by readServeSimStates() on the next /grid/api poll (it kills helpers
-    // whose backing simulator is no longer in the booted set).
+    // Shutdown a booted simulator/emulator. Physical Android devices cannot be
+    // powered off here, but a live stream can still be stopped safely.
     if (url === base + "/grid/api/shutdown" && req.method === "POST") {
       let body = "";
       req.on("data", (chunk: Buffer | string) => {
@@ -883,6 +887,13 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
         // and prunes any helper bound to this now-shutdown device.
         bootedSnapshot = { at: 0, booted: null };
         if (platform === "android") {
+          const state = readServeSimStates().find((s) => s.device === udid && (s.platform ?? "ios") === "android");
+          if (state && !udid.startsWith("emulator-")) {
+            stopServeSimState(state);
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ ok: true, stopped: true, shutdown: false }));
+            return;
+          }
           try {
             shutdownAndroidDevice(udid);
             res.writeHead(200, { "Content-Type": "application/json" });

--- a/packages/serve-sim/src/middleware.ts
+++ b/packages/serve-sim/src/middleware.ts
@@ -73,8 +73,9 @@ type SimctlAllList = {
   devices: Record<string, Array<Omit<SimctlDevice, "runtime">>>;
 };
 
-type ShutdownRequestBody = { udid?: string; platform?: "ios" | "android" };
-type StartRequestBody = { udid?: string; platform?: "ios" | "android" };
+type DevicePlatform = "ios" | "android";
+type ShutdownRequestBody = { udid?: string; platform?: unknown };
+type StartRequestBody = { udid?: string; platform?: unknown };
 type ReleaseRequestBody = { targetId?: string };
 type HighlightRequestBody = { targetId?: string; on?: boolean };
 type ExecRequestBody = { command?: string };
@@ -83,7 +84,7 @@ export interface ServeSimState {
   pid: number;
   port: number;
   device: string;
-  platform?: "ios" | "android";
+  platform?: DevicePlatform;
   name?: string;
   runtime?: string;
   url: string;
@@ -122,6 +123,11 @@ const NON_UI_BUNDLE_RE = /(WidgetRenderer|ExtensionHost|\.extension(\.|$)|Servic
 
 function isUserFacingBundle(bundleId: string): boolean {
   return !NON_UI_BUNDLE_RE.test(bundleId);
+}
+
+export function normalizeRequestPlatform(value: unknown): DevicePlatform | null {
+  if (value == null) return "ios";
+  return value === "ios" || value === "android" ? value : null;
 }
 
 export function parseForegroundAppLogMessage(message: string): { bundleId: string; pid: number } | null {
@@ -872,11 +878,17 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
       });
       req.on("end", () => {
         let udid = "";
-        let platform: "ios" | "android" = "ios";
+        let platform: DevicePlatform = "ios";
         try {
           const parsed = JSON.parse(body) as ShutdownRequestBody;
           udid = parsed.udid ?? "";
-          platform = parsed.platform ?? "ios";
+          const parsedPlatform = normalizeRequestPlatform(parsed.platform);
+          if (!parsedPlatform) {
+            res.writeHead(400, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ ok: false, error: "Invalid platform" }));
+            return;
+          }
+          platform = parsedPlatform;
         } catch {}
         if (!udid || !/^[A-Za-z0-9_.:-]+$/.test(udid)) {
           res.writeHead(400, { "Content-Type": "application/json" });
@@ -931,11 +943,17 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
       });
       req.on("end", () => {
         let udid = "";
-        let platform: "ios" | "android" = "ios";
+        let platform: DevicePlatform = "ios";
         try {
           const parsed = JSON.parse(body) as StartRequestBody;
           udid = parsed.udid ?? "";
-          platform = parsed.platform ?? "ios";
+          const parsedPlatform = normalizeRequestPlatform(parsed.platform);
+          if (!parsedPlatform) {
+            res.writeHead(400, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ ok: false, error: "Invalid platform" }));
+            return;
+          }
+          platform = parsedPlatform;
         } catch {}
         if (!udid || !/^[A-Za-z0-9_.:-]+$/.test(udid)) {
           res.writeHead(400, { "Content-Type": "application/json" });

--- a/packages/serve-sim/src/middleware.ts
+++ b/packages/serve-sim/src/middleware.ts
@@ -130,6 +130,13 @@ export function normalizeRequestPlatform(value: unknown): DevicePlatform | null 
   return value === "ios" || value === "android" ? value : null;
 }
 
+export function isValidDeviceId(value: string, platform: DevicePlatform): boolean {
+  if (!value) return false;
+  return platform === "android"
+    ? /^[A-Za-z0-9_.:-]+$/.test(value)
+    : /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i.test(value);
+}
+
 export function parseForegroundAppLogMessage(message: string): { bundleId: string; pid: number } | null {
   // e.g. "[app<com.apple.mobilesafari>:43117] Setting process visibility to: Foreground"
   const match = /\[app<([^>]+)>:(\d+)\] Setting process visibility to: Foreground/.exec(message);
@@ -890,7 +897,7 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
           }
           platform = parsedPlatform;
         } catch {}
-        if (!udid || !/^[A-Za-z0-9_.:-]+$/.test(udid)) {
+        if (!isValidDeviceId(udid, platform)) {
           res.writeHead(400, { "Content-Type": "application/json" });
           res.end(JSON.stringify({ ok: false, error: "Invalid or missing device id" }));
           return;
@@ -955,7 +962,7 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
           }
           platform = parsedPlatform;
         } catch {}
-        if (!udid || !/^[A-Za-z0-9_.:-]+$/.test(udid)) {
+        if (!isValidDeviceId(udid, platform)) {
           res.writeHead(400, { "Content-Type": "application/json" });
           res.end(JSON.stringify({ ok: false, error: "Invalid or missing device id" }));
           return;

--- a/packages/serve-sim/src/middleware.ts
+++ b/packages/serve-sim/src/middleware.ts
@@ -7,6 +7,12 @@ import { randomBytes, timingSafeEqual } from "crypto";
 import type { IncomingMessage, ServerResponse } from "http";
 import { createAxStreamerCache } from "./ax";
 import { debugMw } from "./debug";
+import {
+  findAdb,
+  listAndroidTargets,
+  isAndroidDeviceBooted,
+  shutdownAndroidDevice,
+} from "./android-device";
 
 type SimReq = IncomingMessage;
 type SimRes = ServerResponse;
@@ -67,8 +73,8 @@ type SimctlAllList = {
   devices: Record<string, Array<Omit<SimctlDevice, "runtime">>>;
 };
 
-type ShutdownRequestBody = { udid?: string };
-type StartRequestBody = { udid?: string };
+type ShutdownRequestBody = { udid?: string; platform?: "ios" | "android" };
+type StartRequestBody = { udid?: string; platform?: "ios" | "android" };
 type ReleaseRequestBody = { targetId?: string };
 type HighlightRequestBody = { targetId?: string; on?: boolean };
 type ExecRequestBody = { command?: string };
@@ -77,6 +83,9 @@ export interface ServeSimState {
   pid: number;
   port: number;
   device: string;
+  platform?: "ios" | "android";
+  name?: string;
+  runtime?: string;
   url: string;
   streamUrl: string;
   wsUrl: string;
@@ -225,7 +234,9 @@ function readServeSimStates(): ServeSimState[] {
       // would accept connections yet never produce frames, leaving the
       // preview stuck on "Connecting...". Recycle the stale state so the
       // caller can spawn a fresh helper bound to whatever is booted.
-      if (booted && !booted.has(state.device)) {
+      const platform = state.platform ?? "ios";
+      const androidGone = platform === "android" && !isAndroidDeviceBooted(state.device);
+      if ((platform === "ios" && booted && !booted.has(state.device)) || androidGone) {
         debugMw(
           "recycling stale helper pid=%d (device %s no longer booted)",
           state.pid,
@@ -486,6 +497,7 @@ function loadHtml(): string {
 }
 
 interface SimctlDevice {
+  platform?: "ios" | "android";
   udid: string;
   name: string;
   state: string;
@@ -494,6 +506,7 @@ interface SimctlDevice {
 }
 
 function listAllSimulators(): SimctlDevice[] {
+  const out: SimctlDevice[] = [];
   try {
     const output = execSync("xcrun simctl list devices -j", {
       encoding: "utf-8",
@@ -501,20 +514,28 @@ function listAllSimulators(): SimctlDevice[] {
       timeout: 3_000,
     });
     const data = JSON.parse(output) as SimctlAllList;
-    const out: SimctlDevice[] = [];
     for (const [runtime, devices] of Object.entries(data.devices)) {
       // Keep this to touch-capable simulator families that serve-sim can frame
       // and inject into. tvOS is intentionally left out for now.
       if (!/SimRuntime\.(iOS|watchOS|visionOS|xrOS)-/i.test(runtime)) continue;
       for (const d of devices) {
         if (d.isAvailable === false) continue;
-        out.push({ ...d, runtime: runtime.replace(/^.*SimRuntime\./, "") });
+        out.push({ ...d, platform: "ios", runtime: runtime.replace(/^.*SimRuntime\./, "") });
       }
     }
-    return out;
-  } catch {
-    return [];
+  } catch {}
+
+  for (const d of listAndroidTargets()) {
+    out.push({
+      platform: "android",
+      udid: d.device,
+      name: d.name,
+      runtime: d.runtime,
+      state: d.state,
+      isAvailable: true,
+    });
   }
+  return out;
 }
 
 // Default per-simulator footprint when we have no running sim to measure
@@ -796,6 +817,7 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
         const remoteHelper = helper ? rewriteStateForRequestHost(helper, req.headers?.host) : null;
         return {
           device: d.udid,
+          platform: d.platform ?? "ios",
           name: d.name,
           runtime: d.runtime,
           state: d.state,
@@ -816,9 +838,10 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
         if (/iphone/i.test(name)) return 0;
         if (/ipad/i.test(name)) return 1;
         if (/watch/i.test(name)) return 2;
-        if (/(apple\s*tv|^tv\b)/i.test(name)) return 3;
-        if (/vision|reality/i.test(name)) return 4;
-        return 5;
+        if (/pixel|android|sdk|phone/i.test(name)) return 3;
+        if (/(apple\s*tv|^tv\b)/i.test(name)) return 4;
+        if (/vision|reality/i.test(name)) return 5;
+        return 6;
       };
       const stateRank = (x: typeof devices[number]) =>
         x.helper ? 0 : x.state === "Booted" ? 1 : 2;
@@ -845,15 +868,34 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
       });
       req.on("end", () => {
         let udid = "";
-        try { udid = (JSON.parse(body) as ShutdownRequestBody).udid ?? ""; } catch {}
-        if (!/^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i.test(udid)) {
+        let platform: "ios" | "android" = "ios";
+        try {
+          const parsed = JSON.parse(body) as ShutdownRequestBody;
+          udid = parsed.udid ?? "";
+          platform = parsed.platform ?? "ios";
+        } catch {}
+        if (!udid || !/^[A-Za-z0-9_.:-]+$/.test(udid)) {
           res.writeHead(400, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ ok: false, error: "Invalid or missing udid" }));
+          res.end(JSON.stringify({ ok: false, error: "Invalid or missing device id" }));
           return;
         }
         // Drop the snapshot so the next /grid/api call re-queries simctl
         // and prunes any helper bound to this now-shutdown device.
         bootedSnapshot = { at: 0, booted: null };
+        if (platform === "android") {
+          try {
+            shutdownAndroidDevice(udid);
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ ok: true }));
+          } catch (err) {
+            res.writeHead(500, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({
+              ok: false,
+              error: err instanceof Error ? err.message : String(err),
+            }));
+          }
+          return;
+        }
         execFile("xcrun", ["simctl", "shutdown", udid], { timeout: 30_000 }, (err, _stdout, stderr) => {
           if (err) {
             res.writeHead(500, { "Content-Type": "application/json" });
@@ -878,10 +920,15 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
       });
       req.on("end", () => {
         let udid = "";
-        try { udid = (JSON.parse(body) as StartRequestBody).udid ?? ""; } catch {}
-        if (!/^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i.test(udid)) {
+        let platform: "ios" | "android" = "ios";
+        try {
+          const parsed = JSON.parse(body) as StartRequestBody;
+          udid = parsed.udid ?? "";
+          platform = parsed.platform ?? "ios";
+        } catch {}
+        if (!udid || !/^[A-Za-z0-9_.:-]+$/.test(udid)) {
           res.writeHead(400, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ ok: false, error: "Invalid or missing udid" }));
+          res.end(JSON.stringify({ ok: false, error: "Invalid or missing device id" }));
           return;
         }
         const resolved = resolveServeSimCommand();
@@ -895,7 +942,7 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
         }
         const child = spawn(
           resolved.command,
-          [...resolved.baseArgs, "--detach", udid],
+          [...resolved.baseArgs, "--detach", "--platform", platform, udid],
           { stdio: ["ignore", "pipe", "pipe"], detached: false },
         );
         let stdout = "";
@@ -914,8 +961,13 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
         child.on("close", (code) => {
           clearTimeout(timer);
           if (code === 0) {
+            let device = udid;
+            try {
+              const parsed = JSON.parse(stdout.trim());
+              device = parsed.device ?? device;
+            } catch {}
             res.writeHead(200, { "Content-Type": "application/json" });
-            res.end(JSON.stringify({ ok: true, stdout: stdout.trim() }));
+            res.end(JSON.stringify({ ok: true, stdout: stdout.trim(), device }));
           } else {
             res.writeHead(500, { "Content-Type": "application/json" });
             res.end(JSON.stringify({
@@ -939,6 +991,14 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
         if (!state) {
           res.writeHead(404, { "Content-Type": "application/json" });
           res.end(JSON.stringify({ error: "No serve-sim device" }));
+          return;
+        }
+        if ((state.platform ?? "ios") === "android") {
+          res.writeHead(200, {
+            "Content-Type": "application/json",
+            "Cache-Control": "no-store",
+          });
+          res.end(JSON.stringify({ port: null, targets: [] }));
           return;
         }
         try {
@@ -1164,11 +1224,14 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
       });
       res.write(":\n\n");
 
-      const child: ChildProcess = spawn("xcrun", [
-        "simctl", "spawn", udid, "log", "stream",
-        "--style", "ndjson",
-        "--level", "info",
-      ], { stdio: ["ignore", "pipe", "ignore"] });
+      const isAndroid = (state.platform ?? "ios") === "android";
+      const child: ChildProcess = isAndroid
+        ? spawn(findAdb() ?? "adb", ["-s", udid, "logcat", "-v", "threadtime"], { stdio: ["ignore", "pipe", "ignore"] })
+        : spawn("xcrun", [
+            "simctl", "spawn", udid, "log", "stream",
+            "--style", "ndjson",
+            "--level", "info",
+          ], { stdio: ["ignore", "pipe", "ignore"] });
 
       let buf = "";
       child.stdout!.on("data", (chunk: Buffer) => {
@@ -1177,7 +1240,15 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
         while ((nl = buf.indexOf("\n")) !== -1) {
           const line = buf.slice(0, nl).trim();
           buf = buf.slice(nl + 1);
-          if (line) res.write("data: " + line + "\n\n");
+          if (line) {
+            res.write(
+              "data: " +
+              (isAndroid
+                ? JSON.stringify({ processImagePath: "adb logcat", eventMessage: line, messageType: "info" })
+                : line) +
+              "\n\n",
+            );
+          }
         }
         // Drop a runaway partial line so a malformed/never-terminated
         // log entry can't grow `buf` without bound.
@@ -1213,6 +1284,37 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
         "X-Accel-Buffering": "no",
       });
       res.write(":\n\n");
+
+      if ((state.platform ?? "ios") === "android") {
+        let closed = false;
+        let lastBundle = "";
+        const poll = async () => {
+          if (closed || res.writableEnded) return;
+          try {
+            const ctrl = new AbortController();
+            const timer = setTimeout(() => ctrl.abort(), 1500);
+            const r = await fetch(`http://127.0.0.1:${state.port}/foreground`, { signal: ctrl.signal });
+            clearTimeout(timer);
+            if (r.ok) {
+              const info = await r.json() as { bundleId?: string; pid?: number };
+              if (info.bundleId && info.bundleId !== lastBundle) {
+                lastBundle = info.bundleId;
+                res.write("data: " + JSON.stringify({
+                  bundleId: info.bundleId,
+                  pid: info.pid,
+                  isReactNative: /^host\.exp\.|expo|\.rn/i.test(info.bundleId),
+                }) + "\n\n");
+              }
+            }
+          } catch {}
+          if (!closed) setTimeout(poll, 1000);
+        };
+        void poll();
+        req.on("close", () => {
+          closed = true;
+        });
+        return;
+      }
 
       // Bootstrap: SpringBoard's log feed is edge-triggered, so a fresh
       // subscriber would otherwise see nothing until the user re-foregrounds


### PR DESCRIPTION
## Overview

This PR adds Android as a first-class `serve-sim` target alongside iOS Simulator. It includes Android device discovery and boot selection, an Android helper process, H.264 streaming into the web UI, WebSocket input forwarding, Android-aware UI affordances, and platform-specific tool visibility.

## What Changed

### Android Device Support

- Adds Android target discovery through `adb devices` and AVD metadata.
- Supports `--android` / `--platform android` flows from the serve-sim CLI.
- Starts and tracks Android helper state through the same multi-device/grid infrastructure used by iOS.
- Filters existing helper state by requested platform, so `serve-sim --android` does not accidentally attach the preview to an existing iOS helper.
- Handles stale Android helper state when the backing emulator/device is no longer available.

### Android Streaming And Input

- Adds an Android helper that streams the device screen using H.264 from `screenrecord`.
- Adds a WebCodecs H.264 client path with Annex B access-unit parsing.
- Keeps MJPEG/image stream handling available for the existing iOS path.
- Forwards touch, keyboard, rotation, home, back, recents, power, and volume controls to Android through `adb shell input`.
- Uses a persistent adb input shell to reduce per-gesture latency.
- Enables Android toolbar controls as soon as a device is selected, so controls remain responsive while the video decoder is still warming up.
- Preserves orientation from the device config endpoint when decoded video frames only report dimensions, avoiding layout/config drift during Android rotation.
- Validates orientation messages before forwarding them to the Android helper.

### Web UI Polish

- Distinguishes iOS and Android devices with platform badges in the toolbar, device picker, grid, and empty state.
- Adds Android-style top toolbar controls: Back, Home, Recents, Volume Down, Volume Up, and Power.
- Shows unavailable/unauthorized Android devices as unavailable instead of offering impossible boot/start actions.
- Allows live physical Android streams to be stopped without exposing a destructive power-off action.
- Avoids shutting down physical Android devices from the web UI; only emulators get the shutdown affordance.
- Updates app detection display so Android shows package/PID/React Native info without trying to fetch iOS app bundle details.
- Hides iOS-only tools on Android: accessibility overlay/tree, WebKit DevTools, simulator camera injection, and iOS permissions.
- Keeps iOS behavior unchanged for those iOS-only tools.
- Labels the grid memory estimate as iOS simulator capacity, since that calculation still comes from CoreSimulator memory usage rather than Android emulator memory.

### Location Simulation

- Keeps iOS location simulation on `xcrun simctl location`.
- Adds Android emulator location simulation through `adb emu geo fix`.
- Hides the location tool for physical Android devices, where the emulator geo API is not available.

### File Drop Support

- Keeps iOS media / IPA drop handling.
- Adds Android APK install and media push support.
- Shell-escapes staged file paths and device identifiers in the generated host commands.

### Startup And Stability

- Gives Android H.264 startup a longer grace period before surfacing stream errors.
- Shows a gentler `Starting video...` state while the Android stream is warming up.
- Treats Android H.264 idle frames differently from MJPEG stale-frame detection, so a valid static Android screen does not fall back to noisy `connecting` status.
- Notifies the parent UI immediately when the first decoded relay frame is drawn.
- Stabilizes reconnect/stream state handling to reduce noisy `connecting` / no-frame transitions during Android startup.

## Known Platform Differences

Some serve-sim features are intentionally still iOS-only because they rely on Simulator.app, CoreSimulator, WebKit inspection, TCC stores, or the existing camera dylib injection path. The Android UI hides those controls instead of showing actions that cannot work.

Android location simulation is available for emulators only. Physical Android devices can be streamed and controlled, but emulator-only APIs such as `adb emu geo fix` and `adb emu kill` are not exposed for them.

## Demo

https://github.com/user-attachments/assets/582bc386-c5bf-4881-bb71-a2491e603905

## Validation

- `bun test packages/serve-sim/src/__tests__` — 146 pass, 23 skipped simulator/device integration tests
- `bun test packages/serve-sim-client/src/__tests__` — 76 pass
- `bunx tsc --noEmit`
- `bun run lint`
- `bun run packages/serve-sim/build.ts`
- Browser smoke against rebuilt dist at `http://localhost:3399/`: Android page loaded, platform label present, iOS location UI absent, Android controls enabled during startup, Home control click succeeded, stream reached `live`, no browser warnings/errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full Android emulator/device support across UI and CLI (start/shutdown, platform badges, device picker)
  * H.264 streaming with decoded-frame relay (canvas) and improved MJPEG/H.264 handling
  * Android device controls (Back/Home/Recents/Volume/Power) and APK install via drag‑and‑drop
  * Platform-aware tools (devtools, location, app detection) and platform-specific device actions

* **Bug Fixes / UX**
  * Improved stream startup, stall detection, loading overlay messaging, and media-drop validation

* **Tests**
  * Added Android-focused unit tests and H.264 parsing tests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EvanBacon/serve-sim/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->