### PR TITLE
[codex] Improve simulated camera connection compatibility

### DIFF
--- a/packages/serve-sim/Sources/SimCameraInjector/SimCamFakes.h
+++ b/packages/serve-sim/Sources/SimCameraInjector/SimCamFakes.h
@@ -72,6 +72,8 @@ AVCaptureDevice *SimCamFakeDeviceForPosition(AVCaptureDevicePosition p);
 AVCaptureDeviceInput *SimCamFakeInputForPosition(AVCaptureDevicePosition p);
 
 AVCaptureConnection *SimCamFakeConnectionForOutput(AVCaptureOutput *out);
+void SimCamSetOutputInput(AVCaptureOutput *out, AVCaptureInput *input);
+AVCaptureInput *SimCamOutputInput(AVCaptureOutput *out);
 
 CMAttitude *SimCamSharedAttitude(void);
 CMAccelerometerData *SimCamSharedAccelerometerData(void);

--- a/packages/serve-sim/Sources/SimCameraInjector/SimCamFakes.m
+++ b/packages/serve-sim/Sources/SimCameraInjector/SimCamFakes.m
@@ -149,6 +149,8 @@ void SimCamLogSwallowedRuntimeError(NSString *via, id object, NSDictionary *user
 - (NSArray *)supportedColorSpaces { return @[]; }
 - (NSArray *)supportedDepthDataFormats { return @[]; }
 - (BOOL)isPortraitEffectSupported { return NO; }
+- (NSArray<Class> *)unsupportedCaptureOutputClasses { return @[]; }
+- (BOOL)isStreamingDisparitySupported { return NO; }
 - (float)minISO { return 25.0f; }
 - (float)maxISO { return 6400.0f; }
 - (CMTime)minExposureDuration { return CMTimeMake(1, 8000); }
@@ -286,6 +288,8 @@ AVCaptureDevice *SimCamFakeDeviceForPosition(AVCaptureDevicePosition p) {
 - (AVCaptureVideoOrientation)_videoOrientation;
 @end
 
+static AVCaptureInputPort *SimCamFakeInputPortForInput(AVCaptureInput *input, AVCaptureDevicePosition position);
+
 @implementation SimCamFakeConnection {
     __weak AVCaptureOutput *_outputRef;
     AVCaptureDevicePosition _position;
@@ -311,8 +315,12 @@ AVCaptureDevice *SimCamFakeDeviceForPosition(AVCaptureDevicePosition p) {
     return c;
 }
 - (AVCaptureOutput *)output { return _outputRef; }
-- (NSArray *)inputPorts { return @[]; }
-- (AVCaptureInput *)input { return nil; }
+- (NSArray *)inputPorts {
+    AVCaptureInput *input = SimCamOutputInput(_outputRef) ?: SimCamFakeInputForPosition(_position);
+    AVCaptureInputPort *port = SimCamFakeInputPortForInput(input, _position);
+    return port ? @[port] : @[];
+}
+- (AVCaptureInput *)input { return SimCamOutputInput(_outputRef) ?: SimCamFakeInputForPosition(_position); }
 - (AVCaptureVideoPreviewLayer *)videoPreviewLayer { return nil; }
 - (BOOL)isEnabled { return _enabled; }
 - (void)setEnabled:(BOOL)e { _enabled = e; }
@@ -409,6 +417,67 @@ AVCaptureConnection *SimCamFakeConnectionForOutput(AVCaptureOutput *out) {
         }
     }
     return conn;
+}
+
+#pragma mark - SimCamFakeInputPort
+
+@interface SimCamFakeInputPort : AVCaptureInputPort
+@end
+
+@implementation SimCamFakeInputPort {
+    __weak AVCaptureInput *_inputRef;
+    AVCaptureDevicePosition _position;
+}
++ (instancetype)allocWithZone:(NSZone *)zone {
+    return class_createInstance([SimCamFakeInputPort class], 0);
+}
++ (instancetype)portForInput:(AVCaptureInput *)input position:(AVCaptureDevicePosition)position {
+    SimCamFakeInputPort *p = [self alloc];
+    if (p) {
+        p->_inputRef = input;
+        p->_position = position;
+    }
+    return p;
+}
+- (AVCaptureInput *)input { return _inputRef; }
+- (AVMediaType)mediaType { return AVMediaTypeVideo; }
+- (AVCaptureDeviceType)sourceDeviceType { return AVCaptureDeviceTypeBuiltInWideAngleCamera; }
+- (AVCaptureDevicePosition)sourceDevicePosition { return _position; }
+- (CMFormatDescriptionRef)formatDescription { return SimCamSharedFakeFormat().formatDescription; }
+- (BOOL)isEnabled { return YES; }
+- (void)setEnabled:(BOOL)enabled { (void)enabled; }
+@end
+
+static char kSimCamOutputInputRefKey;
+static char kSimCamFakeInputPortKey;
+
+void SimCamSetOutputInput(AVCaptureOutput *out, AVCaptureInput *input) {
+    if (!out) return;
+    if (!input) {
+        objc_setAssociatedObject(out, &kSimCamOutputInputRefKey, nil, OBJC_ASSOCIATION_RETAIN);
+        return;
+    }
+    SimCamWeakRef *ref = [SimCamWeakRef new];
+    ref.target = input;
+    objc_setAssociatedObject(out, &kSimCamOutputInputRefKey, ref, OBJC_ASSOCIATION_RETAIN);
+}
+
+AVCaptureInput *SimCamOutputInput(AVCaptureOutput *out) {
+    if (!out) return nil;
+    SimCamWeakRef *ref = objc_getAssociatedObject(out, &kSimCamOutputInputRefKey);
+    return ref.target;
+}
+
+static AVCaptureInputPort *SimCamFakeInputPortForInput(AVCaptureInput *input, AVCaptureDevicePosition position) {
+    if (!input) return nil;
+    AVCaptureInputPort *port = objc_getAssociatedObject(input, &kSimCamFakeInputPortKey);
+    if (!port) {
+        port = (AVCaptureInputPort *)[SimCamFakeInputPort portForInput:input position:position];
+        if (port) {
+            objc_setAssociatedObject(input, &kSimCamFakeInputPortKey, port, OBJC_ASSOCIATION_RETAIN);
+        }
+    }
+    return port;
 }
 
 #pragma mark - SimCamFakeInput marking

--- a/packages/serve-sim/Sources/SimCameraInjector/SimCamSwizzles.m
+++ b/packages/serve-sim/Sources/SimCameraInjector/SimCamSwizzles.m
@@ -200,6 +200,7 @@ static BOOL SwizzleInstanceMethod(Class cls, SEL orig, SEL swiz) {
 static char kSimCamSessionRunningKey;
 static char kSimCamSessionInputsKey;
 static char kSimCamSessionOutputsKey;
+static char kSimCamOutputAttachedToFakeSessionKey;
 
 static NSMutableArray *SimCamSessionTrackedInputs(AVCaptureSession *s) {
     NSMutableArray *arr = objc_getAssociatedObject(s, &kSimCamSessionInputsKey);
@@ -216,6 +217,31 @@ static NSMutableArray *SimCamSessionTrackedOutputs(AVCaptureSession *s) {
         objc_setAssociatedObject(s, &kSimCamSessionOutputsKey, arr, OBJC_ASSOCIATION_RETAIN);
     }
     return arr;
+}
+
+// Real AVFoundation only exposes output connections after an output has been
+// attached to a session. Keep this per-output so newly created outputs still
+// look disconnected during client-side session configuration checks.
+static void SimCamMarkOutputAttachedToFakeSession(AVCaptureSession *s, AVCaptureOutput *output) {
+    if (!output) return;
+    objc_setAssociatedObject(output, &kSimCamOutputAttachedToFakeSessionKey, @YES, OBJC_ASSOCIATION_RETAIN);
+    AVCaptureInput *input = nil;
+    for (AVCaptureInput *candidate in SimCamSessionTrackedInputs(s)) {
+        if (SimCamIsFakeInput(candidate)) {
+            input = candidate;
+            break;
+        }
+    }
+    SimCamSetOutputInput(output, input);
+}
+static void SimCamUnmarkOutputAttachedToFakeSession(AVCaptureOutput *output) {
+    if (!output) return;
+    objc_setAssociatedObject(output, &kSimCamOutputAttachedToFakeSessionKey, nil, OBJC_ASSOCIATION_RETAIN);
+    SimCamSetOutputInput(output, nil);
+}
+static BOOL SimCamOutputAttachedToFakeSession(AVCaptureOutput *output) {
+    if (!output) return NO;
+    return [objc_getAssociatedObject(output, &kSimCamOutputAttachedToFakeSessionKey) boolValue];
 }
 
 @interface AVCaptureSession (SimCam)
@@ -268,6 +294,7 @@ static NSMutableArray *SimCamSessionTrackedOutputs(AVCaptureSession *s) {
 }
 - (void)simcam_addOutput:(AVCaptureOutput *)output {
     SimCamSetPosition(output, SimCamPositionOf(self));
+    SimCamMarkOutputAttachedToFakeSession(self, output);
     SimCamMarkCameraInUse();
     NSMutableArray *tracked = SimCamSessionTrackedOutputs(self);
     if (![tracked containsObject:output]) [tracked addObject:output];
@@ -279,6 +306,7 @@ static NSMutableArray *SimCamSessionTrackedOutputs(AVCaptureSession *s) {
 - (BOOL)simcam_canAddOutput:(AVCaptureOutput *)output { return YES; }
 - (void)simcam_addOutputWithNoConnections:(AVCaptureOutput *)output {
     SimCamSetPosition(output, SimCamPositionOf(self));
+    SimCamMarkOutputAttachedToFakeSession(self, output);
     SimCamMarkCameraInUse();
     NSMutableArray *tracked = SimCamSessionTrackedOutputs(self);
     if (![tracked containsObject:output]) [tracked addObject:output];
@@ -288,6 +316,7 @@ static NSMutableArray *SimCamSessionTrackedOutputs(AVCaptureSession *s) {
         (int)SimCamPositionOf(self));
 }
 - (void)simcam_removeOutput:(AVCaptureOutput *)output {
+    SimCamUnmarkOutputAttachedToFakeSession(output);
     NSMutableArray *tracked = SimCamSessionTrackedOutputs(self);
     [tracked removeObject:output];
     simcam_log(@"removeOutput: %@ — untracked (count=%lu)",
@@ -436,7 +465,7 @@ static NSMutableArray *SimCamSessionTrackedOutputs(AVCaptureSession *s) {
 - (AVCaptureConnection *)simcam_connectionWithMediaType:(AVMediaType)mediaType {
     AVCaptureConnection *real = [self simcam_connectionWithMediaType:mediaType];
     if (real) return real;
-    if (!SimCamCameraIsInUse()) return nil;
+    if (!SimCamOutputAttachedToFakeSession(self)) return nil;
     if (![mediaType isEqualToString:AVMediaTypeVideo]) return nil;
     AVCaptureConnection *fake = SimCamFakeConnectionForOutput(self);
     simcam_log(@"connectionWithMediaType:%@ → fake %p for %@ %p",
@@ -446,7 +475,7 @@ static NSMutableArray *SimCamSessionTrackedOutputs(AVCaptureSession *s) {
 - (NSArray<AVCaptureConnection *> *)simcam_connections {
     NSArray *real = [self simcam_connections];
     if (real.count > 0) return real;
-    if (!SimCamCameraIsInUse()) return real ?: @[];
+    if (!SimCamOutputAttachedToFakeSession(self)) return real ?: @[];
     AVCaptureConnection *fake = SimCamFakeConnectionForOutput(self);
     return fake ? @[fake] : @[];
 }

--- a/packages/serve-sim/Sources/SimCameraInjector/SimCamSwizzles.m
+++ b/packages/serve-sim/Sources/SimCameraInjector/SimCamSwizzles.m
@@ -219,20 +219,20 @@ static NSMutableArray *SimCamSessionTrackedOutputs(AVCaptureSession *s) {
     return arr;
 }
 
+static AVCaptureInput *SimCamFirstFakeInputForSession(AVCaptureSession *s) {
+    for (AVCaptureInput *candidate in SimCamSessionTrackedInputs(s)) {
+        if (SimCamIsFakeInput(candidate)) return candidate;
+    }
+    return nil;
+}
+
 // Real AVFoundation only exposes output connections after an output has been
 // attached to a session. Keep this per-output so newly created outputs still
 // look disconnected during client-side session configuration checks.
 static void SimCamMarkOutputAttachedToFakeSession(AVCaptureSession *s, AVCaptureOutput *output) {
     if (!output) return;
     objc_setAssociatedObject(output, &kSimCamOutputAttachedToFakeSessionKey, @YES, OBJC_ASSOCIATION_RETAIN);
-    AVCaptureInput *input = nil;
-    for (AVCaptureInput *candidate in SimCamSessionTrackedInputs(s)) {
-        if (SimCamIsFakeInput(candidate)) {
-            input = candidate;
-            break;
-        }
-    }
-    SimCamSetOutputInput(output, input);
+    SimCamSetOutputInput(output, SimCamFirstFakeInputForSession(s));
 }
 static void SimCamUnmarkOutputAttachedToFakeSession(AVCaptureOutput *output) {
     if (!output) return;
@@ -242,6 +242,14 @@ static void SimCamUnmarkOutputAttachedToFakeSession(AVCaptureOutput *output) {
 static BOOL SimCamOutputAttachedToFakeSession(AVCaptureOutput *output) {
     if (!output) return NO;
     return [objc_getAssociatedObject(output, &kSimCamOutputAttachedToFakeSessionKey) boolValue];
+}
+static void SimCamRefreshAttachedOutputInputsForSession(AVCaptureSession *s) {
+    AVCaptureInput *input = SimCamFirstFakeInputForSession(s);
+    for (AVCaptureOutput *output in SimCamSessionTrackedOutputs(s)) {
+        if (SimCamOutputAttachedToFakeSession(output)) {
+            SimCamSetOutputInput(output, input);
+        }
+    }
 }
 
 @interface AVCaptureSession (SimCam)
@@ -255,6 +263,7 @@ static BOOL SimCamOutputAttachedToFakeSession(AVCaptureOutput *output) {
         SimCamMarkSessionUsingFakeCamera(self, YES);
         NSMutableArray *tracked = SimCamSessionTrackedInputs(self);
         if (![tracked containsObject:input]) [tracked addObject:input];
+        SimCamRefreshAttachedOutputInputsForSession(self);
         simcam_log(@"addInput: fake input (%@) — tracked (count=%lu), skipping native add",
             p == AVCaptureDevicePositionBack ? @"back" : @"front",
             (unsigned long)tracked.count);
@@ -274,6 +283,7 @@ static BOOL SimCamOutputAttachedToFakeSession(AVCaptureOutput *output) {
         SimCamMarkSessionUsingFakeCamera(self, YES);
         NSMutableArray *tracked = SimCamSessionTrackedInputs(self);
         if (![tracked containsObject:input]) [tracked addObject:input];
+        SimCamRefreshAttachedOutputInputsForSession(self);
         simcam_log(@"addInputWithNoConnections: fake input (%@) — tracked (count=%lu), skipping native add",
             p == AVCaptureDevicePositionBack ? @"back" : @"front",
             (unsigned long)tracked.count);
@@ -285,6 +295,7 @@ static BOOL SimCamOutputAttachedToFakeSession(AVCaptureOutput *output) {
     if (SimCamIsFakeInput(input)) {
         NSMutableArray *tracked = SimCamSessionTrackedInputs(self);
         [tracked removeObject:input];
+        SimCamRefreshAttachedOutputInputsForSession(self);
         if (tracked.count == 0) SimCamMarkSessionUsingFakeCamera(self, NO);
         simcam_log(@"removeInput: fake input — untracked (count=%lu)",
             (unsigned long)tracked.count);


### PR DESCRIPTION
## Summary

- track when fake camera outputs are actually attached to a session before exposing fake `AVCaptureConnection`s
- give fake connections a video input port and associated input, matching the shape clients expect from AVFoundation
- make the fake camera format answer additional compatibility queries used by camera clients

## Root cause

Clients that inspect AVFoundation session topology can create outputs before attaching them to a session, then assert that `output.connections` is still empty. serve-sim previously returned fake connections whenever the global camera-in-use flag was set, so fresh outputs could appear connected too early. Once attached, those fake connections also had empty `inputPorts`, and the fake format did not implement a couple of compatibility selectors used during output support checks.

## Validation

- `packages/serve-sim/Sources/SimCameraInjector/build.sh /tmp/serve-sim-pr-build`
- `git diff --check`
- Verified externally with a React Native VisionCamera Harness test that scanned a generated QR PNG through serve-sim on iOS Simulator using the patched injector dylib.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More accurate camera output–input connection handling in the simulator.
  * Per-output attachment tracking so outputs behave like real AVFoundation sessions.
  * Ability to associate and retrieve specific inputs for outputs in simulated sessions.
  * Better reporting of simulated camera format capabilities and input port resolution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EvanBacon/serve-sim/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->