### PR TITLE
Share camera frames via IOSurface ring

### DIFF
--- a/packages/serve-sim/Sources/SimCameraHelper/build.sh
+++ b/packages/serve-sim/Sources/SimCameraHelper/build.sh
@@ -20,6 +20,7 @@ xcrun --sdk macosx clang \
     -framework CoreImage \
     -framework CoreText \
     -framework ImageIO \
+    -framework IOSurface \
     -framework Accelerate \
     -O2 \
     -o "$BIN" \

--- a/packages/serve-sim/Sources/SimCameraHelper/main.m
+++ b/packages/serve-sim/Sources/SimCameraHelper/main.m
@@ -29,6 +29,7 @@
 #import <CoreImage/CoreImage.h>
 #import <Accelerate/Accelerate.h>
 #import <ImageIO/ImageIO.h>
+#import <IOSurface/IOSurface.h>
 
 #include <fcntl.h>
 #include <signal.h>
@@ -44,7 +45,9 @@
 #pragma mark - Globals (shm + writer)
 
 static SimCamShmHeader *gHeader = NULL;
-static uint8_t *gPixels = NULL;
+static SimCamSurfaceTable *gSurfaceTable = NULL;
+static IOSurfaceRef gSurfaces[SIMCAM_SURFACE_RING];
+static uint32_t gWriteIndex = 0;            // last ring slot rendered into
 static uint32_t gWidth = SIMCAM_DEFAULT_WIDTH;
 static uint32_t gHeight = SIMCAM_DEFAULT_HEIGHT;
 static const char *gShmName = NULL;
@@ -65,11 +68,39 @@ static uint8_t ParseMirrorCode(NSString *mode);
 static NSString *MirrorName(uint8_t code);
 
 // Publish a fully-prepared BGRA frame (gWidth x gHeight, packed at gWidth*4
-// bytes per row) to the shm region. Writers MUST go through this so seq/ts
-// stay coherent for the dylib's tear-detection check.
+// bytes per row) into the next free ring surface. Writers MUST go through this
+// so latestIndex/frameSeq stay coherent for the dylib's tear-detection check.
 static void PublishFrame(const uint8_t *bgra) {
-    if (!gHeader || !gPixels || !bgra) return;
-    memcpy(gPixels, bgra, (size_t)gWidth * gHeight * 4);
+    if (!gHeader || !gSurfaceTable || !bgra) return;
+    uint32_t count = gSurfaceTable->surfaceCount;
+    if (count == 0) return;
+
+    // Render into a surface the reader isn't holding and isn't the one it last
+    // published, so an in-flight frame is never overwritten mid-read.
+    uint32_t latest = gSurfaceTable->latestIndex;
+    uint32_t idx = gWriteIndex;
+    for (uint32_t tries = 0; tries < count; tries++) {
+        idx = (idx + 1) % count;
+        if (idx == latest) continue;
+        if (!IOSurfaceIsInUse(gSurfaces[idx])) break;
+    }
+    gWriteIndex = idx;
+
+    IOSurfaceRef surface = gSurfaces[idx];
+    IOSurfaceLock(surface, 0, NULL);
+    uint8_t *dst = (uint8_t *)IOSurfaceGetBaseAddress(surface);
+    size_t dstStride = IOSurfaceGetBytesPerRow(surface);
+    size_t srcStride = (size_t)gWidth * 4;
+    if (dstStride == srcStride) {
+        memcpy(dst, bgra, srcStride * gHeight);
+    } else {
+        for (uint32_t y = 0; y < gHeight; y++) {
+            memcpy(dst + (size_t)y * dstStride, bgra + (size_t)y * srcStride, srcStride);
+        }
+    }
+    IOSurfaceUnlock(surface, 0, NULL);
+
+    gSurfaceTable->latestIndex = idx;
     gHeader->timestampNs = MachAbsToNs(mach_absolute_time());
     atomic_thread_fence(memory_order_release);
     uint64_t next = atomic_fetch_add(&gFrameSeq, 1) + 1;
@@ -754,7 +785,41 @@ static void ListDevices(void) {
     }
 }
 
-static int OpenShm(const char *name, size_t size) {
+// Allocate the IOSurface ring and record their global IDs in the table.
+static BOOL CreateSurfaces(void) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    NSDictionary *props = @{
+        (id)kIOSurfaceWidth: @(gWidth),
+        (id)kIOSurfaceHeight: @(gHeight),
+        (id)kIOSurfaceBytesPerElement: @4,
+        (id)kIOSurfacePixelFormat: @((uint32_t)kCVPixelFormatType_32BGRA),
+        // Global so the simulator process can resolve the surface by ID.
+        (id)kIOSurfaceIsGlobal: @YES,
+    };
+#pragma clang diagnostic pop
+    for (uint32_t i = 0; i < SIMCAM_SURFACE_RING; i++) {
+        IOSurfaceRef s = IOSurfaceCreate((__bridge CFDictionaryRef)props);
+        if (!s) {
+            fprintf(stderr, "[serve-sim-camera] IOSurfaceCreate failed at %u\n", i);
+            return NO;
+        }
+        gSurfaces[i] = s;
+        gSurfaceTable->ids[i] = IOSurfaceGetID(s);
+    }
+    gSurfaceTable->surfaceCount = SIMCAM_SURFACE_RING;
+    gSurfaceTable->latestIndex = 0;
+    return YES;
+}
+
+static void ReleaseSurfaces(void) {
+    for (uint32_t i = 0; i < SIMCAM_SURFACE_RING; i++) {
+        if (gSurfaces[i]) { CFRelease(gSurfaces[i]); gSurfaces[i] = NULL; }
+    }
+}
+
+static int OpenShm(const char *name) {
+    size_t size = (size_t)SimCamControlSize();
     shm_unlink(name);
     int fd = shm_open(name, O_CREAT | O_RDWR, 0644);
     if (fd < 0) { perror("shm_open"); return -1; }
@@ -762,14 +827,15 @@ static int OpenShm(const char *name, size_t size) {
     void *map = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
     if (map == MAP_FAILED) { perror("mmap"); close(fd); return -1; }
     gHeader = (SimCamShmHeader *)map;
-    gPixels = (uint8_t *)map + sizeof(SimCamShmHeader);
-    memset(gHeader, 0, sizeof(*gHeader));
+    gSurfaceTable = (SimCamSurfaceTable *)((uint8_t *)map + sizeof(SimCamShmHeader));
+    memset(map, 0, size);
+    if (!CreateSurfaces()) { close(fd); return -1; }
     gHeader->magic = SIMCAM_SHM_MAGIC;
-    gHeader->version = 1;
+    gHeader->version = 2;
     gHeader->width = gWidth;
     gHeader->height = gHeight;
     gHeader->pixelFormat = SIMCAM_PIXEL_BGRA;
-    gHeader->bytesPerRow = gWidth * 4;
+    gHeader->bytesPerRow = (uint32_t)IOSurfaceGetBytesPerRow(gSurfaces[0]);
     gHeader->pixelByteSize = (uint64_t)gWidth * gHeight * 4;
     gHeader->mirrorMode = SIMCAM_MIRROR_UNSET; // dylib falls back to env
     return fd;
@@ -824,10 +890,9 @@ int main(int argc, const char *argv[]) {
             // (no-op marker; --device implies webcam below if user intended it)
         }
 
-        size_t shmSize = (size_t)SimCamShmSizeFor(gWidth, gHeight);
-        if (OpenShm(gShmName, shmSize) < 0) return 1;
-        fprintf(stderr, "[serve-sim-camera] shm \"%s\" %zu bytes (%ux%u BGRA)\n",
-                gShmName, shmSize, gWidth, gHeight);
+        if (OpenShm(gShmName) < 0) return 1;
+        fprintf(stderr, "[serve-sim-camera] shm \"%s\" + %u IOSurfaces (%ux%u BGRA)\n",
+                gShmName, SIMCAM_SURFACE_RING, gWidth, gHeight);
 
         gSourceQueue = dispatch_queue_create("simcam.helper.source", DISPATCH_QUEUE_SERIAL);
 
@@ -863,6 +928,7 @@ int main(int argc, const char *argv[]) {
         if (gControlListenFd >= 0) { close(gControlListenFd); if (socketPath) unlink(socketPath); }
         StopPlaceholderSource();
         StopWebcamSource();
+        ReleaseSurfaces();
         if (gShmName) shm_unlink(gShmName);
         fprintf(stderr, "[serve-sim-camera] stopped\n");
         return 0;

--- a/packages/serve-sim/Sources/SimCameraHelper/main.m
+++ b/packages/serve-sim/Sources/SimCameraHelper/main.m
@@ -79,11 +79,16 @@ static void PublishFrame(const uint8_t *bgra) {
     // published, so an in-flight frame is never overwritten mid-read.
     uint32_t latest = gSurfaceTable->latestIndex;
     uint32_t idx = gWriteIndex;
+    BOOL found = NO;
     for (uint32_t tries = 0; tries < count; tries++) {
         idx = (idx + 1) % count;
         if (idx == latest) continue;
-        if (!IOSurfaceIsInUse(gSurfaces[idx])) break;
+        if (!IOSurfaceIsInUse(gSurfaces[idx])) {
+            found = YES;
+            break;
+        }
     }
+    if (!found) return;
     gWriteIndex = idx;
 
     IOSurfaceRef surface = gSurfaces[idx];
@@ -104,7 +109,7 @@ static void PublishFrame(const uint8_t *bgra) {
     gHeader->timestampNs = MachAbsToNs(mach_absolute_time());
     atomic_thread_fence(memory_order_release);
     uint64_t next = atomic_fetch_add(&gFrameSeq, 1) + 1;
-    gHeader->frameSeq = next;
+    atomic_store_explicit(&gHeader->frameSeq, next, memory_order_release);
 }
 
 #pragma mark - Source pipeline (start / stop / switch)
@@ -928,6 +933,7 @@ int main(int argc, const char *argv[]) {
         if (gControlListenFd >= 0) { close(gControlListenFd); if (socketPath) unlink(socketPath); }
         StopPlaceholderSource();
         StopWebcamSource();
+        StopVideoSource();
         ReleaseSurfaces();
         if (gShmName) shm_unlink(gShmName);
         fprintf(stderr, "[serve-sim-camera] stopped\n");

--- a/packages/serve-sim/Sources/SimCameraInjector/SimCamFrameSource.m
+++ b/packages/serve-sim/Sources/SimCameraInjector/SimCamFrameSource.m
@@ -247,7 +247,7 @@ static CGImageRef SimCamAcquireCachedCGImage(void) CF_RETURNS_RETAINED {
 - (CVPixelBufferRef)newPixelBufferFromSurfaceForceFresh:(BOOL)force CF_RETURNS_RETAINED {
     if (!gShmHeader || !gSurfaceTable) return NULL;
     if (gShmHeader->magic != SIMCAM_SHM_MAGIC) return NULL;
-    uint64_t seqA = gShmHeader->frameSeq;
+    uint64_t seqA = atomic_load_explicit(&gShmHeader->frameSeq, memory_order_acquire);
     if (seqA == 0) return NULL;
     if (!force && seqA == gLastSeenSeq) return NULL;
 
@@ -256,7 +256,10 @@ static CGImageRef SimCamAcquireCachedCGImage(void) CF_RETURNS_RETAINED {
     uint32_t idx = gSurfaceTable->latestIndex;
     if (idx >= count) return NULL;
     IOSurfaceRef surface = gSurfaces[idx];
-    if (!surface) return NULL;
+    if (!surface) {
+        simcam_log(@"missing IOSurface at latest index %u/%u", idx, count);
+        return NULL;
+    }
 
     CVPixelBufferRef pb = NULL;
     NSDictionary *attrs = @{ (id)kCVPixelBufferIOSurfacePropertiesKey: @{} };
@@ -264,8 +267,7 @@ static CGImageRef SimCamAcquireCachedCGImage(void) CF_RETURNS_RETAINED {
         (__bridge CFDictionaryRef)attrs, &pb);
     if (r != kCVReturnSuccess || !pb) return NULL;
 
-    atomic_thread_fence(memory_order_acquire);
-    uint64_t seqB = gShmHeader->frameSeq;
+    uint64_t seqB = atomic_load_explicit(&gShmHeader->frameSeq, memory_order_acquire);
     if (!force && seqA != seqB) {
         CVPixelBufferRelease(pb);
         return NULL;
@@ -360,7 +362,7 @@ static CGImageRef SimCamAcquireCachedCGImage(void) CF_RETURNS_RETAINED {
         dispatch_once(&logOnce, ^{
             simcam_log(@"no-signal fallback: shm=%@ frameSeq=%llu cache=empty",
                 gShmHeader ? @"attached" : @"unattached",
-                (unsigned long long)(gShmHeader ? gShmHeader->frameSeq : 0));
+                (unsigned long long)(gShmHeader ? atomic_load_explicit(&gShmHeader->frameSeq, memory_order_acquire) : 0));
         });
         pb = [self newPixelBufferNoSignal];
     }
@@ -554,8 +556,14 @@ void SimCamFrameSourceOpenShmIfRequested(void) {
         if (s) resolved++;
     }
 #pragma clang diagnostic pop
-    if (resolved == 0) {
-        simcam_log(@"no IOSurfaces resolved from shm \"%s\"", shmName);
+    if (resolved != count) {
+        for (uint32_t i = 0; i < count; i++) {
+            if (gSurfaces[i]) {
+                CFRelease(gSurfaces[i]);
+                gSurfaces[i] = NULL;
+            }
+        }
+        simcam_log(@"only %u/%u IOSurfaces resolved from shm \"%s\"", resolved, count, shmName);
         munmap(map, size);
         return;
     }

--- a/packages/serve-sim/Sources/SimCameraInjector/SimCamFrameSource.m
+++ b/packages/serve-sim/Sources/SimCameraInjector/SimCamFrameSource.m
@@ -6,6 +6,7 @@
 #import <CoreImage/CoreImage.h>
 #import <CoreMedia/CoreMedia.h>
 #import <CoreVideo/CoreVideo.h>
+#import <IOSurface/IOSurfaceRef.h>
 #import <UIKit/UIKit.h>
 #import <QuartzCore/QuartzCore.h>
 #import <objc/runtime.h>
@@ -26,8 +27,8 @@ static size_t kFrameHeight = 720;
 static const double kFrameRate = 30.0;
 
 static SimCamShmHeader *gShmHeader = NULL;
-static const uint8_t *gShmPixels = NULL;
-static size_t gShmTotalSize = 0;
+static SimCamSurfaceTable *gSurfaceTable = NULL;
+static IOSurfaceRef gSurfaces[SIMCAM_SURFACE_RING];  // resolved from global IDs
 static uint64_t gLastSeenSeq = 0;
 
 #pragma mark - Last-frame cache
@@ -236,35 +237,32 @@ static CGImageRef SimCamAcquireCachedCGImage(void) CF_RETURNS_RETAINED {
     });
 }
 
-- (CVPixelBufferRef)newPixelBufferFromShm CF_RETURNS_RETAINED {
-    return [self newPixelBufferFromShmForceFresh:NO];
+- (CVPixelBufferRef)newPixelBufferFromSurface CF_RETURNS_RETAINED {
+    return [self newPixelBufferFromSurfaceForceFresh:NO];
 }
 
-- (CVPixelBufferRef)newPixelBufferFromShmForceFresh:(BOOL)force CF_RETURNS_RETAINED {
-    if (!gShmHeader || !gShmPixels) return NULL;
+// Wrap the latest shared IOSurface as a CVPixelBuffer — zero copy. Holding the
+// pixel buffer keeps the surface in use, so the host writer renders into a
+// different ring slot until we release it.
+- (CVPixelBufferRef)newPixelBufferFromSurfaceForceFresh:(BOOL)force CF_RETURNS_RETAINED {
+    if (!gShmHeader || !gSurfaceTable) return NULL;
     if (gShmHeader->magic != SIMCAM_SHM_MAGIC) return NULL;
     uint64_t seqA = gShmHeader->frameSeq;
     if (seqA == 0) return NULL;
     if (!force && seqA == gLastSeenSeq) return NULL;
-    uint32_t w = gShmHeader->width;
-    uint32_t h = gShmHeader->height;
-    uint32_t bpr = gShmHeader->bytesPerRow;
-    if (!w || !h || bpr < w * 4) return NULL;
-    if (sizeof(SimCamShmHeader) + (size_t)bpr * h > gShmTotalSize) return NULL;
+
+    uint32_t count = gSurfaceTable->surfaceCount;
+    if (count == 0 || count > SIMCAM_SURFACE_RING) return NULL;
+    uint32_t idx = gSurfaceTable->latestIndex;
+    if (idx >= count) return NULL;
+    IOSurfaceRef surface = gSurfaces[idx];
+    if (!surface) return NULL;
 
     CVPixelBufferRef pb = NULL;
     NSDictionary *attrs = @{ (id)kCVPixelBufferIOSurfacePropertiesKey: @{} };
-    CVReturn r = CVPixelBufferCreate(kCFAllocatorDefault, w, h,
-        kCVPixelFormatType_32BGRA, (__bridge CFDictionaryRef)attrs, &pb);
+    CVReturn r = CVPixelBufferCreateWithIOSurface(kCFAllocatorDefault, surface,
+        (__bridge CFDictionaryRef)attrs, &pb);
     if (r != kCVReturnSuccess || !pb) return NULL;
-    CVPixelBufferLockBaseAddress(pb, 0);
-    uint8_t *dst = (uint8_t *)CVPixelBufferGetBaseAddress(pb);
-    size_t dstBpr = CVPixelBufferGetBytesPerRow(pb);
-    size_t copyBpr = MIN((size_t)bpr, dstBpr);
-    for (uint32_t y = 0; y < h; y++) {
-        memcpy(dst + y * dstBpr, gShmPixels + y * bpr, copyBpr);
-    }
-    CVPixelBufferUnlockBaseAddress(pb, 0);
 
     atomic_thread_fence(memory_order_acquire);
     uint64_t seqB = gShmHeader->frameSeq;
@@ -277,7 +275,7 @@ static CGImageRef SimCamAcquireCachedCGImage(void) CF_RETURNS_RETAINED {
 }
 
 - (CVPixelBufferRef)currentPixelBuffer CF_RETURNS_RETAINED {
-    CVPixelBufferRef pb = [self newPixelBufferFromShmForceFresh:YES];
+    CVPixelBufferRef pb = [self newPixelBufferFromSurfaceForceFresh:YES];
     if (!pb) pb = [self newPixelBufferFromImage];
     return pb;
 }
@@ -350,7 +348,7 @@ static CGImageRef SimCamAcquireCachedCGImage(void) CF_RETURNS_RETAINED {
 }
 
 - (CMSampleBufferRef)newSampleBufferAtTime:(CMTime)pts CF_RETURNS_RETAINED {
-    CVPixelBufferRef pb = [self newPixelBufferFromShm];
+    CVPixelBufferRef pb = [self newPixelBufferFromSurface];
     if (!pb) pb = [self newPixelBufferFromImage];
     if (pb) {
         SimCamCacheFrame(pb);
@@ -518,13 +516,14 @@ void SimCamFrameSourceOpenShmIfRequested(void) {
         simcam_log(@"shm_open(%s) failed: %s", shmName, strerror(errno));
         return;
     }
+    size_t size = (size_t)SimCamControlSize();
     struct stat st;
-    if (fstat(fd, &st) < 0 || st.st_size < (off_t)sizeof(SimCamShmHeader)) {
+    if (fstat(fd, &st) < 0 || (size_t)st.st_size < size) {
         simcam_log(@"shm fstat failed or too small");
         close(fd);
         return;
     }
-    void *map = mmap(NULL, (size_t)st.st_size, PROT_READ, MAP_SHARED, fd, 0);
+    void *map = mmap(NULL, size, PROT_READ, MAP_SHARED, fd, 0);
     close(fd);
     if (map == MAP_FAILED) {
         simcam_log(@"shm mmap failed: %s", strerror(errno));
@@ -533,14 +532,38 @@ void SimCamFrameSourceOpenShmIfRequested(void) {
     SimCamShmHeader *hdr = (SimCamShmHeader *)map;
     if (hdr->magic != SIMCAM_SHM_MAGIC) {
         simcam_log(@"shm magic mismatch: 0x%x", hdr->magic);
-        munmap(map, (size_t)st.st_size);
+        munmap(map, size);
         return;
     }
+    SimCamSurfaceTable *table =
+        (SimCamSurfaceTable *)((uint8_t *)map + sizeof(SimCamShmHeader));
+    uint32_t count = table->surfaceCount;
+    if (count == 0 || count > SIMCAM_SURFACE_RING) {
+        simcam_log(@"shm surface table invalid (count=%u)", count);
+        munmap(map, size);
+        return;
+    }
+
+    // Resolve each global IOSurface ID to a local reference.
+    uint32_t resolved = 0;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    for (uint32_t i = 0; i < count; i++) {
+        IOSurfaceRef s = IOSurfaceLookup(table->ids[i]);
+        gSurfaces[i] = s;
+        if (s) resolved++;
+    }
+#pragma clang diagnostic pop
+    if (resolved == 0) {
+        simcam_log(@"no IOSurfaces resolved from shm \"%s\"", shmName);
+        munmap(map, size);
+        return;
+    }
+
     gShmHeader = hdr;
-    gShmPixels = (const uint8_t *)map + sizeof(SimCamShmHeader);
-    gShmTotalSize = (size_t)st.st_size;
+    gSurfaceTable = table;
     kFrameWidth = hdr->width;
     kFrameHeight = hdr->height;
-    simcam_log(@"shm \"%s\" attached (%ux%u, %llu bytes)",
-               shmName, hdr->width, hdr->height, (unsigned long long)st.st_size);
+    simcam_log(@"shm \"%s\" attached (%ux%u, %u/%u IOSurfaces resolved)",
+               shmName, hdr->width, hdr->height, resolved, count);
 }

--- a/packages/serve-sim/Sources/SimCameraInjector/build.sh
+++ b/packages/serve-sim/Sources/SimCameraInjector/build.sh
@@ -25,6 +25,7 @@ xcrun --sdk iphonesimulator clang \
     -framework CoreMotion \
     -framework CoreVideo \
     -framework CoreGraphics \
+    -framework IOSurface \
     -framework QuartzCore \
     -install_name "@rpath/libSimCameraInjector.dylib" \
     -o "$DYLIB" \

--- a/packages/serve-sim/Sources/SimCameraInjector/include/SimCamShared.h
+++ b/packages/serve-sim/Sources/SimCameraInjector/include/SimCamShared.h
@@ -22,7 +22,9 @@
 #ifndef SIM_CAM_SHARED_H
 #define SIM_CAM_SHARED_H
 
+#include <stddef.h>
 #include <stdint.h>
+#include <stdatomic.h>
 
 #define SIMCAM_SHM_MAGIC      0x53434D31u  // 'SCM1'
 #define SIMCAM_PIXEL_BGRA     0u
@@ -43,7 +45,7 @@
 #define SIMCAM_MIRROR_OFF     2
 
 // Control header is 64 bytes. The surface-ID table follows immediately after.
-typedef struct __attribute__((packed)) {
+typedef struct {
     uint32_t magic;        // SIMCAM_SHM_MAGIC
     uint32_t version;      // bumps on layout change
     uint32_t width;
@@ -51,13 +53,15 @@ typedef struct __attribute__((packed)) {
     uint32_t pixelFormat;  // SIMCAM_PIXEL_BGRA
     uint32_t bytesPerRow;  // actual IOSurface row stride (may exceed width*4)
     uint64_t pixelByteSize;// logical frame size: width*height*4
-    uint64_t frameSeq;     // written LAST; readers check tearing via re-read
+    _Atomic uint64_t frameSeq; // written LAST with release; readers acquire-load
     uint64_t timestampNs;  // mach_absolute_time-based, host monotonic
     uint8_t  mirrorMode;   // SIMCAM_MIRROR_*; UNSET = ignore (use env)
     uint8_t  reserved[15];
 } SimCamShmHeader;
 
 _Static_assert(sizeof(SimCamShmHeader) == 64, "SimCamShmHeader must be 64 bytes");
+_Static_assert(offsetof(SimCamShmHeader, frameSeq) == 32, "frameSeq offset must stay stable");
+_Static_assert(offsetof(SimCamShmHeader, mirrorMode) == 48, "mirrorMode offset must stay stable");
 
 // Ring of global IOSurface IDs, written once at startup. `latestIndex` is
 // updated each frame (before frameSeq) to point at the freshest surface.

--- a/packages/serve-sim/Sources/SimCameraInjector/include/SimCamShared.h
+++ b/packages/serve-sim/Sources/SimCameraInjector/include/SimCamShared.h
@@ -1,16 +1,23 @@
-// Shared memory wire format for serve-sim's simulator camera feed.
+// Wire format for serve-sim's simulator camera feed.
 //
-// One process (the host helper, running on macOS) captures webcam frames and
-// writes them into a POSIX shared-memory region. The injected dylib inside
-// the simulator app maps the same region and dispatches the latest frame to
-// AVFoundation delegates / preview layers.
+// Frames travel over a small ring of IOSurfaces shared by global surface ID.
+// The host helper (running on macOS) renders BGRA frames straight into the
+// surfaces; the injected dylib inside the simulator app looks the surfaces up
+// by ID and wraps the latest one as a CVPixelBuffer — no per-frame pixel copy.
 //
-// Format: BGRA, top-down, no padding except whatever bytesPerRow says.
+// A tiny POSIX shared-memory region acts as the control channel: it carries
+// the surface IDs, which surface holds the newest frame, the frame sequence
+// number, and the mirror mode. The pixels themselves live in the IOSurfaces,
+// not in this region.
 //
-// Synchronization is intentionally lock-free and lossy: the writer bumps
-// `frameSeq` last after writing pixels; the reader samples `frameSeq` before
-// and after copying and discards the read if they disagree. A single dropped
-// frame is fine for a 30 fps camera.
+// Surfaces are BGRA. Row stride comes from IOSurfaceGetBytesPerRow (it may be
+// padded beyond width*4); `bytesPerRow` below mirrors that actual stride.
+//
+// Synchronization is lock-free and lossy. The writer renders into a surface
+// the reader is not holding, points `latestIndex` at it, then bumps `frameSeq`
+// last. The reader samples `frameSeq` before and after wrapping the surface and
+// retries on the next tick if they disagree. A single dropped frame is fine for
+// a 30 fps camera.
 
 #ifndef SIM_CAM_SHARED_H
 #define SIM_CAM_SHARED_H
@@ -22,6 +29,11 @@
 #define SIMCAM_DEFAULT_WIDTH  1280u
 #define SIMCAM_DEFAULT_HEIGHT 720u
 
+// Number of IOSurfaces in the ring. The writer keeps off whichever surface the
+// reader most recently published, so a few buffers absorb a reader that holds
+// a frame for a tick or two without tearing.
+#define SIMCAM_SURFACE_RING   4u
+
 // Mirror mode codes for SimCamShmHeader.mirrorMode.
 // "Unset" lets the dylib fall back to its env-var configuration (back-compat
 // with hosts that don't write the byte).
@@ -30,15 +42,15 @@
 #define SIMCAM_MIRROR_ON      1
 #define SIMCAM_MIRROR_OFF     2
 
-// Header is 64 bytes — keeps pixel data 16-byte aligned.
+// Control header is 64 bytes. The surface-ID table follows immediately after.
 typedef struct __attribute__((packed)) {
     uint32_t magic;        // SIMCAM_SHM_MAGIC
     uint32_t version;      // bumps on layout change
     uint32_t width;
     uint32_t height;
     uint32_t pixelFormat;  // SIMCAM_PIXEL_BGRA
-    uint32_t bytesPerRow;
-    uint64_t pixelByteSize;
+    uint32_t bytesPerRow;  // actual IOSurface row stride (may exceed width*4)
+    uint64_t pixelByteSize;// logical frame size: width*height*4
     uint64_t frameSeq;     // written LAST; readers check tearing via re-read
     uint64_t timestampNs;  // mach_absolute_time-based, host monotonic
     uint8_t  mirrorMode;   // SIMCAM_MIRROR_*; UNSET = ignore (use env)
@@ -47,9 +59,17 @@ typedef struct __attribute__((packed)) {
 
 _Static_assert(sizeof(SimCamShmHeader) == 64, "SimCamShmHeader must be 64 bytes");
 
-// Total shm size for given dimensions: header + width*height*4
-static inline uint64_t SimCamShmSizeFor(uint32_t w, uint32_t h) {
-    return (uint64_t)sizeof(SimCamShmHeader) + (uint64_t)w * (uint64_t)h * 4ull;
+// Ring of global IOSurface IDs, written once at startup. `latestIndex` is
+// updated each frame (before frameSeq) to point at the freshest surface.
+typedef struct __attribute__((packed)) {
+    uint32_t surfaceCount;                 // valid entries in ids[]
+    uint32_t latestIndex;                  // ids[] slot holding the newest frame
+    uint32_t ids[SIMCAM_SURFACE_RING];     // global IOSurface IDs
+} SimCamSurfaceTable;
+
+// Total control-region size: header + surface table.
+static inline uint64_t SimCamControlSize(void) {
+    return (uint64_t)sizeof(SimCamShmHeader) + (uint64_t)sizeof(SimCamSurfaceTable);
 }
 
 #endif

--- a/packages/serve-sim/src/__tests__/shm-probe.integration.test.ts
+++ b/packages/serve-sim/src/__tests__/shm-probe.integration.test.ts
@@ -174,8 +174,8 @@ async function loadIOSurface(): Promise<NonNullable<typeof iosurface>> {
   );
   iosurface = {
     lookup: (id) => io.symbols.IOSurfaceLookup(id) as unknown,
-    width: (s) => Number(io.symbols.IOSurfaceGetWidth(s as never) as number),
-    height: (s) => Number(io.symbols.IOSurfaceGetHeight(s as never) as number),
+    width: (s) => Number(io.symbols.IOSurfaceGetWidth(s as never) as number | bigint),
+    height: (s) => Number(io.symbols.IOSurfaceGetHeight(s as never) as number | bigint),
     release: (s) => {
       cf.symbols.CFRelease(s as never);
     },
@@ -312,6 +312,10 @@ describeIf("SimCameraHelper shm probe", () => {
       const table = readSurfaceTable(handle.buffer);
       expect(table.surfaceCount).toBe(SURFACE_RING);
       expect(table.latestIndex).toBeLessThan(table.surfaceCount);
+      const latestSurfaceId = table.ids[table.latestIndex];
+      if (latestSurfaceId === undefined) {
+        throw new Error(`missing IOSurface ID at index ${table.latestIndex}`);
+      }
       // All ring slots carry a distinct, non-zero global surface id.
       const unique = new Set(table.ids);
       expect(unique.size).toBe(SURFACE_RING);
@@ -319,7 +323,7 @@ describeIf("SimCameraHelper shm probe", () => {
 
       // The latest surface resolves cross-process and matches the header dims.
       const io = await loadIOSurface();
-      const surface = io.lookup(table.ids[table.latestIndex]);
+      const surface = io.lookup(latestSurfaceId);
       expect(surface).toBeTruthy();
       if (surface) {
         expect(io.width(surface)).toBe(DEFAULT_WIDTH);

--- a/packages/serve-sim/src/__tests__/shm-probe.integration.test.ts
+++ b/packages/serve-sim/src/__tests__/shm-probe.integration.test.ts
@@ -12,6 +12,10 @@ const HELPER_PATH = join(
 const SIMCAM_MAGIC = 0x53434d31;
 const SIMCAM_PIXEL_BGRA = 0;
 const HEADER_BYTES = 64;
+const SURFACE_RING = 4;
+// SimCamSurfaceTable: surfaceCount + latestIndex + ids[SURFACE_RING].
+const TABLE_BYTES = 4 + 4 + SURFACE_RING * 4;
+const CONTROL_BYTES = HEADER_BYTES + TABLE_BYTES;
 const DEFAULT_WIDTH = 1280;
 const DEFAULT_HEIGHT = 720;
 
@@ -90,7 +94,7 @@ async function openExistingShm(name: string): Promise<ShmHandle | null> {
   const sys = await loadFfi();
   const fd = sys.shm_open(Buffer.from(`${name}\0`), 0, 0);
   if (fd < 0) return null;
-  const size = HEADER_BYTES;
+  const size = CONTROL_BYTES;
   const ptr = sys.mmap(null, BigInt(size), 1, 1, fd, 0n);
   if (!ptr) {
     sys.close(fd);
@@ -130,6 +134,53 @@ function readHeader(buffer: ArrayBuffer): {
     timestampNs: view.getBigUint64(40, true),
     mirrorMode: view.getUint8(48),
   };
+}
+
+function readSurfaceTable(buffer: ArrayBuffer): {
+  surfaceCount: number;
+  latestIndex: number;
+  ids: number[];
+} {
+  const view = new DataView(buffer);
+  const surfaceCount = view.getUint32(HEADER_BYTES, true);
+  const latestIndex = view.getUint32(HEADER_BYTES + 4, true);
+  const ids: number[] = [];
+  for (let i = 0; i < SURFACE_RING; i++) {
+    ids.push(view.getUint32(HEADER_BYTES + 8 + i * 4, true));
+  }
+  return { surfaceCount, latestIndex, ids };
+}
+
+let iosurface:
+  | undefined
+  | {
+      lookup: (id: number) => unknown;
+      width: (surface: unknown) => number;
+      height: (surface: unknown) => number;
+      release: (surface: unknown) => void;
+    };
+
+async function loadIOSurface(): Promise<NonNullable<typeof iosurface>> {
+  if (iosurface) return iosurface;
+  const { dlopen, FFIType } = await import("bun:ffi");
+  const io = dlopen("/System/Library/Frameworks/IOSurface.framework/IOSurface", {
+    IOSurfaceLookup: { args: [FFIType.u32], returns: FFIType.ptr },
+    IOSurfaceGetWidth: { args: [FFIType.ptr], returns: FFIType.u64 },
+    IOSurfaceGetHeight: { args: [FFIType.ptr], returns: FFIType.u64 },
+  });
+  const cf = dlopen(
+    "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
+    { CFRelease: { args: [FFIType.ptr], returns: FFIType.void } },
+  );
+  iosurface = {
+    lookup: (id) => io.symbols.IOSurfaceLookup(id) as unknown,
+    width: (s) => Number(io.symbols.IOSurfaceGetWidth(s as never) as number),
+    height: (s) => Number(io.symbols.IOSurfaceGetHeight(s as never) as number),
+    release: (s) => {
+      cf.symbols.CFRelease(s as never);
+    },
+  };
+  return iosurface;
 }
 
 function sendHelperCommand(socketPath: string, cmd: object, timeoutMs = 3000): Promise<any> {
@@ -248,6 +299,48 @@ describeIf("SimCameraHelper shm probe", () => {
         2000,
       );
       expect(advanced).toBe(true);
+    } finally {
+      await closeShm(handle);
+    }
+  });
+
+  test("publishes an IOSurface ring resolvable by global id", async () => {
+    const handle = await openExistingShm(SHM_NAME);
+    expect(handle).not.toBeNull();
+    if (!handle) return;
+    try {
+      const table = readSurfaceTable(handle.buffer);
+      expect(table.surfaceCount).toBe(SURFACE_RING);
+      expect(table.latestIndex).toBeLessThan(table.surfaceCount);
+      // All ring slots carry a distinct, non-zero global surface id.
+      const unique = new Set(table.ids);
+      expect(unique.size).toBe(SURFACE_RING);
+      expect(table.ids.every((id) => id > 0)).toBe(true);
+
+      // The latest surface resolves cross-process and matches the header dims.
+      const io = await loadIOSurface();
+      const surface = io.lookup(table.ids[table.latestIndex]);
+      expect(surface).toBeTruthy();
+      if (surface) {
+        expect(io.width(surface)).toBe(DEFAULT_WIDTH);
+        expect(io.height(surface)).toBe(DEFAULT_HEIGHT);
+        io.release(surface);
+      }
+    } finally {
+      await closeShm(handle);
+    }
+  });
+
+  test("latestIndex stays in range as frames advance", async () => {
+    const handle = await openExistingShm(SHM_NAME);
+    expect(handle).not.toBeNull();
+    if (!handle) return;
+    try {
+      const moved = await waitFor(() => {
+        const t = readSurfaceTable(handle.buffer);
+        return t.latestIndex < t.surfaceCount;
+      }, 1000);
+      expect(moved).toBe(true);
     } finally {
       await closeShm(handle);
     }

--- a/packages/serve-sim/src/__tests__/shm-probe.integration.test.ts
+++ b/packages/serve-sim/src/__tests__/shm-probe.integration.test.ts
@@ -174,8 +174,8 @@ async function loadIOSurface(): Promise<NonNullable<typeof iosurface>> {
   );
   iosurface = {
     lookup: (id) => io.symbols.IOSurfaceLookup(id) as unknown,
-    width: (s) => Number(io.symbols.IOSurfaceGetWidth(s as never) as number | bigint),
-    height: (s) => Number(io.symbols.IOSurfaceGetHeight(s as never) as number | bigint),
+    width: (s) => Number(io.symbols.IOSurfaceGetWidth(s as never) as bigint),
+    height: (s) => Number(io.symbols.IOSurfaceGetHeight(s as never) as bigint),
     release: (s) => {
       cf.symbols.CFRelease(s as never);
     },
@@ -281,7 +281,7 @@ describeIf("SimCameraHelper shm probe", () => {
       expect(header.width).toBe(DEFAULT_WIDTH);
       expect(header.height).toBe(DEFAULT_HEIGHT);
       expect(header.pixelFormat).toBe(SIMCAM_PIXEL_BGRA);
-      expect(header.bytesPerRow).toBe(DEFAULT_WIDTH * 4);
+      expect(header.bytesPerRow).toBeGreaterThanOrEqual(DEFAULT_WIDTH * 4);
       expect(header.pixelByteSize).toBe(BigInt(DEFAULT_WIDTH * DEFAULT_HEIGHT * 4));
     } finally {
       await closeShm(handle);
@@ -340,9 +340,11 @@ describeIf("SimCameraHelper shm probe", () => {
     expect(handle).not.toBeNull();
     if (!handle) return;
     try {
+      const initialFrameSeq = readHeader(handle.buffer).frameSeq;
       const moved = await waitFor(() => {
+        const header = readHeader(handle.buffer);
         const t = readSurfaceTable(handle.buffer);
-        return t.latestIndex < t.surfaceCount;
+        return header.frameSeq !== initialFrameSeq && t.latestIndex < t.surfaceCount;
       }, 1000);
       expect(moved).toBe(true);
     } finally {
@@ -379,7 +381,7 @@ describeIf("SimCameraHelper shm probe", () => {
       const header = readHeader(handle.buffer);
       expect(header.width).toBe(DEFAULT_WIDTH);
       expect(header.height).toBe(DEFAULT_HEIGHT);
-      expect(header.bytesPerRow).toBe(header.width * 4);
+      expect(header.bytesPerRow).toBeGreaterThanOrEqual(header.width * 4);
     } finally {
       await closeShm(handle);
     }
@@ -393,10 +395,11 @@ describeIf("SimCameraHelper shm probe", () => {
     try {
       await sendHelperCommand(SOCKET_PATH, { action: "shutdown" });
     } catch {}
-    await Promise.race([
+    const exitCode = await Promise.race([
       exited,
-      new Promise((r) => setTimeout(r, 3000)),
+      new Promise<"timeout">((r) => setTimeout(() => r("timeout"), 3000)),
     ]);
+    expect(exitCode).not.toBe("timeout");
     helper = null;
 
     const sys = await loadFfi();


### PR DESCRIPTION
## Summary
- replace the camera pixel payload in POSIX shm with a small IOSurface ring control table
- have the helper publish BGRA frames into global IOSurfaces and the injected dylib wrap the latest surface as a CVPixelBuffer
- add integration coverage that validates surface IDs resolve and latestIndex stays in range

## Test plan
- bun run packages/serve-sim/build.ts
- bun test packages/serve-sim/src/__tests__/shm-probe.integration.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Switch to a zero-copy surface ring for camera frames, improving frame delivery and reducing copy latency.

* **Chores**
  * Link the IOSurface framework in build configurations.
  * Revise the shared-memory control layout to include a surface-ring table for safer, lock-free frame handoff and lifecycle handling.

* **Tests**
  * Add integration tests validating the surface-ring behavior, cross-process surface resolution, and advancing-frame semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->