### PR TITLE
feat: add Claude Code plugin marketplace manifest

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "serve-sim",
+  "description": "Stream and control Apple Simulators from Claude Code",
+  "owner": {
+    "name": "Evan Bacon"
+  },
+  "plugins": [
+    {
+      "name": "serve-sim",
+      "source": "./",
+      "description": "Control and stream a running iOS, iPad, or Apple Watch Simulator with serve-sim — taps, gestures, hardware buttons, rotation, camera injection, and the live preview.",
+      "category": "development"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "serve-sim",
+  "version": "1.0.0",
+  "description": "Control and stream a running iOS, iPad, or Apple Watch Simulator with serve-sim.",
+  "author": {
+    "name": "Evan Bacon"
+  },
+  "homepage": "https://github.com/EvanBacon/serve-sim",
+  "repository": "https://github.com/EvanBacon/serve-sim",
+  "license": "Apache-2.0"
+}


### PR DESCRIPTION
The README advertises `/plugin marketplace add EvanBacon/serve-sim`, but the repo ships no `.claude-plugin/marketplace.json`, so that command currently fails. This adds a self-referential marketplace and plugin manifest that exposes the existing `skills/serve-sim` Agent Skill, making the advertised command work.

**Changes** (2 files, no restructuring):
- `.claude-plugin/marketplace.json`: catalog with one plugin, `source: "./"`
- `.claude-plugin/plugin.json`: manifest; skill auto-discovered from `skills/`

**Tested:** `claude plugin validate --strict` passes; `marketplace add` plus `install serve-sim@serve-sim` succeed; `plugin details` shows `Skills (1) serve-sim`.

**Tradeoff:** install copies the repo into the plugin cache (disk only; token cost is just the skill). A leaner footprint would need a dedicated plugin subdir, which would relocate or duplicate the skill that `npx skills add` relies on at `skills/serve-sim`.

**Alternative:** if you'd rather keep `npx skills add` as the single path, the other fix is to drop the `/plugin marketplace add` line from the README. Happy to switch this PR to that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added plugin manifest and marketplace configuration files to enable registration and distribution of the serve-sim plugin through the Claude Code marketplace, including plugin metadata, version information, and marketplace-specific details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->