### PR TITLE
Add simulator-wide settings sidebar with WebSocket control channel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,12 @@ through `serve-sim` subcommands against a running server:
   that need explicit `begin`/`move`/`end` events.
 - `serve-sim button [home|lock|…] [-d udid]` — hardware button.
 - `serve-sim camera …` — inject the dylib, hot-swap source, toggle mirror.
+- `serve-sim ui <option> [value] [-d udid]` — simulator-wide UI options
+  (appearance, liquid-glass, color-filter, text-size, reduce-motion,
+  increase-contrast, show-borders, reduce-transparency, voiceover); `ui status
+  --json` dumps all. Verify sets via `simctl ui <udid> <option>` readback or
+  `simctl spawn <udid> defaults read` on com.apple.Accessibility /
+  com.apple.mediaaccessibility / com.apple.UIKit.
 - `xcrun simctl openurl booted <url>` — deep-link into apps (faster than
   tapping through Expo Go's recent-projects list).
 

--- a/bun.lock
+++ b/bun.lock
@@ -13,18 +13,20 @@
     },
     "packages/serve-sim": {
       "name": "serve-sim",
-      "version": "0.1.32",
+      "version": "0.1.34",
       "bin": {
         "serve-sim": "dist/serve-sim.js",
       },
       "dependencies": {
         "inspect-webkit": "^0.0.5",
+        "ws": "^8.21.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
         "@types/debug": "^4.1.13",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
+        "@types/ws": "^8.18.1",
         "bun-plugin-tailwind": "^0.1.2",
         "commander": "^14.0.1",
         "debug": "^4.4.3",
@@ -247,6 +249,8 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
@@ -428,6 +432,8 @@
     "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 

--- a/packages/serve-sim/Sources/SimAXSettings/build.sh
+++ b/packages/serve-sim/Sources/SimAXSettings/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+OUT_DIR="${1:-$HERE/../../dist/simax}"
+mkdir -p "$OUT_DIR"
+
+SDK="$(xcrun --sdk iphonesimulator --show-sdk-path)"
+BIN="$OUT_DIR/serve-sim-ax-settings"
+
+# Build a fat simulator executable (arm64 + x86_64); it runs inside the sim
+# via `simctl spawn`.
+xcrun --sdk iphonesimulator clang \
+    -arch arm64 -arch x86_64 \
+    -mios-simulator-version-min=15.0 \
+    -isysroot "$SDK" \
+    -framework CoreFoundation \
+    -o "$BIN" \
+    "$HERE/sim-ax-settings.m"
+
+echo "Built: $BIN"
+file "$BIN"

--- a/packages/serve-sim/Sources/SimAXSettings/sim-ax-settings.m
+++ b/packages/serve-sim/Sources/SimAXSettings/sim-ax-settings.m
@@ -1,0 +1,273 @@
+// sim-ax-settings — tiny CLI that runs *inside* the iOS Simulator (via
+// `simctl spawn`) to read and write the simulator-wide settings that
+// `simctl ui` does not cover. It drives the same private libAccessibility
+// and MediaAccessibility setters the Xcode Devices app uses, which write the
+// backing preference *and* post the darwin notification that makes running
+// apps pick the change up live.
+//
+// Usage:
+//   sim-ax-settings get <key>
+//   sim-ax-settings set <key> <value>
+//   sim-ax-settings status            # JSON object of every key
+//
+// Keys / values:
+//   reduce-motion        on|off    -> _AXSSetReduceMotionEnabled
+//   show-borders         on|off    -> _AXSSetButtonShapesEnabled
+//   reduce-transparency  on|off    -> _AXSSetEnhanceBackgroundContrastEnabled
+//   voiceover            on|off    -> _AXSVoiceOverTouchSetEnabled
+//   color-filter         none|grayscale|red-green|green-red|blue-yellow
+//                                  -> MADisplayFilterPrefSetType/CategoryEnabled
+//   liquid-glass         clear|tinted
+//                                  -> com.apple.UIKit UIViewGlassLegibilitySetting
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <dlfcn.h>
+#include <notify.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef int (*GetBoolFn)(void);
+typedef void (*SetBoolFn)(int);
+typedef long (*MAGetTypeFn)(long);
+typedef void (*MASetTypeFn)(long, long);
+typedef int (*MAGetEnabledFn)(long);
+typedef void (*MASetEnabledFn)(long, int);
+
+// MADisplayFilterPref* "category" argument: 1 maps to the "__Color__." key
+// prefix in com.apple.mediaaccessibility (the Settings > Color Filters pane).
+static const long kMAColorCategory = 1;
+
+// MADisplayFilterType values, confirmed against libAccessibility's
+// _AXS{GreenRed,BlueYellow}FilterSetEnabled disassembly on iOS 26.5.
+enum {
+  kFilterNone = 0,
+  kFilterGrayscale = 1,
+  kFilterRedGreen = 2,   // protanopia
+  kFilterGreenRed = 4,   // deuteranopia
+  kFilterBlueYellow = 8, // tritanopia
+};
+
+static void *axHandle(void) {
+  static void *handle;
+  if (!handle) handle = dlopen("/usr/lib/libAccessibility.dylib", RTLD_NOW);
+  return handle;
+}
+
+static void *maHandle(void) {
+  static void *handle;
+  if (!handle) {
+    handle = dlopen(
+        "/System/Library/Frameworks/MediaAccessibility.framework/MediaAccessibility",
+        RTLD_NOW);
+  }
+  return handle;
+}
+
+static void *requireSym(void *handle, const char *name) {
+  void *sym = handle ? dlsym(handle, name) : NULL;
+  if (!sym) {
+    fprintf(stderr, "sim-ax-settings: missing symbol %s\n", name);
+    exit(2);
+  }
+  return sym;
+}
+
+// ─── Boolean AXS settings ───
+
+typedef struct {
+  const char *key;
+  const char *getter;
+  const char *setter;
+} BoolSetting;
+
+static const BoolSetting kBoolSettings[] = {
+    {"reduce-motion", "_AXSReduceMotionEnabled", "_AXSSetReduceMotionEnabled"},
+    {"show-borders", "_AXSButtonShapesEnabled", "_AXSSetButtonShapesEnabled"},
+    {"reduce-transparency", "_AXSEnhanceBackgroundContrastEnabled",
+     "_AXSSetEnhanceBackgroundContrastEnabled"},
+    {"voiceover", "_AXSVoiceOverTouchEnabled", "_AXSVoiceOverTouchSetEnabled"},
+};
+static const size_t kBoolSettingCount =
+    sizeof(kBoolSettings) / sizeof(kBoolSettings[0]);
+
+static const BoolSetting *findBoolSetting(const char *key) {
+  for (size_t i = 0; i < kBoolSettingCount; i++) {
+    if (strcmp(kBoolSettings[i].key, key) == 0) return &kBoolSettings[i];
+  }
+  return NULL;
+}
+
+static int getBoolSetting(const BoolSetting *s) {
+  GetBoolFn fn = (GetBoolFn)requireSym(axHandle(), s->getter);
+  return fn() ? 1 : 0;
+}
+
+static void setBoolSetting(const BoolSetting *s, int enabled) {
+  SetBoolFn fn = (SetBoolFn)requireSym(axHandle(), s->setter);
+  fn(enabled);
+}
+
+// ─── Color filter ───
+
+static const char *filterName(long type, int enabled) {
+  if (!enabled) return "none";
+  switch (type) {
+    case kFilterGrayscale: return "grayscale";
+    case kFilterRedGreen: return "red-green";
+    case kFilterGreenRed: return "green-red";
+    case kFilterBlueYellow: return "blue-yellow";
+    default: return "none";
+  }
+}
+
+static long filterTypeForName(const char *name) {
+  if (strcmp(name, "grayscale") == 0) return kFilterGrayscale;
+  if (strcmp(name, "red-green") == 0) return kFilterRedGreen;
+  if (strcmp(name, "green-red") == 0) return kFilterGreenRed;
+  if (strcmp(name, "blue-yellow") == 0) return kFilterBlueYellow;
+  return kFilterNone;
+}
+
+static const char *getColorFilter(void) {
+  MAGetTypeFn getType =
+      (MAGetTypeFn)requireSym(maHandle(), "MADisplayFilterPrefGetType");
+  MAGetEnabledFn getEnabled = (MAGetEnabledFn)requireSym(
+      maHandle(), "MADisplayFilterPrefGetCategoryEnabled");
+  return filterName(getType(kMAColorCategory), getEnabled(kMAColorCategory));
+}
+
+static void setColorFilter(const char *name) {
+  MASetTypeFn setType =
+      (MASetTypeFn)requireSym(maHandle(), "MADisplayFilterPrefSetType");
+  MASetEnabledFn setEnabled = (MASetEnabledFn)requireSym(
+      maHandle(), "MADisplayFilterPrefSetCategoryEnabled");
+  long type = filterTypeForName(name);
+  if (type == kFilterNone) {
+    setEnabled(kMAColorCategory, 0);
+  } else {
+    setType(kMAColorCategory, type);
+    setEnabled(kMAColorCategory, 1);
+  }
+  // Keep the com.apple.Accessibility grayscale flag in sync, matching what
+  // the Xcode Devices app writes for the Grayscale filter.
+  SetBoolFn setGrayscale =
+      (SetBoolFn)requireSym(axHandle(), "_AXSGrayscaleSetEnabled");
+  setGrayscale(type == kFilterGrayscale);
+}
+
+// ─── Liquid Glass (iOS 26+) ───
+
+static CFStringRef kGlassDomain = CFSTR("com.apple.UIKit");
+static CFStringRef kGlassKey = CFSTR("UIViewGlassLegibilitySetting");
+
+static const char *getLiquidGlass(void) {
+  CFPropertyListRef value = CFPreferencesCopyValue(
+      kGlassKey, kGlassDomain, kCFPreferencesCurrentUser, kCFPreferencesAnyHost);
+  int tinted = 0;
+  if (value) {
+    if (CFGetTypeID(value) == CFNumberGetTypeID()) {
+      int n = 0;
+      CFNumberGetValue((CFNumberRef)value, kCFNumberIntType, &n);
+      tinted = n == 1;
+    }
+    CFRelease(value);
+  }
+  return tinted ? "tinted" : "clear";
+}
+
+static void setLiquidGlass(const char *name) {
+  int tinted = strcmp(name, "tinted") == 0;
+  CFNumberRef value = CFNumberCreate(NULL, kCFNumberIntType, &tinted);
+  CFPreferencesSetValue(kGlassKey, value, kGlassDomain,
+                        kCFPreferencesCurrentUser, kCFPreferencesAnyHost);
+  CFRelease(value);
+  CFPreferencesSynchronize(kGlassDomain, kCFPreferencesCurrentUser,
+                           kCFPreferencesAnyHost);
+  notify_post("UIViewGlassLegibilityUpdateNotification");
+}
+
+// ─── Entry point ───
+
+static void printStatus(void) {
+  printf("{");
+  for (size_t i = 0; i < kBoolSettingCount; i++) {
+    printf("\"%s\":\"%s\",", kBoolSettings[i].key,
+           getBoolSetting(&kBoolSettings[i]) ? "on" : "off");
+  }
+  printf("\"color-filter\":\"%s\",", getColorFilter());
+  printf("\"liquid-glass\":\"%s\"}\n", getLiquidGlass());
+}
+
+static int parseOnOff(const char *value) {
+  if (strcmp(value, "on") == 0 || strcmp(value, "1") == 0 ||
+      strcmp(value, "true") == 0 || strcmp(value, "enabled") == 0)
+    return 1;
+  if (strcmp(value, "off") == 0 || strcmp(value, "0") == 0 ||
+      strcmp(value, "false") == 0 || strcmp(value, "disabled") == 0)
+    return 0;
+  return -1;
+}
+
+int main(int argc, char **argv) {
+  if (argc >= 2 && strcmp(argv[1], "status") == 0) {
+    printStatus();
+    return 0;
+  }
+
+  if (argc == 3 && strcmp(argv[1], "get") == 0) {
+    const char *key = argv[2];
+    const BoolSetting *bs = findBoolSetting(key);
+    if (bs) {
+      printf("%s\n", getBoolSetting(bs) ? "on" : "off");
+      return 0;
+    }
+    if (strcmp(key, "color-filter") == 0) {
+      printf("%s\n", getColorFilter());
+      return 0;
+    }
+    if (strcmp(key, "liquid-glass") == 0) {
+      printf("%s\n", getLiquidGlass());
+      return 0;
+    }
+    fprintf(stderr, "sim-ax-settings: unknown key %s\n", key);
+    return 1;
+  }
+
+  if (argc == 4 && strcmp(argv[1], "set") == 0) {
+    const char *key = argv[2];
+    const char *value = argv[3];
+    const BoolSetting *bs = findBoolSetting(key);
+    if (bs) {
+      int enabled = parseOnOff(value);
+      if (enabled < 0) {
+        fprintf(stderr, "sim-ax-settings: %s wants on|off, got %s\n", key, value);
+        return 1;
+      }
+      setBoolSetting(bs, enabled);
+      return 0;
+    }
+    if (strcmp(key, "color-filter") == 0) {
+      if (strcmp(value, "none") != 0 && filterTypeForName(value) == kFilterNone) {
+        fprintf(stderr, "sim-ax-settings: unknown color filter %s\n", value);
+        return 1;
+      }
+      setColorFilter(value);
+      return 0;
+    }
+    if (strcmp(key, "liquid-glass") == 0) {
+      if (strcmp(value, "clear") != 0 && strcmp(value, "tinted") != 0) {
+        fprintf(stderr, "sim-ax-settings: liquid-glass wants clear|tinted\n");
+        return 1;
+      }
+      setLiquidGlass(value);
+      return 0;
+    }
+    fprintf(stderr, "sim-ax-settings: unknown key %s\n", key);
+    return 1;
+  }
+
+  fprintf(stderr,
+          "Usage: sim-ax-settings status | get <key> | set <key> <value>\n");
+  return 64;
+}

--- a/packages/serve-sim/build.ts
+++ b/packages/serve-sim/build.ts
@@ -173,6 +173,10 @@ const compile = spawnSync(
     resolve(root, "src/index.ts"),
     "--outfile", resolve(distDir, "serve-sim"),
     "--define", `__PREVIEW_HTML_B64__=${JSON.stringify(htmlB64)}`,
+    // `ws` must stay a runtime-resolved specifier so Bun substitutes its
+    // native implementation — bundling the Node implementation breaks
+    // upgrades (raw handshake writes never flush under Bun's node:http).
+    "--external", "ws",
   ],
   { stdio: "inherit" },
 );

--- a/packages/serve-sim/build.ts
+++ b/packages/serve-sim/build.ts
@@ -207,4 +207,20 @@ if (helperBuild.status !== 0) {
 }
 console.log("dist/simcam/serve-sim-camera-helper");
 
+// ─── 7. sim-ax-settings in-sim CLI (simulator-wide UI settings) ──────────
+
+const axSettingsBuild = spawnSync(
+  "bash",
+  [
+    resolve(root, "Sources/SimAXSettings/build.sh"),
+    resolve(distDir, "simax"),
+  ],
+  { stdio: "inherit" },
+);
+if (axSettingsBuild.status !== 0) {
+  console.error("SimAXSettings build failed.");
+  process.exit(axSettingsBuild.status ?? 1);
+}
+console.log("dist/simax/serve-sim-ax-settings");
+
 console.log("Done.");

--- a/packages/serve-sim/build.ts
+++ b/packages/serve-sim/build.ts
@@ -112,13 +112,17 @@ const PREVIEW_DEFINE = {
 
 // ─── 3. Middleware ESM (serve-sim/middleware) ─────────────────────────────
 
+// `ws` stays external in the node-target bundles: under Node it resolves to
+// the installed package (a real dependency), and under Bun the module
+// specifier is substituted with Bun's native implementation — inlining the
+// Node implementation would break WebSocket upgrades on Bun.
 const mwResult = await Bun.build({
   entrypoints: [resolve(root, "src/middleware.ts")],
   target: "node",
   format: "esm",
   minify: true,
   outdir: distDir,
-  external: ["fs", "path", "os", "child_process", "url", "net", "tls", "crypto", "stream", "events", "http", "https", "zlib", "buffer", "module"],
+  external: ["fs", "path", "os", "child_process", "url", "net", "tls", "crypto", "stream", "events", "http", "https", "zlib", "buffer", "module", "ws"],
   define: PREVIEW_DEFINE,
 });
 if (!mwResult.success) {
@@ -144,7 +148,7 @@ const binJsResult = await Bun.build({
   minify: true,
   outdir: distDir,
   naming: "serve-sim.js",
-  external: ["fs", "path", "os", "child_process", "url", "net", "tls", "crypto", "stream", "events", "http", "https", "zlib", "buffer", "module"],
+  external: ["fs", "path", "os", "child_process", "url", "net", "tls", "crypto", "stream", "events", "http", "https", "zlib", "buffer", "module", "ws"],
   define: PREVIEW_DEFINE,
 });
 if (!binJsResult.success) {

--- a/packages/serve-sim/package.json
+++ b/packages/serve-sim/package.json
@@ -66,9 +66,10 @@
     "@types/debug": "^4.1.13",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "debug": "^4.4.3",
+    "@types/ws": "^8.18.1",
     "bun-plugin-tailwind": "^0.1.2",
     "commander": "^14.0.1",
+    "debug": "^4.4.3",
     "preact": "^10.29.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
@@ -77,6 +78,7 @@
     "typescript": "^5.7.0"
   },
   "dependencies": {
-    "inspect-webkit": "^0.0.5"
+    "inspect-webkit": "^0.0.5",
+    "ws": "^8.21.0"
   }
 }

--- a/packages/serve-sim/package.json
+++ b/packages/serve-sim/package.json
@@ -29,6 +29,7 @@
     "dist/middleware.cjs",
     "dist/simcam/libSimCameraInjector.dylib",
     "dist/simcam/serve-sim-camera-helper",
+    "dist/simax/serve-sim-ax-settings",
     "src/ax-shared.ts",
     "src/ax.ts",
     "src/middleware.ts",
@@ -40,7 +41,9 @@
     "Sources/SimCameraInjector/include/SimCamShared.h",
     "Sources/SimCameraInjector/build.sh",
     "Sources/SimCameraHelper/main.m",
-    "Sources/SimCameraHelper/build.sh"
+    "Sources/SimCameraHelper/build.sh",
+    "Sources/SimAXSettings/sim-ax-settings.m",
+    "Sources/SimAXSettings/build.sh"
   ],
   "exports": {
     "./middleware": {

--- a/packages/serve-sim/src/__tests__/exec-ws.test.ts
+++ b/packages/serve-sim/src/__tests__/exec-ws.test.ts
@@ -1,0 +1,134 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { simMiddleware } from "../middleware";
+import { servePreview, type PreviewServer } from "../runtime";
+
+// The control channel is the ONLY transport the preview page uses for execs,
+// simulator settings, and SSE side-channels — there is deliberately no HTTP
+// fallback, so a broken upgrade path bricks the UI. This suite runs under
+// `bun test` (the CI flow), which is exactly the runtime where hand-rolled
+// RFC6455 framing silently failed before: node:http under Bun emits
+// `upgrade` but never flushes raw handshake bytes, which is why the channel
+// is built on `ws` (Bun substitutes its native implementation).
+
+const PORT = 3461;
+const TOKEN = "exec-ws-test-token";
+
+let server: PreviewServer;
+
+beforeAll(async () => {
+  const middleware = simMiddleware({ basePath: "/", execToken: TOKEN });
+  server = await servePreview({ port: PORT, middleware, host: "127.0.0.1" });
+});
+
+afterAll(() => {
+  server?.stop(true);
+});
+
+interface Reply {
+  ready?: boolean;
+  id?: number;
+  stdout?: string;
+  exitCode?: number;
+  error?: string;
+  sub?: number;
+  end?: boolean;
+}
+
+function connect(token: string): Promise<{
+  next: () => Promise<Reply>;
+  send: (body: Record<string, unknown>) => void;
+  close: () => void;
+  closed: Promise<void>;
+}> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${PORT}/exec-ws`);
+    const queue: Reply[] = [];
+    const waiters: Array<(r: Reply) => void> = [];
+    let closeResolve: () => void;
+    const closed = new Promise<void>((r) => {
+      closeResolve = r;
+    });
+    const timer = setTimeout(() => reject(new Error("connect timeout")), 5000);
+    ws.onopen = () => {
+      clearTimeout(timer);
+      ws.send(JSON.stringify({ token }));
+      resolve({
+        next: () =>
+          new Promise<Reply>((r, rej) => {
+            const queued = queue.shift();
+            if (queued) return r(queued);
+            const bail = setTimeout(() => rej(new Error("reply timeout")), 5000);
+            waiters.push((reply) => {
+              clearTimeout(bail);
+              r(reply);
+            });
+          }),
+        send: (body) => ws.send(JSON.stringify(body)),
+        close: () => ws.close(),
+        closed,
+      });
+    };
+    ws.onmessage = (event) => {
+      const reply = JSON.parse(String(event.data)) as Reply;
+      const waiter = waiters.shift();
+      if (waiter) waiter(reply);
+      else queue.push(reply);
+    };
+    ws.onerror = () => {
+      clearTimeout(timer);
+      reject(new Error("socket error"));
+    };
+    ws.onclose = () => closeResolve();
+  });
+}
+
+describe("exec-ws control channel", () => {
+  test("authenticates and runs a shell exec", async () => {
+    const channel = await connect(TOKEN);
+    expect((await channel.next()).ready).toBe(true);
+    channel.send({ id: 1, command: "echo channel-works" });
+    const reply = await channel.next();
+    expect(reply.id).toBe(1);
+    expect(reply.exitCode).toBe(0);
+    expect(reply.stdout?.trim()).toBe("channel-works");
+    channel.close();
+  });
+
+  test("rejects a bad token by closing the socket", async () => {
+    const channel = await connect("wrong-token");
+    await channel.closed;
+  });
+
+  test("ui requests validate their payload", async () => {
+    const channel = await connect(TOKEN);
+    await channel.next(); // ready
+    channel.send({ id: 2, ui: { device: "not a udid!!", option: "appearance" } });
+    const reply = await channel.next();
+    expect(reply.id).toBe(2);
+    expect(reply.error).toMatch(/invalid device/i);
+    channel.close();
+  });
+
+  test("sse subscriptions reject paths outside the allowlist", async () => {
+    const channel = await connect(TOKEN);
+    await channel.next(); // ready
+    channel.send({ sub: 7, path: "/exec" });
+    const reply = await channel.next();
+    expect(reply.sub).toBe(7);
+    expect(reply.end).toBe(true);
+    expect(reply.error).toMatch(/not allowed/i);
+    channel.close();
+  });
+
+  test("sse subscription streams a real middleware route", async () => {
+    const channel = await connect(TOKEN);
+    await channel.next(); // ready
+    channel.send({ sub: 8, path: "/api/events" });
+    // /api/events sends an initial SSE payload immediately on connect.
+    const reply = await channel.next();
+    expect(reply.sub).toBe(8);
+    expect(typeof (reply as { data?: string }).data).toBe("string");
+    channel.send({ unsub: 8 });
+    channel.close();
+  });
+});

--- a/packages/serve-sim/src/__tests__/ui-settings.e2e.test.ts
+++ b/packages/serve-sim/src/__tests__/ui-settings.e2e.test.ts
@@ -28,11 +28,37 @@ function bootedUdid(): string | null {
 }
 
 const udid = bootedUdid();
-const describeIfSim = udid && existsSync(CLI) ? describe : describe.skip;
+
+// Every `simctl ui` call (reads included) hangs indefinitely on GitHub's
+// headless macOS runners — the booted sim's UI services never come up, the
+// same breakage that keeps the /ax accessibility endpoint stuck there. Probe
+// once with a hard timeout and skip the suite when the host can't do it;
+// locally the full suite runs. The timeout also bounds the probe itself.
+function simctlUiUsable(): boolean {
+  if (!udid) return false;
+  try {
+    execFileSync("xcrun", ["simctl", "ui", udid, "appearance"], {
+      encoding: "utf-8",
+      timeout: 15_000,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return true;
+  } catch {
+    console.warn("[ui-settings.e2e] skipping: `simctl ui` is not functional on this host");
+    return false;
+  }
+}
+
+const describeIfSim = udid && existsSync(CLI) && simctlUiUsable() ? describe : describe.skip;
+
+// Timeouts on every child call so a wedged simulator fails the test instead
+// of hanging the CI job.
+const EXEC_TIMEOUT_MS = 15_000;
 
 function cli(...args: string[]): string {
   return execFileSync("node", [CLI, "ui", ...args, "-d", udid!], {
     encoding: "utf-8",
+    timeout: EXEC_TIMEOUT_MS,
   }).trim();
 }
 
@@ -41,7 +67,7 @@ function simDefault(domain: string, key: string): string {
     return execFileSync(
       "xcrun",
       ["simctl", "spawn", udid!, "defaults", "read", domain, key],
-      { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] },
+      { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"], timeout: EXEC_TIMEOUT_MS },
     ).trim();
   } catch {
     return "<missing>";
@@ -51,6 +77,7 @@ function simDefault(domain: string, key: string): string {
 function simctlUi(subcommand: string): string {
   return execFileSync("xcrun", ["simctl", "ui", udid!, subcommand], {
     encoding: "utf-8",
+    timeout: EXEC_TIMEOUT_MS,
   }).trim();
 }
 

--- a/packages/serve-sim/src/__tests__/ui-settings.e2e.test.ts
+++ b/packages/serve-sim/src/__tests__/ui-settings.e2e.test.ts
@@ -29,13 +29,21 @@ function bootedUdid(): string | null {
 
 const udid = bootedUdid();
 
-// Every `simctl ui` call (reads included) hangs indefinitely on GitHub's
-// headless macOS runners — the booted sim's UI services never come up, the
-// same breakage that keeps the /ax accessibility endpoint stuck there. Probe
-// once with a hard timeout and skip the suite when the host can't do it;
-// locally the full suite runs. The timeout also bounds the probe itself.
+// `simctl ui` hangs *intermittently per-call* on GitHub's shared macOS
+// runners — a probe can succeed and the very next call hang for minutes
+// (the same unwarmed-UI-plane breakage the avcc and ax suites skip around),
+// so no point-in-time health check can gate this reliably. Skip on CI by
+// default; SERVE_SIM_UI_E2E=1 forces the suite on for runners where the
+// simulator UI plane actually works. Off-CI, a bounded probe still guards
+// against a wedged local sim.
+const skipOnCi = !!process.env.CI && process.env.SERVE_SIM_UI_E2E !== "1";
+
 function simctlUiUsable(): boolean {
   if (!udid) return false;
+  if (skipOnCi) {
+    console.warn("[ui-settings.e2e] skipping on CI: `simctl ui` hangs intermittently on shared runners (set SERVE_SIM_UI_E2E=1 to force)");
+    return false;
+  }
   try {
     execFileSync("xcrun", ["simctl", "ui", udid, "appearance"], {
       encoding: "utf-8",

--- a/packages/serve-sim/src/__tests__/ui-settings.e2e.test.ts
+++ b/packages/serve-sim/src/__tests__/ui-settings.e2e.test.ts
@@ -1,0 +1,161 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { execFileSync, execSync } from "child_process";
+import { existsSync } from "fs";
+import { join } from "path";
+
+// Drives the built CLI's `ui` verb against whatever simulator is already
+// booted (the CI `sim-test.yml` job boots one before running this directory).
+// Each assertion reads the underlying preference store the simulator actually
+// consults — com.apple.Accessibility, com.apple.mediaaccessibility,
+// com.apple.UIKit — or `simctl ui` for the options it natively reports,
+// rather than trusting the value the CLI itself echoes back.
+
+const PKG_DIR = join(import.meta.dir, "../..");
+const CLI = join(PKG_DIR, "dist/serve-sim.js");
+
+function bootedUdid(): string | null {
+  try {
+    const out = execSync("xcrun simctl list devices booted -j", { encoding: "utf-8" });
+    const data = JSON.parse(out) as {
+      devices: Record<string, Array<{ udid: string; state: string }>>;
+    };
+    for (const [runtime, devices] of Object.entries(data.devices)) {
+      if (!/iOS/i.test(runtime)) continue;
+      for (const d of devices) if (d.state === "Booted") return d.udid;
+    }
+  } catch {}
+  return null;
+}
+
+const udid = bootedUdid();
+const describeIfSim = udid && existsSync(CLI) ? describe : describe.skip;
+
+function cli(...args: string[]): string {
+  return execFileSync("node", [CLI, "ui", ...args, "-d", udid!], {
+    encoding: "utf-8",
+  }).trim();
+}
+
+function simDefault(domain: string, key: string): string {
+  try {
+    return execFileSync(
+      "xcrun",
+      ["simctl", "spawn", udid!, "defaults", "read", domain, key],
+      { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] },
+    ).trim();
+  } catch {
+    return "<missing>";
+  }
+}
+
+function simctlUi(subcommand: string): string {
+  return execFileSync("xcrun", ["simctl", "ui", udid!, subcommand], {
+    encoding: "utf-8",
+  }).trim();
+}
+
+describeIfSim("serve-sim ui (simulator-wide options)", () => {
+  afterAll(() => {
+    // Leave the simulator in stock state for whatever runs next.
+    for (const [option, value] of [
+      ["appearance", "light"],
+      ["liquid-glass", "clear"],
+      ["color-filter", "none"],
+      ["text-size", "large"],
+      ["reduce-motion", "off"],
+      ["increase-contrast", "off"],
+      ["show-borders", "off"],
+      ["reduce-transparency", "off"],
+      ["voiceover", "off"],
+    ] as const) {
+      try {
+        cli(option, value);
+      } catch {}
+    }
+  });
+
+  test("appearance switches dark and back", () => {
+    cli("appearance", "dark");
+    expect(simctlUi("appearance")).toBe("dark");
+    cli("appearance", "light");
+    expect(simctlUi("appearance")).toBe("light");
+  });
+
+  test("liquid glass writes the UIKit legibility preference", () => {
+    cli("liquid-glass", "tinted");
+    expect(simDefault("com.apple.UIKit", "UIViewGlassLegibilitySetting")).toBe("1");
+    expect(cli("liquid-glass")).toBe("tinted");
+    cli("liquid-glass", "clear");
+    expect(simDefault("com.apple.UIKit", "UIViewGlassLegibilitySetting")).toBe("0");
+  });
+
+  test("color filters set the media-accessibility display filter", () => {
+    const cases = [
+      ["grayscale", "1"],
+      ["red-green", "2"],
+      ["green-red", "4"],
+      ["blue-yellow", "8"],
+    ] as const;
+    for (const [name, type] of cases) {
+      cli("color-filter", name);
+      expect(
+        simDefault("com.apple.mediaaccessibility", "__Color__.MADisplayFilterCategoryEnabled"),
+      ).toBe("1");
+      expect(
+        simDefault("com.apple.mediaaccessibility", "__Color__.MADisplayFilterType"),
+      ).toBe(type);
+      expect(cli("color-filter")).toBe(name);
+    }
+    // Grayscale additionally mirrors into the Accessibility domain.
+    cli("color-filter", "grayscale");
+    expect(simDefault("com.apple.Accessibility", "GrayscaleDisplay")).toBe("1");
+    cli("color-filter", "none");
+    expect(
+      simDefault("com.apple.mediaaccessibility", "__Color__.MADisplayFilterCategoryEnabled"),
+    ).toBe("0");
+    expect(simDefault("com.apple.Accessibility", "GrayscaleDisplay")).toBe("0");
+  }, 30_000);
+
+  test("text size sets the content size category", () => {
+    cli("text-size", "accessibility-medium");
+    expect(simctlUi("content_size")).toBe("accessibility-medium");
+    cli("text-size", "large");
+    expect(simctlUi("content_size")).toBe("large");
+  });
+
+  test("increase contrast toggles through simctl ui", () => {
+    cli("increase-contrast", "on");
+    expect(simctlUi("increase_contrast")).toBe("enabled");
+    cli("increase-contrast", "off");
+    expect(simctlUi("increase_contrast")).toBe("disabled");
+  });
+
+  test.each([
+    ["reduce-motion", "ReduceMotionEnabled"],
+    ["show-borders", "ButtonShapesEnabled"],
+    ["reduce-transparency", "EnhancedBackgroundContrastEnabled"],
+    ["voiceover", "VoiceOverTouchEnabled"],
+  ] as const)("%s writes %s in com.apple.Accessibility", (option, key) => {
+    cli(option, "on");
+    expect(simDefault("com.apple.Accessibility", key)).toBe("1");
+    expect(cli(option)).toBe("on");
+    cli(option, "off");
+    expect(simDefault("com.apple.Accessibility", key)).toBe("0");
+    expect(cli(option)).toBe("off");
+  }, 15_000);
+
+  test("status reports every option as json", () => {
+    const status = JSON.parse(cli("status", "--json")) as Record<string, string>;
+    expect(Object.keys(status).sort()).toEqual([
+      "appearance",
+      "color-filter",
+      "increase-contrast",
+      "liquid-glass",
+      "reduce-motion",
+      "reduce-transparency",
+      "show-borders",
+      "text-size",
+      "voiceover",
+    ]);
+  });
+});

--- a/packages/serve-sim/src/__tests__/ui-settings.test.ts
+++ b/packages/serve-sim/src/__tests__/ui-settings.test.ts
@@ -41,6 +41,11 @@ describe("parseUiArgs", () => {
     expect(parseUiArgs(["sound", "50"]).error).toMatch(/unknown option/i);
   });
 
+  test("dangling -d/--device flag is an error", () => {
+    expect(parseUiArgs(["appearance", "-d"]).error).toMatch(/requires a value/i);
+    expect(parseUiArgs(["status", "--device"]).error).toMatch(/requires a value/i);
+  });
+
   test("invalid value is an error", () => {
     expect(parseUiArgs(["appearance", "blue"]).error).toMatch(/invalid value/i);
   });

--- a/packages/serve-sim/src/__tests__/ui-settings.test.ts
+++ b/packages/serve-sim/src/__tests__/ui-settings.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CONTENT_SIZE_CATEGORIES,
+  UI_OPTIONS,
+  normalizeUiValue,
+  parseUiArgs,
+} from "../ui-settings";
+
+describe("parseUiArgs", () => {
+  test("no args requests status", () => {
+    expect(parseUiArgs([])).toEqual({ command: "status", json: false });
+  });
+
+  test("status with --json and -d", () => {
+    expect(parseUiArgs(["status", "--json", "-d", "ABC"])).toEqual({
+      command: "status",
+      json: true,
+      device: "ABC",
+    });
+  });
+
+  test("get a single option", () => {
+    expect(parseUiArgs(["appearance"])).toEqual({
+      command: "get",
+      option: "appearance",
+      json: false,
+    });
+  });
+
+  test("set an option with a value", () => {
+    expect(parseUiArgs(["appearance", "dark", "-d", "ABC"])).toEqual({
+      command: "set",
+      option: "appearance",
+      value: "dark",
+      device: "ABC",
+      json: false,
+    });
+  });
+
+  test("unknown option is an error", () => {
+    expect(parseUiArgs(["sound", "50"]).error).toMatch(/unknown option/i);
+  });
+
+  test("invalid value is an error", () => {
+    expect(parseUiArgs(["appearance", "blue"]).error).toMatch(/invalid value/i);
+  });
+
+  test("color filter accepts vision-deficiency aliases", () => {
+    expect(parseUiArgs(["color-filter", "protanopia"]).value).toBe("red-green");
+    expect(parseUiArgs(["color-filter", "deuteranopia"]).value).toBe("green-red");
+    expect(parseUiArgs(["color-filter", "tritanopia"]).value).toBe("blue-yellow");
+    expect(parseUiArgs(["color-filter", "grayscale"]).value).toBe("grayscale");
+  });
+
+  test("text-size accepts categories and increment/decrement", () => {
+    expect(parseUiArgs(["text-size", "large"]).value).toBe("large");
+    expect(parseUiArgs(["text-size", "accessibility-medium"]).value).toBe(
+      "accessibility-medium",
+    );
+    expect(parseUiArgs(["text-size", "increment"]).value).toBe("increment");
+    expect(parseUiArgs(["text-size", "giant"]).error).toMatch(/invalid value/i);
+  });
+});
+
+describe("normalizeUiValue", () => {
+  test("toggles accept on/off synonyms", () => {
+    for (const v of ["on", "true", "enabled", "1", "yes"]) {
+      expect(normalizeUiValue("reduce-motion", v)).toBe("on");
+    }
+    for (const v of ["off", "false", "disabled", "0", "no"]) {
+      expect(normalizeUiValue("reduce-motion", v)).toBe("off");
+    }
+  });
+
+  test("non-toggle options pass through canonical values only", () => {
+    expect(normalizeUiValue("liquid-glass", "tinted")).toBe("tinted");
+    expect(normalizeUiValue("liquid-glass", "frosted")).toBeNull();
+  });
+});
+
+describe("option catalogue", () => {
+  test("covers every sidebar option", () => {
+    expect(Object.keys(UI_OPTIONS).sort()).toEqual(
+      [
+        "appearance",
+        "color-filter",
+        "increase-contrast",
+        "liquid-glass",
+        "reduce-motion",
+        "reduce-transparency",
+        "show-borders",
+        "text-size",
+        "voiceover",
+      ].sort(),
+    );
+  });
+
+  test("content size categories span standard and accessibility ranges", () => {
+    expect(CONTENT_SIZE_CATEGORIES).toHaveLength(12);
+    expect(CONTENT_SIZE_CATEGORIES[0]).toBe("extra-small");
+    expect(CONTENT_SIZE_CATEGORIES[3]).toBe("large");
+    expect(CONTENT_SIZE_CATEGORIES[11]).toBe(
+      "accessibility-extra-extra-extra-large",
+    );
+  });
+});

--- a/packages/serve-sim/src/client/client.tsx
+++ b/packages/serve-sim/src/client/client.tsx
@@ -47,7 +47,7 @@ import {
 } from "./avcc-fallback";
 import { parseSimctlList, type SimDevice } from "./utils/devices";
 import { fileExtension } from "./utils/drop";
-import { execOnHost } from "./utils/exec";
+import { execOnHost, openHostEventStream } from "./utils/exec";
 import { hidUsageForCode } from "./utils/hid";
 import {
   DEVTOOLS_PANEL_WIDTH,
@@ -129,7 +129,7 @@ function App() {
 
     // Server pushes the serve-sim state only when it actually changes (helper
     // boot/shutdown or device selection), so there's no polling loop here.
-    const es = new EventSource(eventsUrl);
+    const es = openHostEventStream(eventsUrl);
     es.onmessage = (event) => {
       try {
         applyConfig(JSON.parse(event.data) as PreviewConfig | null);
@@ -141,7 +141,7 @@ function App() {
   // Stream simctl logs into the browser console with colors + grouping
   useEffect(() => {
     if (!config?.logsEndpoint) return;
-    const es = new EventSource(config.logsEndpoint);
+    const es = openHostEventStream(config.logsEndpoint);
 
     const procColors = new Map<string, string>();
     const palette = [
@@ -481,7 +481,15 @@ function AppWithConfig({
 
   // Subscribe to app-state SSE.
   const [currentApp, setCurrentApp] = useState<{ bundleId: string; isReactNative: boolean; pid?: number } | null>(null);
-  const [panelOpen, setPanelOpen] = useState(false);
+  // Start with the tools panel open when the viewport has room for it beside
+  // the simulator (typical device frame ≈ 420px plus page/panel gutters);
+  // smaller windows keep it closed so the device isn't squeezed on load.
+  const [panelOpen, setPanelOpen] = useState(() => {
+    if (typeof window === "undefined") return false;
+    const stored = Number(window.localStorage.getItem("serve-sim:tools-panel-width"));
+    const panelWidth = Number.isFinite(stored) && stored > 0 ? stored : PANEL_WIDTH;
+    return window.innerWidth >= panelWidth + 480;
+  });
   const { width: toolsPanelWidth, onPointerDown: onToolsResize } = useResizableWidth(
     "serve-sim:tools-panel-width",
     PANEL_WIDTH,
@@ -515,7 +523,7 @@ function AppWithConfig({
     return () => window.removeEventListener("resize", onResize);
   }, []);
   useEffect(() => {
-    const es = new EventSource(config.appStateEndpoint ?? simEndpoint("appstate"));
+    const es = openHostEventStream(config.appStateEndpoint ?? simEndpoint("appstate"));
     let timer: ReturnType<typeof setTimeout> | null = null;
     es.onmessage = (e) => {
       try {

--- a/packages/serve-sim/src/client/components/app-detection-tool.tsx
+++ b/packages/serve-sim/src/client/components/app-detection-tool.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, type ReactNode } from "react";
 import { type AppDetails, fetchAppDetails } from "../utils/app-icon";
 import { execOnHost, shellEscape } from "../utils/exec";
-import { Chevron } from "../icons";
+import { CollapsibleSection } from "./collapsible-section";
 
 export function AppDetectionTool({
   udid,
@@ -44,43 +44,40 @@ export function AppDetectionTool({
   }
 
   return (
-    <div className="bg-panel border border-white/8 rounded-[10px] flex flex-col gap-2.5 px-3 py-2">
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        className="lem-toggle flex items-center gap-3 bg-transparent border-none text-white/90 py-2 px-1 -my-2 -mx-1 cursor-pointer w-[calc(100%+8px)] text-left min-h-[36px]"
-        aria-expanded={open}
-      >
-        {details.iconDataUrl ? (
-          <img
-            src={details.iconDataUrl}
-            className="w-10 h-10 rounded-[8px] shrink-0 object-cover border border-white/8"
-            alt=""
-          />
-        ) : (
-          <div className="w-10 h-10 rounded-[8px] shrink-0 border border-white/8 bg-white/[0.04]" />
-        )}
-        <div className="min-w-0 flex-1 leading-tight">
-          <div className="text-[13px] font-semibold text-white/90 truncate">
-            {details.displayName ?? details.bundleId}
-            {details.loading && <span className="text-white/45 font-normal"> …</span>}
-          </div>
-          <div className="text-[11px] text-white/55 font-mono truncate" title={details.bundleId}>
-            {details.bundleId}
-          </div>
-        </div>
-        <Chevron open={open} />
-      </button>
-
-      {open && (
+    <CollapsibleSection
+      open={open}
+      onOpenChange={setOpen}
+      summaryClassName="flex items-center gap-3 text-left"
+      summary={
         <>
-          {details.error && (
-            <div className="bg-danger/10 border border-danger/20 text-danger-soft text-[11px] px-2 py-1.5 rounded-md">
-              {details.error}
-            </div>
+          {details.iconDataUrl ? (
+            <img
+              src={details.iconDataUrl}
+              className="w-10 h-10 rounded-[8px] shrink-0 object-cover border border-white/8"
+              alt=""
+            />
+          ) : (
+            <div className="w-10 h-10 rounded-[8px] shrink-0 border border-white/8 bg-white/[0.04]" />
           )}
+          <div className="min-w-0 flex-1 leading-tight">
+            <div className="text-[13px] font-semibold text-white/90 truncate">
+              {details.displayName ?? details.bundleId}
+              {details.loading && <span className="text-white/45 font-normal"> …</span>}
+            </div>
+            <div className="text-[11px] text-white/55 font-mono truncate" title={details.bundleId}>
+              {details.bundleId}
+            </div>
+          </div>
+        </>
+      }
+    >
+      {details.error && (
+        <div className="bg-danger/10 border border-danger/20 text-danger-soft text-[11px] px-2 py-1.5 rounded-md">
+          {details.error}
+        </div>
+      )}
 
-          <dl className="m-0 flex flex-col gap-1.5">
+      <dl className="m-0 flex flex-col gap-1.5">
             <Row label="Version" value={details.shortVersion ? `${details.shortVersion} (${details.bundleVersion ?? "—"})` : details.loading ? "…" : "—"} />
             <Row label="Min iOS" value={details.minOS ?? (details.loading ? "…" : "—")} />
             <Row label="Executable" value={details.executable ?? (details.loading ? "…" : "—")} />
@@ -106,9 +103,7 @@ export function AppDetectionTool({
               }
             />
           </dl>
-        </>
-      )}
-    </div>
+    </CollapsibleSection>
   );
 }
 

--- a/packages/serve-sim/src/client/components/app-permissions-tool.tsx
+++ b/packages/serve-sim/src/client/components/app-permissions-tool.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
-import { Chevron, ReloadIcon } from "../icons";
+import { ReloadIcon } from "../icons";
 import { execOnHost, shellEscape } from "../utils/exec";
+import { CollapsibleSection } from "./collapsible-section";
 import {
   PERMISSION_SERVICES,
   type PermAction,
@@ -82,26 +83,24 @@ export function AppPermissionsTool({
   }
 
   return (
-    <div className="bg-panel border border-white/8 rounded-[10px] flex flex-col gap-2.5 px-3 py-2">
-      <button
-        type="button"
-        onClick={() => setOpen((o) => !o)}
-        className="lem-toggle grid [grid-template-columns:auto_1fr_auto] items-center gap-2 bg-transparent border-none text-white/90 py-2.5 px-1 -my-2 -mx-1 cursor-pointer w-[calc(100%+8px)] text-left min-h-[36px] leading-none"
-        aria-expanded={open}
-      >
-        <span className="text-[11px] font-semibold text-white/50 uppercase tracking-[0.08em] leading-none inline-flex items-center">Permissions</span>
-        <span />
-        <Chevron open={open} />
-      </button>
-
-      {open && error && (
-        <div className="bg-danger/10 border border-danger/20 text-danger-soft text-[11px] px-2 py-1.5 rounded-md mt-2">
+    <CollapsibleSection
+      open={open}
+      onOpenChange={setOpen}
+      summaryClassName="grid [grid-template-columns:auto_1fr_auto] items-center gap-2 text-left"
+      summary={
+        <>
+          <span className="text-[11px] font-semibold text-white/50 uppercase tracking-[0.08em] leading-none inline-flex items-center">Permissions</span>
+          <span />
+        </>
+      }
+    >
+      {error && (
+        <div className="bg-danger/10 border border-danger/20 text-danger-soft text-[11px] px-2 py-1.5 rounded-md">
           {error}
         </div>
       )}
 
-      {open && (
-        <div className="relative mt-2">
+      <div className="relative">
           <div className="max-h-[260px] overflow-y-auto flex flex-col gap-1 py-2 [scrollbar-width:thin]">
             {PERMISSION_SERVICES.map(({ key, label }) => {
               const current = state[key];
@@ -153,21 +152,18 @@ export function AppPermissionsTool({
           <div className="absolute top-0 left-0 right-0 h-[14px] pointer-events-none rounded-t-[10px] bg-[linear-gradient(to_bottom,#1c1c1e_0%,rgba(28,28,30,0)_100%)]" />
           <div className="absolute bottom-0 left-0 right-0 h-[14px] pointer-events-none bg-[linear-gradient(to_top,#1c1c1e_0%,rgba(28,28,30,0)_100%)]" />
         </div>
-      )}
 
-      {open && (
-        <div className="flex justify-end pt-2">
-          <button
-            onClick={resetAll}
-            disabled={pending === "__all__"}
-            className="bg-transparent border border-white/12 text-white/70 text-[10px] px-2 py-[3px] rounded-[5px] cursor-pointer uppercase tracking-[0.04em]"
-            title="serve-sim permissions reset all"
-          >
-            {pending === "__all__" ? "…" : "Reset all"}
-          </button>
-        </div>
-      )}
-    </div>
+      <div className="flex justify-end">
+        <button
+          onClick={resetAll}
+          disabled={pending === "__all__"}
+          className="bg-transparent border border-white/12 text-white/70 text-[10px] px-2 py-[3px] rounded-[5px] cursor-pointer uppercase tracking-[0.04em]"
+          title="serve-sim permissions reset all"
+        >
+          {pending === "__all__" ? "…" : "Reset all"}
+        </button>
+      </div>
+    </CollapsibleSection>
   );
 }
 

--- a/packages/serve-sim/src/client/components/camera-tool.tsx
+++ b/packages/serve-sim/src/client/components/camera-tool.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type DragEvent } from "react";
-import { Chevron, PlayGlyph, StopGlyph, ReloadIcon } from "../icons";
+import { PlayGlyph, StopGlyph, ReloadIcon } from "../icons";
 import { execOnHost, shellEscape } from "../utils/exec";
 import { fileExtension, uploadFileToTmp } from "../utils/drop";
+import { CollapsibleSection } from "./collapsible-section";
 
 export type CamSource = "placeholder" | "image" | "video" | "webcam";
 type CamMirror = "on" | "off";
@@ -693,26 +694,25 @@ export function CameraTool({
         : "placeholder";
 
   return (
-    <div className="bg-panel border border-white/8 rounded-[10px] flex flex-col gap-2.5 px-3 py-2">
-      <button
-        type="button"
-        onClick={() => setOpen((o) => !o)}
-        className="lem-toggle grid [grid-template-columns:auto_1fr_auto] items-center gap-2 bg-transparent border-none text-white/90 py-2.5 px-1 -my-2 -mx-1 cursor-pointer w-[calc(100%+8px)] text-left min-h-[36px] leading-none"
-        aria-expanded={open}
+    <CollapsibleSection
+      open={open}
+      onOpenChange={setOpen}
+      bodyClassName="pt-2.5"
+      summaryClassName="grid [grid-template-columns:auto_1fr_auto] items-center gap-2 text-left"
+      summary={
+        <>
+          <span className="text-[11px] font-semibold text-white/50 uppercase tracking-[0.08em] leading-none inline-flex items-center">Camera</span>
+          <CameraStatusPill state={pillState} />
+        </>
+      }
+    >
+      <div
+        onDragEnter={onDragEnter}
+        onDragOver={onDragOver}
+        onDragLeave={onDragLeave}
+        onDrop={onDrop}
+        className="flex flex-col gap-2.5"
       >
-        <span className="text-[11px] font-semibold text-white/50 uppercase tracking-[0.08em] leading-none inline-flex items-center">Camera</span>
-        <CameraStatusPill state={pillState} />
-        <Chevron open={open} />
-      </button>
-
-      {open && (
-        <div
-          onDragEnter={onDragEnter}
-          onDragOver={onDragOver}
-          onDragLeave={onDragLeave}
-          onDrop={onDrop}
-          className="flex flex-col gap-2.5"
-        >
           <p className="m-0 text-[10px] leading-[1.5] text-white/45">
             Replaces the simulator's camera feed by injecting a dylib at app launch
             and streaming frames into shared memory. Pick media or a webcam,
@@ -898,7 +898,6 @@ export function CameraTool({
           {warning && <CameraInlineBanner kind="warning" message={warning} />}
           {error && <CameraInlineBanner kind="error" message={error} />}
         </div>
-      )}
-    </div>
+    </CollapsibleSection>
   );
 }

--- a/packages/serve-sim/src/client/components/collapsible-section.tsx
+++ b/packages/serve-sim/src/client/components/collapsible-section.tsx
@@ -1,0 +1,45 @@
+import { type ReactNode } from "react";
+import { Chevron } from "../icons";
+
+// Shared collapsible card for the tool sections. Built on native
+// <details>/<summary> so the open/close height transition is CSS-only (see
+// `details.lem-section` in global.css) rather than a JS height animation.
+//
+// `open`/`onOpenChange` keep React in the loop: callers still own the state
+// (default-open, programmatic expand, …) and stay synced via the `toggle`
+// event the browser fires on user clicks.
+export function CollapsibleSection({
+  open,
+  onOpenChange,
+  summary,
+  children,
+  summaryClassName = "",
+  bodyClassName = "flex flex-col gap-2.5 pt-2.5",
+  className = "",
+  ...dataProps
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  summary: ReactNode;
+  children: ReactNode;
+  summaryClassName?: string;
+  bodyClassName?: string;
+  className?: string;
+} & Record<`data-${string}`, string | undefined>) {
+  return (
+    <details
+      open={open}
+      onToggle={(e) => onOpenChange((e.currentTarget as HTMLDetailsElement).open)}
+      className={`lem-section bg-panel border border-white/8 rounded-[10px] px-3 py-2 ${className}`}
+      {...dataProps}
+    >
+      <summary
+        className={`lem-toggle cursor-pointer select-none text-white/90 min-h-[36px] leading-none py-2.5 px-1 -my-2 -mx-1 w-[calc(100%+8px)] ${summaryClassName}`}
+      >
+        {summary}
+        <Chevron open={open} />
+      </summary>
+      <div className={bodyClassName}>{children}</div>
+    </details>
+  );
+}

--- a/packages/serve-sim/src/client/components/simulator-settings-tool.tsx
+++ b/packages/serve-sim/src/client/components/simulator-settings-tool.tsx
@@ -113,12 +113,16 @@ function SettingSwitch({
       aria-label={label}
       disabled={disabled}
       onClick={() => onChange(!checked)}
-      className={`relative h-[18px] w-8 shrink-0 cursor-pointer rounded-full border-none p-0 [transition:background_0.15s] ${
-        checked ? "bg-[#0a84ff]" : "bg-white/20"
-      } ${disabled ? "opacity-60" : ""}`}
+      className={`relative h-[18px] w-8 shrink-0 rounded-full border-none p-0 [transition:background_0.15s] ${
+        disabled
+          ? "cursor-default bg-white/20"
+          : checked
+            ? "cursor-pointer bg-[#0a84ff]"
+            : "cursor-pointer bg-white/20"
+      }`}
     >
       <span
-        className="absolute top-[2px] size-[14px] rounded-full bg-white [transition:left_0.15s]"
+        className={`absolute top-[2px] size-[14px] rounded-full [transition:left_0.15s] ${disabled ? "bg-white/50" : "bg-white"}`}
         style={{ left: checked ? 16 : 2 }}
       />
     </button>
@@ -173,16 +177,21 @@ function TextSizeSlider({
   const max = TEXT_SIZE_CATEGORIES.length - 1;
   const shown = drag ?? value;
   const fill = `${(shown / max) * 100}%`;
+  // Filled portion goes gray while disabled so the control doesn't read as
+  // live during hydration.
+  const fillColor = disabled ? "rgba(255,255,255,0.3)" : "#0a84ff";
 
   const trackClasses =
     "[&::-webkit-slider-runnable-track]:h-[4px] [&::-webkit-slider-runnable-track]:rounded-full " +
-    "[&::-webkit-slider-runnable-track]:[background:linear-gradient(to_right,#0a84ff_var(--slider-fill),rgba(255,255,255,0.22)_var(--slider-fill))] " +
+    "[&::-webkit-slider-runnable-track]:[background:linear-gradient(to_right,var(--slider-fill-color)_var(--slider-fill),rgba(255,255,255,0.22)_var(--slider-fill))] " +
     "[&::-moz-range-track]:h-[4px] [&::-moz-range-track]:rounded-full [&::-moz-range-track]:bg-white/20 " +
-    "[&::-moz-range-progress]:h-[4px] [&::-moz-range-progress]:rounded-full [&::-moz-range-progress]:bg-[#0a84ff]";
+    "[&::-moz-range-progress]:h-[4px] [&::-moz-range-progress]:rounded-full [&::-moz-range-progress]:bg-[var(--slider-fill-color)]";
   const thumbClasses =
     "[&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:size-[13px] [&::-webkit-slider-thumb]:rounded-full " +
-    "[&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:shadow-[0_1px_3px_rgba(0,0,0,0.45)] [&::-webkit-slider-thumb]:-mt-[4.5px] " +
-    "[&::-moz-range-thumb]:size-[13px] [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-none [&::-moz-range-thumb]:bg-white";
+    "[&::-webkit-slider-thumb]:bg-white [&:disabled::-webkit-slider-thumb]:bg-white/50 " +
+    "[&::-webkit-slider-thumb]:shadow-[0_1px_3px_rgba(0,0,0,0.45)] [&::-webkit-slider-thumb]:-mt-[4.5px] " +
+    "[&::-moz-range-thumb]:size-[13px] [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-none " +
+    "[&::-moz-range-thumb]:bg-white [&:disabled::-moz-range-thumb]:bg-white/50";
 
   return (
     <span className="flex w-[120px] min-w-0 flex-col">
@@ -198,8 +207,8 @@ function TextSizeSlider({
         onPointerUp={flush}
         onKeyUp={flush}
         onBlur={flush}
-        style={{ "--slider-fill": fill } as CSSProperties}
-        className={`h-[13px] w-full cursor-pointer appearance-none rounded-full bg-transparent outline-none focus-visible:[outline:1.5px_solid_rgba(10,132,255,0.55)] focus-visible:outline-offset-4 ${trackClasses} ${thumbClasses}`}
+        style={{ "--slider-fill": fill, "--slider-fill-color": fillColor } as CSSProperties}
+        className={`h-[13px] w-full appearance-none rounded-full bg-transparent outline-none focus-visible:[outline:1.5px_solid_rgba(10,132,255,0.55)] focus-visible:outline-offset-4 ${disabled ? "cursor-default" : "cursor-pointer"} ${trackClasses} ${thumbClasses}`}
       />
       <span aria-hidden className="pointer-events-none mt-[3px] flex justify-between px-[5.5px]">
         {TEXT_SIZE_CATEGORIES.map((category) => (
@@ -229,7 +238,7 @@ function SettingSelect({
       value={value}
       disabled={disabled}
       onChange={(e) => onChange((e.target as HTMLSelectElement).value)}
-      className="appearance-none [-webkit-appearance:none] bg-white/[0.06] border border-white/10 rounded-md text-white/90 text-[12px] py-0.5 px-2 font-[inherit] cursor-pointer min-w-0 max-w-[150px] truncate"
+      className="appearance-none [-webkit-appearance:none] bg-white/[0.06] border border-white/10 rounded-md text-white/90 text-[12px] py-0.5 px-2 font-[inherit] cursor-pointer min-w-0 max-w-[150px] truncate disabled:cursor-default disabled:text-white/40"
     >
       {options.map((o) => (
         <option key={o.value} value={o.value}>

--- a/packages/serve-sim/src/client/components/simulator-settings-tool.tsx
+++ b/packages/serve-sim/src/client/components/simulator-settings-tool.tsx
@@ -1,0 +1,487 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
+import { hostUiRequest } from "../utils/exec";
+import { CollapsibleSection } from "./collapsible-section";
+
+// Simulator-wide UI options, mirroring the Xcode Devices app sidebar. Every
+// control drives `serve-sim ui <option> <value>`, which handles the simctl-
+// native options (appearance, contrast, text size) and the private-setter
+// ones (liquid glass, color filter, reduce motion, …) uniformly.
+
+// The slider spans the seven standard content-size categories (the
+// accessibility-extended range stays CLI-only); `extra-extra-extra-large` is
+// the maximum the control allows.
+export const TEXT_SIZE_CATEGORIES = [
+  "extra-small",
+  "small",
+  "medium",
+  "large",
+  "extra-large",
+  "extra-extra-large",
+  "extra-extra-extra-large",
+] as const;
+
+const TEXT_SIZE_DEBOUNCE_MS = 250;
+
+type SettingsState = Record<string, string>;
+
+// Stock values rendered (disabled) until the real state arrives, so the
+// section keeps its full height instead of swapping a "Loading…" line for
+// the controls.
+const DEFAULT_STATE: SettingsState = {
+  appearance: "light",
+  "liquid-glass": "clear",
+  "color-filter": "none",
+  "text-size": "large",
+  "reduce-motion": "off",
+  "increase-contrast": "off",
+  "show-borders": "off",
+  "reduce-transparency": "off",
+  voiceover: "off",
+};
+
+const SELECT_OPTIONS: Record<string, Array<{ value: string; label: string }>> = {
+  appearance: [
+    { value: "light", label: "Light" },
+    { value: "dark", label: "Dark" },
+  ],
+  "liquid-glass": [
+    { value: "clear", label: "Clear" },
+    { value: "tinted", label: "Tinted" },
+  ],
+  "color-filter": [
+    { value: "none", label: "None" },
+    { value: "red-green", label: "Red/Green (Protanopia)" },
+    { value: "green-red", label: "Green/Red (Deuteranopia)" },
+    { value: "blue-yellow", label: "Blue/Yellow (Tritanopia)" },
+    { value: "grayscale", label: "Grayscale" },
+  ],
+};
+
+const TOGGLE_OPTIONS = [
+  { key: "reduce-motion", label: "Reduce Motion" },
+  { key: "increase-contrast", label: "Increase Contrast" },
+  { key: "show-borders", label: "Show Borders" },
+  { key: "reduce-transparency", label: "Reduce Transparency" },
+  { key: "voiceover", label: "VoiceOver" },
+] as const;
+
+function SettingRow({
+  icon,
+  label,
+  children,
+}: {
+  icon: ReactNode;
+  label: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-2 min-h-[30px]" data-setting-row={label}>
+      <span className="flex shrink-0 items-center gap-2 text-[12px] text-white/90 whitespace-nowrap">
+        <span className="flex size-[18px] items-center justify-center text-white">{icon}</span>
+        {label}
+      </span>
+      {/* min-w-0 lets the control shrink instead of overflowing the panel
+          when it's resized to its narrow end. */}
+      <span className="flex min-w-0 justify-end">{children}</span>
+    </div>
+  );
+}
+
+function SettingSwitch({
+  label,
+  checked,
+  disabled,
+  onChange,
+}: {
+  label: string;
+  checked: boolean;
+  disabled: boolean;
+  onChange: (next: boolean) => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+      className={`relative h-[18px] w-8 shrink-0 cursor-pointer rounded-full border-none p-0 [transition:background_0.15s] ${
+        checked ? "bg-[#0a84ff]" : "bg-white/20"
+      } ${disabled ? "opacity-60" : ""}`}
+    >
+      <span
+        className="absolute top-[2px] size-[14px] rounded-full bg-white [transition:left_0.15s]"
+        style={{ left: checked ? 16 : 2 }}
+      />
+    </button>
+  );
+}
+
+function TextSizeSlider({
+  value,
+  disabled,
+  onChange,
+}: {
+  value: number;
+  disabled: boolean;
+  onChange: (index: number) => void;
+}) {
+  // Local value while dragging so prop round-trips can't interrupt the
+  // gesture. Changes apply live but debounced; release flushes immediately.
+  const [drag, setDrag] = useState<number | null>(null);
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastSent = useRef<number | null>(null);
+
+  const send = useCallback(
+    (index: number) => {
+      if (lastSent.current === index) return;
+      lastSent.current = index;
+      onChange(index);
+    },
+    [onChange],
+  );
+
+  const handleInput = useCallback(
+    (index: number) => {
+      setDrag(index);
+      if (debounceTimer.current) clearTimeout(debounceTimer.current);
+      debounceTimer.current = setTimeout(() => send(index), TEXT_SIZE_DEBOUNCE_MS);
+    },
+    [send],
+  );
+
+  const flush = useCallback(() => {
+    if (debounceTimer.current) {
+      clearTimeout(debounceTimer.current);
+      debounceTimer.current = null;
+    }
+    setDrag((d) => {
+      if (d !== null) send(d);
+      return null;
+    });
+    lastSent.current = null;
+  }, [send]);
+
+  const max = TEXT_SIZE_CATEGORIES.length - 1;
+  const shown = drag ?? value;
+  const fill = `${(shown / max) * 100}%`;
+
+  const trackClasses =
+    "[&::-webkit-slider-runnable-track]:h-[4px] [&::-webkit-slider-runnable-track]:rounded-full " +
+    "[&::-webkit-slider-runnable-track]:[background:linear-gradient(to_right,#0a84ff_var(--slider-fill),rgba(255,255,255,0.22)_var(--slider-fill))] " +
+    "[&::-moz-range-track]:h-[4px] [&::-moz-range-track]:rounded-full [&::-moz-range-track]:bg-white/20 " +
+    "[&::-moz-range-progress]:h-[4px] [&::-moz-range-progress]:rounded-full [&::-moz-range-progress]:bg-[#0a84ff]";
+  const thumbClasses =
+    "[&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:size-[13px] [&::-webkit-slider-thumb]:rounded-full " +
+    "[&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:shadow-[0_1px_3px_rgba(0,0,0,0.45)] [&::-webkit-slider-thumb]:-mt-[4.5px] " +
+    "[&::-moz-range-thumb]:size-[13px] [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-none [&::-moz-range-thumb]:bg-white";
+
+  return (
+    <span className="flex w-[120px] min-w-0 flex-col">
+      <input
+        type="range"
+        aria-label="Text Size"
+        min={0}
+        max={max}
+        step={1}
+        value={shown}
+        disabled={disabled}
+        onChange={(e) => handleInput(Number((e.target as HTMLInputElement).value))}
+        onPointerUp={flush}
+        onKeyUp={flush}
+        onBlur={flush}
+        style={{ "--slider-fill": fill } as CSSProperties}
+        className={`h-[13px] w-full cursor-pointer appearance-none rounded-full bg-transparent outline-none focus-visible:[outline:1.5px_solid_rgba(10,132,255,0.55)] focus-visible:outline-offset-4 ${trackClasses} ${thumbClasses}`}
+      />
+      <span aria-hidden className="pointer-events-none mt-[3px] flex justify-between px-[5.5px]">
+        {TEXT_SIZE_CATEGORIES.map((category) => (
+          <span key={category} className="size-[2px] rounded-full bg-white/40" />
+        ))}
+      </span>
+    </span>
+  );
+}
+
+function SettingSelect({
+  label,
+  value,
+  options,
+  disabled,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  options: Array<{ value: string; label: string }>;
+  disabled: boolean;
+  onChange: (next: string) => void;
+}) {
+  return (
+    <select
+      aria-label={label}
+      value={value}
+      disabled={disabled}
+      onChange={(e) => onChange((e.target as HTMLSelectElement).value)}
+      className="appearance-none [-webkit-appearance:none] bg-white/[0.06] border border-white/10 rounded-md text-white/90 text-[12px] py-0.5 px-2 font-[inherit] cursor-pointer min-w-0 max-w-[150px] truncate"
+    >
+      {options.map((o) => (
+        <option key={o.value} value={o.value}>
+          {o.label}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+// Inline 14px glyphs, stroked at full opacity (no dimmed icons).
+const I = {
+  appearance: (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 3a9 9 0 0 1 0 18z" fill="currentColor" stroke="none" />
+    </svg>
+  ),
+  glass: (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <rect x="3" y="5" width="18" height="14" rx="4" />
+      <rect x="7" y="9" width="10" height="6" rx="3" fill="currentColor" stroke="none" />
+    </svg>
+  ),
+  filter: (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <circle cx="9" cy="12" r="6" />
+      <circle cx="15" cy="12" r="6" />
+    </svg>
+  ),
+  textSize: (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+      <path d="M4 18V8m0 0h4M4 8H2.5" />
+      <path d="M13 18V5m0 0h5.5M13 5H8" />
+    </svg>
+  ),
+  motion: (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+      <circle cx="14" cy="12" r="6" />
+      <path d="M3 8h4M2 12h4M3 16h4" />
+    </svg>
+  ),
+  contrast: (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 3v18A9 9 0 0 0 12 3z" fill="currentColor" stroke="none" />
+    </svg>
+  ),
+  borders: (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <rect x="3" y="3" width="18" height="18" rx="4" strokeDasharray="4 3" />
+      <rect x="8" y="8" width="8" height="8" rx="2" />
+    </svg>
+  ),
+  transparency: (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <rect x="3" y="3" width="13" height="13" rx="3" />
+      <rect x="8" y="8" width="13" height="13" rx="3" />
+    </svg>
+  ),
+  voiceover: (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+      <circle cx="12" cy="12" r="9" />
+      <path d="M9 15l3-7 3 7m-5-2h4" />
+    </svg>
+  ),
+};
+
+export function SimulatorSettingsTool({ udid }: { udid: string }) {
+  const [open, setOpen] = useState(true);
+  const [state, setState] = useState<SettingsState | null>(null);
+  const [pending, setPending] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Hydration can fail outright (server restarted under the tab, control
+  // socket unreachable) or stall — both must land in the error state with a
+  // Retry, never an eternal disabled section.
+  const refresh = useCallback(async () => {
+    setError(null);
+    try {
+      const status = await hostUiRequest(
+        { device: udid },
+        { signal: AbortSignal.timeout(15_000) },
+      );
+      if (status) setState(status);
+      else setError("Unexpected simulator-settings reply");
+    } catch (e) {
+      setError(
+        e instanceof DOMException && e.name === "TimeoutError"
+          ? "Timed out reading simulator settings"
+          : e instanceof Error && e.message !== "Failed to fetch"
+            ? e.message
+            : "Could not reach the preview server — reload the page if this persists",
+      );
+    }
+  }, [udid]);
+
+  useEffect(() => {
+    setState(null);
+    void refresh();
+  }, [refresh]);
+
+  const apply = useCallback(
+    async (option: string, value: string) => {
+      setPending(option);
+      setError(null);
+      setState((s) => (s ? { ...s, [option]: value } : s));
+      try {
+        await hostUiRequest(
+          { device: udid, option, value },
+          { signal: AbortSignal.timeout(15_000) },
+        );
+      } catch (e) {
+        setError(e instanceof Error ? e.message : `Failed to set ${option}`);
+        // Re-sync from the simulator rather than restoring a snapshot — with
+        // rapid queued updates (slider drags) a snapshot can predate several
+        // successful sets and would yank the control backwards.
+        void refresh();
+      } finally {
+        setPending(null);
+      }
+    },
+    [udid, refresh],
+  );
+
+  // Rapid slider movements queue latest-wins: one exec in flight at a time,
+  // intermediate values dropped, so out-of-order completions can't leave the
+  // simulator on a stale size.
+  const textSizeQueue = useRef<{ running: boolean; next: number | null }>({
+    running: false,
+    next: null,
+  });
+  const applyRef = useRef(apply);
+  applyRef.current = apply;
+  const applyTextSize = useCallback((index: number) => {
+    const queue = textSizeQueue.current;
+    queue.next = index;
+    if (queue.running) return;
+    queue.running = true;
+    void (async () => {
+      while (queue.next !== null) {
+        const next = queue.next;
+        queue.next = null;
+        await applyRef.current("text-size", TEXT_SIZE_CATEGORIES[next]!);
+      }
+      queue.running = false;
+    })();
+  }, []);
+
+  const ready = state !== null;
+  const shown = state ?? DEFAULT_STATE;
+  const rawTextSizeIndex = TEXT_SIZE_CATEGORIES.indexOf(shown["text-size"] as never);
+  // CLI-set accessibility-range sizes exceed the slider; pin them to its max.
+  const textSizeIndex =
+    rawTextSizeIndex >= 0
+      ? rawTextSizeIndex
+      : shown["text-size"]?.startsWith("accessibility")
+        ? TEXT_SIZE_CATEGORIES.length - 1
+        : 3;
+
+  return (
+    <CollapsibleSection
+      open={open}
+      onOpenChange={setOpen}
+      data-simulator-settings=""
+      summaryClassName="grid [grid-template-columns:auto_1fr_auto] items-center gap-2 text-left"
+      summary={
+        <>
+          <span className="text-[11px] font-semibold text-white/50 uppercase tracking-[0.08em] leading-none inline-flex items-center">
+            Simulator
+          </span>
+          <span />
+        </>
+      }
+    >
+      {error && (
+        <div className="bg-danger/10 border border-danger/20 text-danger-soft text-[11px] px-2 py-1.5 rounded-md flex items-center justify-between gap-2">
+          <span className="min-w-0">{error}</span>
+          <button
+            type="button"
+            onClick={() => void refresh()}
+            className="shrink-0 cursor-pointer rounded border border-danger/30 bg-transparent px-1.5 py-0.5 text-[11px] text-danger-soft"
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      <div className="flex flex-col gap-1.5 pb-1.5">
+          <SettingRow icon={I.appearance} label="Appearance">
+            <SettingSelect
+              label="Appearance"
+              value={shown.appearance ?? "light"}
+              options={SELECT_OPTIONS.appearance!}
+              disabled={!ready || pending === "appearance"}
+              onChange={(v) => apply("appearance", v)}
+            />
+          </SettingRow>
+
+          <SettingRow icon={I.glass} label="Liquid Glass">
+            <SettingSelect
+              label="Liquid Glass"
+              value={shown["liquid-glass"] ?? "clear"}
+              options={SELECT_OPTIONS["liquid-glass"]!}
+              disabled={!ready || pending === "liquid-glass"}
+              onChange={(v) => apply("liquid-glass", v)}
+            />
+          </SettingRow>
+
+          <SettingRow icon={I.filter} label="Color Filter">
+            <SettingSelect
+              label="Color Filter"
+              value={shown["color-filter"] ?? "none"}
+              options={SELECT_OPTIONS["color-filter"]!}
+              disabled={!ready || pending === "color-filter"}
+              onChange={(v) => apply("color-filter", v)}
+            />
+          </SettingRow>
+
+          <SettingRow icon={I.textSize} label="Text Size">
+            <TextSizeSlider
+              value={textSizeIndex}
+              disabled={!ready}
+              onChange={applyTextSize}
+            />
+          </SettingRow>
+
+          {TOGGLE_OPTIONS.map(({ key, label }) => (
+            <SettingRow
+              key={key}
+              icon={I[
+                key === "reduce-motion"
+                  ? "motion"
+                  : key === "increase-contrast"
+                    ? "contrast"
+                    : key === "show-borders"
+                      ? "borders"
+                      : key === "reduce-transparency"
+                        ? "transparency"
+                        : "voiceover"
+              ]}
+              label={label}
+            >
+              <SettingSwitch
+                label={label}
+                checked={shown[key] === "on"}
+                disabled={!ready || pending === key}
+                onChange={(next) => apply(key, next ? "on" : "off")}
+              />
+            </SettingRow>
+          ))}
+        </div>
+    </CollapsibleSection>
+  );
+}

--- a/packages/serve-sim/src/client/components/tools-panel.tsx
+++ b/packages/serve-sim/src/client/components/tools-panel.tsx
@@ -5,6 +5,7 @@ import { AppDetectionTool } from "./app-detection-tool";
 import { AppPermissionsTool } from "./app-permissions-tool";
 import { AxTreeTool } from "./ax-tree-tool";
 import { CameraTool } from "./camera-tool";
+import { SimulatorSettingsTool } from "./simulator-settings-tool";
 
 export function ToolsPanel({
   open,
@@ -33,6 +34,7 @@ export function ToolsPanel({
       {open && (
         <div className="p-3.5 overflow-y-auto flex-1 flex flex-col gap-3">
           <AppDetectionTool udid={udid} currentApp={currentApp} />
+          <SimulatorSettingsTool udid={udid} />
           <AxTreeTool
             overlayEnabled={axOverlayEnabled}
             onToggleOverlay={onToggleAxOverlay}

--- a/packages/serve-sim/src/client/global.css
+++ b/packages/serve-sim/src/client/global.css
@@ -24,6 +24,36 @@
   --font-system: -apple-system, system-ui, sans-serif;
 }
 
+/* Collapsible tool sections (<details>) animate open/close height with a
+   CSS-only ::details-content transition. interpolate-size lets `height: auto`
+   participate in the transition; allow-discrete swaps content-visibility at the
+   keyframe boundaries so collapsed content stays out of the a11y tree. */
+@supports (interpolate-size: allow-keywords) {
+  :root {
+    interpolate-size: allow-keywords;
+  }
+}
+
+details.lem-section::details-content {
+  height: 0;
+  overflow: clip;
+  transition:
+    height 0.22s ease,
+    content-visibility 0.22s allow-discrete;
+}
+
+details.lem-section[open]::details-content {
+  height: auto;
+}
+
+/* The Chevron is the disclosure affordance; drop the native marker. */
+details.lem-section > summary {
+  list-style: none;
+}
+details.lem-section > summary::-webkit-details-marker {
+  display: none;
+}
+
 @keyframes grid-spin {
   to { transform: rotate(360deg); }
 }

--- a/packages/serve-sim/src/client/hooks/use-ax-snapshot.ts
+++ b/packages/serve-sim/src/client/hooks/use-ax-snapshot.ts
@@ -1,6 +1,7 @@
 import { createContext, useContext, useEffect, useState } from "react";
 import type { AxSnapshot } from "../../ax-shared";
 import { isAxeUnavailable } from "../utils/ax";
+import { openHostEventStream } from "../utils/exec";
 
 export function useAxSnapshot(endpoint?: string) {
   const [snapshot, setSnapshot] = useState<AxSnapshot | null>(null);
@@ -15,7 +16,7 @@ export function useAxSnapshot(endpoint?: string) {
 
     setSnapshot(null);
     setStatus("AX waiting");
-    const source = new EventSource(endpoint);
+    const source = openHostEventStream(endpoint);
     source.onmessage = (event) => {
       try {
         const next = JSON.parse(event.data) as AxSnapshot;
@@ -29,9 +30,9 @@ export function useAxSnapshot(endpoint?: string) {
         setStatus("AX parse error");
       }
     };
-    source.addEventListener("error", () => {
+    source.onerror = () => {
       setStatus("AX reconnecting");
-    });
+    };
     return () => source.close();
   }, [endpoint]);
 

--- a/packages/serve-sim/src/client/location-emulation-tool.tsx
+++ b/packages/serve-sim/src/client/location-emulation-tool.tsx
@@ -38,6 +38,7 @@ import {
   StopGlyph,
   WalkGlyph,
 } from "./icons";
+import { CollapsibleSection } from "./components/collapsible-section";
 
 const TRAIL_MORPH_MS = 650;
 
@@ -317,30 +318,27 @@ export function LocationEmulationTool({
     : `${formatDistance(prepared.totalDistance)} total`;
 
   return (
-    <div className="bg-panel border border-white/8 rounded-[10px] flex flex-col gap-2.5 px-3 py-2">
-      <style>{HOVER_CSS}</style>
-      <button
-        type="button"
-        onClick={() => setOpen((v: boolean) => !v)}
-        className="lem-toggle grid [grid-template-columns:auto_1fr_auto] items-center gap-2 bg-transparent border-none text-white/90 py-2.5 px-1 -my-2 -mx-1 cursor-pointer w-[calc(100%+8px)] text-left min-h-[36px] leading-none"
-        aria-expanded={open}
-      >
-        <span className="text-[11px] font-semibold text-white/50 uppercase tracking-[0.08em] leading-none inline-flex items-center">Location</span>
-        <span className="text-[11px] text-white/55 font-mono inline-flex items-center gap-1.5 justify-self-end leading-none">
-          <span
-            className="size-1.5 rounded-full [transition:background_0.2s,box-shadow_0.2s]"
-            style={{
-              background: playing ? "#4ade80" : prepared.totalDistance > 0 ? "rgba(255,255,255,0.3)" : "transparent",
-              boxShadow: playing ? "0 0 6px rgba(74,222,128,0.7)" : "none",
-            }}
-          />
-          {headerStatus}
-        </span>
-        <Chevron open={open} />
-      </button>
-
-      {open && (
+    <CollapsibleSection
+      open={open}
+      onOpenChange={setOpen}
+      summaryClassName="grid [grid-template-columns:auto_1fr_auto] items-center gap-2 text-left"
+      summary={
         <>
+          <style>{HOVER_CSS}</style>
+          <span className="text-[11px] font-semibold text-white/50 uppercase tracking-[0.08em] leading-none inline-flex items-center">Location</span>
+          <span className="text-[11px] text-white/55 font-mono inline-flex items-center gap-1.5 justify-self-end leading-none">
+            <span
+              className="size-1.5 rounded-full [transition:background_0.2s,box-shadow_0.2s]"
+              style={{
+                background: playing ? "#4ade80" : prepared.totalDistance > 0 ? "rgba(255,255,255,0.3)" : "transparent",
+                boxShadow: playing ? "0 0 6px rgba(74,222,128,0.7)" : "none",
+              }}
+            />
+            {headerStatus}
+          </span>
+        </>
+      }
+    >
           <div className="flex flex-col gap-1">
             <div className="relative block">
               <select
@@ -429,9 +427,7 @@ export function LocationEmulationTool({
               {error}
             </div>
           )}
-        </>
-      )}
-    </div>
+    </CollapsibleSection>
   );
 }
 

--- a/packages/serve-sim/src/client/utils/exec.ts
+++ b/packages/serve-sim/src/client/utils/exec.ts
@@ -6,13 +6,16 @@ export interface ExecResult {
   exitCode: number;
 }
 
-// Host execs ride a dedicated WebSocket (`/exec-ws`) rather than pooled
-// fetches: every preview tab holds several long-lived HTTP streams (MJPEG +
-// SSE), and with two or more tabs open a pooled `fetch("/exec")` queues
-// behind them against the browser's six-connections-per-origin cap. The
-// socket is shared per tab, authenticated with the same exec token, and any
-// socket failure falls back to the POST /exec route (which also covers
-// middleware mounts that don't forward upgrade events).
+// Everything the preview page asks of the host — shell execs, simulator
+// settings, and the SSE side-channels — rides one WebSocket (`/exec-ws`).
+// Pooled fetches are not used: every tab holds long-lived HTTP streams
+// (MJPEG), and the browser's six-connections-per-origin cap let pooled
+// requests starve with multiple tabs open. The channel is intentionally
+// WS-only with no HTTP fallback — a broken socket surfaces as an error
+// instead of silently degrading back into the starvation it exists to fix.
+
+const CONNECT_TIMEOUT_MS = 5_000;
+const STREAM_RETRY_MS = 2_000;
 
 type SocketReply = {
   id?: number;
@@ -53,7 +56,7 @@ function rejectAllPending(reason: Error): void {
 
 function openExecSocket(): Promise<WebSocket> {
   socketPromise ??= new Promise<WebSocket>((resolve, reject) => {
-    let ready = false;
+    let settled = false;
     let ws: WebSocket;
     try {
       ws = new WebSocket(execSocketUrl());
@@ -62,6 +65,16 @@ function openExecSocket(): Promise<WebSocket> {
       reject(e);
       return;
     }
+    // Fail fast if the server never completes the handshake or auth — a
+    // hung connection must not stall every request behind it.
+    const connectTimer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        socketPromise = null;
+        reject(new Error("control socket connect timeout"));
+        ws.close();
+      }
+    }, CONNECT_TIMEOUT_MS);
     ws.onopen = () => {
       ws.send(JSON.stringify({ token: window.__SIM_PREVIEW__?.execToken ?? "" }));
     };
@@ -73,9 +86,12 @@ function openExecSocket(): Promise<WebSocket> {
         return;
       }
       if (msg.ready) {
-        ready = true;
-        openSocket = ws;
-        resolve(ws);
+        if (!settled) {
+          settled = true;
+          clearTimeout(connectTimer);
+          openSocket = ws;
+          resolve(ws);
+        }
         return;
       }
       if (typeof msg.sub === "number") {
@@ -98,12 +114,16 @@ function openExecSocket(): Promise<WebSocket> {
     const fail = () => {
       socketPromise = null;
       openSocket = null;
-      const err = new Error("exec socket closed");
+      const err = new Error("control socket closed — reload the page if this persists");
       rejectAllPending(err);
       const subscriptions = [...activeSubscriptions.values()];
       activeSubscriptions.clear();
       for (const subscription of subscriptions) subscription.onEnd();
-      if (!ready) reject(err);
+      if (!settled) {
+        settled = true;
+        clearTimeout(connectTimer);
+        reject(err);
+      }
     };
     ws.onerror = fail;
     ws.onclose = fail;
@@ -111,80 +131,12 @@ function openExecSocket(): Promise<WebSocket> {
   return socketPromise;
 }
 
-export interface HostEventStream {
-  onmessage: ((event: { data: string }) => void) | null;
-  onerror: (() => void) | null;
-  close(): void;
-}
-
-/**
- * EventSource-shaped subscription to one of the middleware's SSE routes,
- * carried over the shared control socket so it doesn't occupy one of the
- * browser's six pooled connections. Falls back to a real EventSource (which
- * also brings its native auto-reconnect) when the socket isn't available.
- */
-export function openHostEventStream(path: string): HostEventStream {
-  const stream: HostEventStream = { onmessage: null, onerror: null, close: () => {} };
-  let closed = false;
-  let native: EventSource | null = null;
-  let subId: number | null = null;
-  let sseBuffer = "";
-
-  const fallbackToNative = () => {
-    if (closed || native) return;
-    subId = null;
-    stream.onerror?.();
-    native = new EventSource(path);
-    native.onmessage = (event) => stream.onmessage?.({ data: String(event.data) });
-    native.onerror = () => stream.onerror?.();
-  };
-
-  const handleChunk = (chunk: string) => {
-    sseBuffer += chunk.replace(/\r\n/g, "\n");
-    let boundary: number;
-    while ((boundary = sseBuffer.indexOf("\n\n")) !== -1) {
-      const block = sseBuffer.slice(0, boundary);
-      sseBuffer = sseBuffer.slice(boundary + 2);
-      const data = block
-        .split("\n")
-        .filter((line) => line.startsWith("data:"))
-        .map((line) => line.slice(5).replace(/^ /, ""))
-        .join("\n");
-      if (data) stream.onmessage?.({ data });
-    }
-  };
-
-  void (async () => {
-    try {
-      const ws = await openExecSocket();
-      if (closed) return;
-      if (ws.readyState !== WebSocket.OPEN) throw new Error("socket not open");
-      subId = nextSubId++;
-      activeSubscriptions.set(subId, { onData: handleChunk, onEnd: fallbackToNative });
-      ws.send(JSON.stringify({ sub: subId, path }));
-    } catch {
-      fallbackToNative();
-    }
-  })();
-
-  stream.close = () => {
-    closed = true;
-    native?.close();
-    native = null;
-    if (subId !== null) {
-      activeSubscriptions.delete(subId);
-      try {
-        openSocket?.send(JSON.stringify({ unsub: subId }));
-      } catch {}
-      subId = null;
-    }
-  };
-  return stream;
-}
-
-async function socketRequest(body: Record<string, unknown>, signal?: AbortSignal): Promise<SocketReply> {
+async function socketRequest(
+  body: Record<string, unknown>,
+  signal?: AbortSignal,
+): Promise<SocketReply> {
   const ws = await openExecSocket();
-  if (ws.readyState !== WebSocket.OPEN) throw new Error("exec socket not open");
+  if (ws.readyState !== WebSocket.OPEN) throw new Error("control socket not open");
   return new Promise<SocketReply>((resolve, reject) => {
     const id = nextRequestId++;
     const onAbort = () => {
@@ -212,42 +164,16 @@ async function socketRequest(body: Record<string, unknown>, signal?: AbortSignal
   });
 }
 
-async function execViaSocket(command: string, signal?: AbortSignal): Promise<ExecResult> {
-  const reply = await socketRequest({ command }, signal);
+export async function execOnHost(
+  command: string,
+  opts?: { signal?: AbortSignal },
+): Promise<ExecResult> {
+  const reply = await socketRequest({ command }, opts?.signal);
   return {
     stdout: reply.stdout ?? "",
     stderr: reply.stderr ?? "",
     exitCode: reply.exitCode ?? 1,
   };
-}
-
-async function execViaFetch(
-  command: string,
-  opts?: { signal?: AbortSignal },
-): Promise<ExecResult> {
-  const token = window.__SIM_PREVIEW__?.execToken;
-  const headers: Record<string, string> = { "Content-Type": "application/json" };
-  if (token) headers["Authorization"] = `Bearer ${token}`;
-  const res = await fetch(simEndpoint("exec"), {
-    method: "POST",
-    headers,
-    body: JSON.stringify({ command }),
-    signal: opts?.signal,
-  });
-  return res.json();
-}
-
-export async function execOnHost(
-  command: string,
-  opts?: { signal?: AbortSignal },
-): Promise<ExecResult> {
-  try {
-    return await execViaSocket(command, opts?.signal);
-  } catch (e) {
-    // Aborts (caller timeouts) propagate; transport failures retry over HTTP.
-    if (opts?.signal?.aborted) throw e;
-    return execViaFetch(command, opts);
-  }
 }
 
 export interface UiRequestPayload {
@@ -266,25 +192,82 @@ export async function hostUiRequest(
   payload: UiRequestPayload,
   opts?: { signal?: AbortSignal },
 ): Promise<Record<string, string> | null> {
-  let reply: SocketReply;
-  try {
-    reply = await socketRequest({ ui: payload }, opts?.signal);
-  } catch (e) {
-    if (opts?.signal?.aborted) throw e;
-    // Transport failure — fall back to the pooled HTTP route.
-    const token = window.__SIM_PREVIEW__?.execToken;
-    const headers: Record<string, string> = { "Content-Type": "application/json" };
-    if (token) headers["Authorization"] = `Bearer ${token}`;
-    const res = await fetch(simEndpoint("ui-settings"), {
-      method: "POST",
-      headers,
-      body: JSON.stringify(payload),
-      signal: opts?.signal,
-    });
-    reply = await res.json();
-  }
+  const reply = await socketRequest({ ui: payload }, opts?.signal);
   if (reply.error) throw new Error(reply.error);
   return reply.status ?? null;
+}
+
+export interface HostEventStream {
+  onmessage: ((event: { data: string }) => void) | null;
+  onerror: (() => void) | null;
+  close(): void;
+}
+
+/**
+ * EventSource-shaped subscription to one of the middleware's SSE routes,
+ * carried over the shared control socket. Resubscribes (with backoff) when
+ * the socket drops or the upstream ends, mirroring EventSource's native
+ * auto-reconnect; `onerror` fires on each interruption.
+ */
+export function openHostEventStream(path: string): HostEventStream {
+  const stream: HostEventStream = { onmessage: null, onerror: null, close: () => {} };
+  let closed = false;
+  let subId: number | null = null;
+  let retryTimer: ReturnType<typeof setTimeout> | null = null;
+  let sseBuffer = "";
+
+  const handleChunk = (chunk: string) => {
+    sseBuffer += chunk.replace(/\r\n/g, "\n");
+    let boundary: number;
+    while ((boundary = sseBuffer.indexOf("\n\n")) !== -1) {
+      const block = sseBuffer.slice(0, boundary);
+      sseBuffer = sseBuffer.slice(boundary + 2);
+      const data = block
+        .split("\n")
+        .filter((line) => line.startsWith("data:"))
+        .map((line) => line.slice(5).replace(/^ /, ""))
+        .join("\n");
+      if (data) stream.onmessage?.({ data });
+    }
+  };
+
+  const scheduleRetry = () => {
+    if (closed || retryTimer) return;
+    stream.onerror?.();
+    retryTimer = setTimeout(() => {
+      retryTimer = null;
+      void subscribe();
+    }, STREAM_RETRY_MS);
+  };
+
+  const subscribe = async () => {
+    if (closed) return;
+    try {
+      const ws = await openExecSocket();
+      if (closed) return;
+      sseBuffer = "";
+      subId = nextSubId++;
+      activeSubscriptions.set(subId, { onData: handleChunk, onEnd: scheduleRetry });
+      ws.send(JSON.stringify({ sub: subId, path }));
+    } catch {
+      scheduleRetry();
+    }
+  };
+
+  void subscribe();
+
+  stream.close = () => {
+    closed = true;
+    if (retryTimer) clearTimeout(retryTimer);
+    if (subId !== null) {
+      activeSubscriptions.delete(subId);
+      try {
+        openSocket?.send(JSON.stringify({ unsub: subId }));
+      } catch {}
+      subId = null;
+    }
+  };
+  return stream;
 }
 
 export function shellEscape(s: string): string {

--- a/packages/serve-sim/src/client/utils/exec.ts
+++ b/packages/serve-sim/src/client/utils/exec.ts
@@ -6,7 +6,225 @@ export interface ExecResult {
   exitCode: number;
 }
 
-export async function execOnHost(command: string): Promise<ExecResult> {
+// Host execs ride a dedicated WebSocket (`/exec-ws`) rather than pooled
+// fetches: every preview tab holds several long-lived HTTP streams (MJPEG +
+// SSE), and with two or more tabs open a pooled `fetch("/exec")` queues
+// behind them against the browser's six-connections-per-origin cap. The
+// socket is shared per tab, authenticated with the same exec token, and any
+// socket failure falls back to the POST /exec route (which also covers
+// middleware mounts that don't forward upgrade events).
+
+type SocketReply = {
+  id?: number;
+  sub?: number;
+  data?: string;
+  end?: boolean;
+  ready?: boolean;
+  error?: string;
+} & Partial<ExecResult> & { status?: Record<string, string>; ok?: boolean };
+
+interface PendingRequest {
+  resolve: (reply: SocketReply) => void;
+  reject: (err: unknown) => void;
+}
+
+interface ActiveSubscription {
+  onData: (chunk: string) => void;
+  onEnd: () => void;
+}
+
+let socketPromise: Promise<WebSocket> | null = null;
+let openSocket: WebSocket | null = null;
+let nextRequestId = 1;
+let nextSubId = 1;
+const pendingRequests = new Map<number, PendingRequest>();
+const activeSubscriptions = new Map<number, ActiveSubscription>();
+
+function execSocketUrl(): string {
+  const url = new URL(simEndpoint("exec-ws"), window.location.href);
+  url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+  return url.toString();
+}
+
+function rejectAllPending(reason: Error): void {
+  for (const pending of pendingRequests.values()) pending.reject(reason);
+  pendingRequests.clear();
+}
+
+function openExecSocket(): Promise<WebSocket> {
+  socketPromise ??= new Promise<WebSocket>((resolve, reject) => {
+    let ready = false;
+    let ws: WebSocket;
+    try {
+      ws = new WebSocket(execSocketUrl());
+    } catch (e) {
+      socketPromise = null;
+      reject(e);
+      return;
+    }
+    ws.onopen = () => {
+      ws.send(JSON.stringify({ token: window.__SIM_PREVIEW__?.execToken ?? "" }));
+    };
+    ws.onmessage = (event) => {
+      let msg: SocketReply;
+      try {
+        msg = JSON.parse(String(event.data));
+      } catch {
+        return;
+      }
+      if (msg.ready) {
+        ready = true;
+        openSocket = ws;
+        resolve(ws);
+        return;
+      }
+      if (typeof msg.sub === "number") {
+        const subscription = activeSubscriptions.get(msg.sub);
+        if (!subscription) return;
+        if (msg.end) {
+          activeSubscriptions.delete(msg.sub);
+          subscription.onEnd();
+        } else if (typeof msg.data === "string") {
+          subscription.onData(msg.data);
+        }
+        return;
+      }
+      if (typeof msg.id !== "number") return;
+      const pending = pendingRequests.get(msg.id);
+      if (!pending) return;
+      pendingRequests.delete(msg.id);
+      pending.resolve(msg);
+    };
+    const fail = () => {
+      socketPromise = null;
+      openSocket = null;
+      const err = new Error("exec socket closed");
+      rejectAllPending(err);
+      const subscriptions = [...activeSubscriptions.values()];
+      activeSubscriptions.clear();
+      for (const subscription of subscriptions) subscription.onEnd();
+      if (!ready) reject(err);
+    };
+    ws.onerror = fail;
+    ws.onclose = fail;
+  });
+  return socketPromise;
+}
+
+export interface HostEventStream {
+  onmessage: ((event: { data: string }) => void) | null;
+  onerror: (() => void) | null;
+  close(): void;
+}
+
+/**
+ * EventSource-shaped subscription to one of the middleware's SSE routes,
+ * carried over the shared control socket so it doesn't occupy one of the
+ * browser's six pooled connections. Falls back to a real EventSource (which
+ * also brings its native auto-reconnect) when the socket isn't available.
+ */
+export function openHostEventStream(path: string): HostEventStream {
+  const stream: HostEventStream = { onmessage: null, onerror: null, close: () => {} };
+  let closed = false;
+  let native: EventSource | null = null;
+  let subId: number | null = null;
+  let sseBuffer = "";
+
+  const fallbackToNative = () => {
+    if (closed || native) return;
+    subId = null;
+    stream.onerror?.();
+    native = new EventSource(path);
+    native.onmessage = (event) => stream.onmessage?.({ data: String(event.data) });
+    native.onerror = () => stream.onerror?.();
+  };
+
+  const handleChunk = (chunk: string) => {
+    sseBuffer += chunk.replace(/\r\n/g, "\n");
+    let boundary: number;
+    while ((boundary = sseBuffer.indexOf("\n\n")) !== -1) {
+      const block = sseBuffer.slice(0, boundary);
+      sseBuffer = sseBuffer.slice(boundary + 2);
+      const data = block
+        .split("\n")
+        .filter((line) => line.startsWith("data:"))
+        .map((line) => line.slice(5).replace(/^ /, ""))
+        .join("\n");
+      if (data) stream.onmessage?.({ data });
+    }
+  };
+
+  void (async () => {
+    try {
+      const ws = await openExecSocket();
+      if (closed) return;
+      if (ws.readyState !== WebSocket.OPEN) throw new Error("socket not open");
+      subId = nextSubId++;
+      activeSubscriptions.set(subId, { onData: handleChunk, onEnd: fallbackToNative });
+      ws.send(JSON.stringify({ sub: subId, path }));
+    } catch {
+      fallbackToNative();
+    }
+  })();
+
+  stream.close = () => {
+    closed = true;
+    native?.close();
+    native = null;
+    if (subId !== null) {
+      activeSubscriptions.delete(subId);
+      try {
+        openSocket?.send(JSON.stringify({ unsub: subId }));
+      } catch {}
+      subId = null;
+    }
+  };
+  return stream;
+}
+
+async function socketRequest(body: Record<string, unknown>, signal?: AbortSignal): Promise<SocketReply> {
+  const ws = await openExecSocket();
+  if (ws.readyState !== WebSocket.OPEN) throw new Error("exec socket not open");
+  return new Promise<SocketReply>((resolve, reject) => {
+    const id = nextRequestId++;
+    const onAbort = () => {
+      pendingRequests.delete(id);
+      reject(signal?.reason ?? new DOMException("Aborted", "AbortError"));
+    };
+    if (signal) {
+      if (signal.aborted) {
+        onAbort();
+        return;
+      }
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
+    pendingRequests.set(id, {
+      resolve: (reply) => {
+        signal?.removeEventListener("abort", onAbort);
+        resolve(reply);
+      },
+      reject: (err) => {
+        signal?.removeEventListener("abort", onAbort);
+        reject(err);
+      },
+    });
+    ws.send(JSON.stringify({ id, ...body }));
+  });
+}
+
+async function execViaSocket(command: string, signal?: AbortSignal): Promise<ExecResult> {
+  const reply = await socketRequest({ command }, signal);
+  return {
+    stdout: reply.stdout ?? "",
+    stderr: reply.stderr ?? "",
+    exitCode: reply.exitCode ?? 1,
+  };
+}
+
+async function execViaFetch(
+  command: string,
+  opts?: { signal?: AbortSignal },
+): Promise<ExecResult> {
   const token = window.__SIM_PREVIEW__?.execToken;
   const headers: Record<string, string> = { "Content-Type": "application/json" };
   if (token) headers["Authorization"] = `Bearer ${token}`;
@@ -14,8 +232,59 @@ export async function execOnHost(command: string): Promise<ExecResult> {
     method: "POST",
     headers,
     body: JSON.stringify({ command }),
+    signal: opts?.signal,
   });
   return res.json();
+}
+
+export async function execOnHost(
+  command: string,
+  opts?: { signal?: AbortSignal },
+): Promise<ExecResult> {
+  try {
+    return await execViaSocket(command, opts?.signal);
+  } catch (e) {
+    // Aborts (caller timeouts) propagate; transport failures retry over HTTP.
+    if (opts?.signal?.aborted) throw e;
+    return execViaFetch(command, opts);
+  }
+}
+
+export interface UiRequestPayload {
+  device: string;
+  option?: string;
+  value?: string;
+}
+
+/**
+ * Simulator-settings request, handled in-process by the preview server (just
+ * the underlying simctl/ax-tool spawn — no `node <cli>` shell round-trip).
+ * Resolves to the settings map for status requests; rejects with the server's
+ * error message for invalid requests or failed sets.
+ */
+export async function hostUiRequest(
+  payload: UiRequestPayload,
+  opts?: { signal?: AbortSignal },
+): Promise<Record<string, string> | null> {
+  let reply: SocketReply;
+  try {
+    reply = await socketRequest({ ui: payload }, opts?.signal);
+  } catch (e) {
+    if (opts?.signal?.aborted) throw e;
+    // Transport failure — fall back to the pooled HTTP route.
+    const token = window.__SIM_PREVIEW__?.execToken;
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (token) headers["Authorization"] = `Bearer ${token}`;
+    const res = await fetch(simEndpoint("ui-settings"), {
+      method: "POST",
+      headers,
+      body: JSON.stringify(payload),
+      signal: opts?.signal,
+    });
+    reply = await res.json();
+  }
+  if (reply.error) throw new Error(reply.error);
+  return reply.status ?? null;
 }
 
 export function shellEscape(s: string): string {

--- a/packages/serve-sim/src/exec-ws.ts
+++ b/packages/serve-sim/src/exec-ws.ts
@@ -1,0 +1,315 @@
+import { exec, type ExecException } from "child_process";
+import { createHash, timingSafeEqual } from "crypto";
+import { request as httpRequest, type IncomingMessage } from "http";
+import type { Socket } from "net";
+import type { Duplex } from "stream";
+
+// WebSocket control channel for the preview page. Browsers cap HTTP/1.1 at
+// six connections per origin, and every preview tab used to hold several
+// long-lived requests (MJPEG + 3-4 SSE channels + pooled exec fetches) — with
+// two or more tabs open, new requests queue behind them forever. This channel
+// carries shell execs *and* multiplexes the SSE side-channels, so each tab
+// needs just one pooled connection (the video stream) plus this socket.
+//
+// Wire protocol (all JSON text frames):
+//   client → {token}                  first frame; must match the exec token
+//   server → {ready:true}             auth accepted
+//   client → {id, command}            run a shell command
+//   server → {id, stdout, stderr, exitCode}
+//   client → {id, ui:{…}}             simulator-settings request (in-process,
+//   server → {id, …} | {id, error}     no shell round-trip)
+//   client → {sub, path}              subscribe to a same-origin SSE route
+//   server → {sub, data}              raw SSE bytes for that subscription
+//   server → {sub, end:true}          upstream closed
+//   client → {unsub: sub}             cancel a subscription
+
+const WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+const AUTH_TIMEOUT_MS = 10_000;
+const MAX_FRAME_BYTES = 4 * 1024 * 1024;
+
+function tokensMatch(a: string, b: string): boolean {
+  // Hash both sides so the comparison is constant-time even when lengths differ.
+  const ha = createHash("sha256").update(a).digest();
+  const hb = createHash("sha256").update(b).digest();
+  return timingSafeEqual(ha, hb);
+}
+
+function sendFrame(socket: Duplex, opcode: number, payload: Buffer): void {
+  const len = payload.length;
+  let header: Buffer;
+  if (len < 126) {
+    header = Buffer.from([0x80 | opcode, len]);
+  } else if (len < 65_536) {
+    header = Buffer.alloc(4);
+    header[0] = 0x80 | opcode;
+    header[1] = 126;
+    header.writeUInt16BE(len, 2);
+  } else {
+    header = Buffer.alloc(10);
+    header[0] = 0x80 | opcode;
+    header[1] = 127;
+    header.writeBigUInt64BE(BigInt(len), 2);
+  }
+  socket.write(Buffer.concat([header, payload]));
+}
+
+function sendJson(socket: Duplex, value: unknown): void {
+  sendFrame(socket, 0x1, Buffer.from(JSON.stringify(value)));
+}
+
+function closeSocket(socket: Duplex): void {
+  try {
+    sendFrame(socket, 0x8, Buffer.alloc(0));
+  } catch {}
+  socket.end();
+}
+
+interface ExecMessage {
+  token?: string;
+  id?: number;
+  command?: string;
+  ui?: unknown;
+  sub?: number;
+  path?: string;
+  unsub?: number;
+}
+
+/** In-process handler for `{id, ui}` requests; resolves to the reply body. */
+export type UiRequestHandler = (payload: unknown) => Promise<Record<string, unknown>>;
+
+function wireExecSocket(
+  socket: Duplex,
+  execToken: string,
+  ssePrefixes: string[],
+  onUiRequest?: UiRequestHandler,
+): void {
+  let buffer = Buffer.alloc(0);
+  let authed = false;
+  let fragments: Buffer[] = [];
+  let fragmentOpcode = 0;
+  const subscriptions = new Map<number, { destroy: () => void }>();
+
+  const authTimer = setTimeout(() => {
+    if (!authed) closeSocket(socket);
+  }, AUTH_TIMEOUT_MS);
+  authTimer.unref?.();
+
+  const subscribe = (sub: number, path: string) => {
+    if (subscriptions.has(sub)) return;
+    // Only same-origin SSE routes owned by this middleware are reachable, and
+    // only for authed sockets — strictly less exposure than the routes' own
+    // direct (tokenless same-origin) GET surface.
+    const pathOnly = path.split("?")[0]!;
+    if (!path.startsWith("/") || !ssePrefixes.some((p) => pathOnly === p)) {
+      sendJson(socket, { sub, end: true, error: "path not allowed" });
+      return;
+    }
+    // Loop the request back through our own HTTP server; server-to-self
+    // connections are not subject to the browser's per-origin pool.
+    const port = (socket as Socket).localPort;
+    if (!port) {
+      sendJson(socket, { sub, end: true, error: "no local port" });
+      return;
+    }
+    const upstream = httpRequest(
+      {
+        host: "127.0.0.1",
+        port,
+        path,
+        headers: { accept: "text/event-stream" },
+      },
+      (res) => {
+        res.on("data", (chunk: Buffer) => {
+          if (!socket.destroyed) sendJson(socket, { sub, data: chunk.toString("utf-8") });
+        });
+        res.on("end", () => {
+          subscriptions.delete(sub);
+          if (!socket.destroyed) sendJson(socket, { sub, end: true });
+        });
+      },
+    );
+    upstream.on("error", () => {
+      subscriptions.delete(sub);
+      if (!socket.destroyed) sendJson(socket, { sub, end: true });
+    });
+    upstream.end();
+    subscriptions.set(sub, { destroy: () => upstream.destroy() });
+  };
+
+  const handleMessage = (payload: Buffer) => {
+    let msg: ExecMessage;
+    try {
+      msg = JSON.parse(payload.toString("utf-8")) as ExecMessage;
+    } catch {
+      return;
+    }
+    if (!authed) {
+      if (typeof msg.token === "string" && tokensMatch(msg.token, execToken)) {
+        authed = true;
+        clearTimeout(authTimer);
+        sendJson(socket, { ready: true });
+      } else {
+        closeSocket(socket);
+      }
+      return;
+    }
+    if (typeof msg.unsub === "number") {
+      subscriptions.get(msg.unsub)?.destroy();
+      subscriptions.delete(msg.unsub);
+      return;
+    }
+    if (typeof msg.sub === "number" && typeof msg.path === "string") {
+      subscribe(msg.sub, msg.path);
+      return;
+    }
+    if (typeof msg.id === "number" && msg.ui !== undefined) {
+      const { id } = msg;
+      if (!onUiRequest) {
+        sendJson(socket, { id, error: "ui requests not supported" });
+        return;
+      }
+      onUiRequest(msg.ui)
+        .then((reply) => {
+          if (!socket.destroyed) sendJson(socket, { id, ...reply });
+        })
+        .catch((e: unknown) => {
+          if (!socket.destroyed) {
+            sendJson(socket, { id, error: e instanceof Error ? e.message : String(e) });
+          }
+        });
+      return;
+    }
+    if (typeof msg.id !== "number" || typeof msg.command !== "string" || !msg.command) {
+      return;
+    }
+    const { id, command } = msg;
+    exec(command, { maxBuffer: 16 * 1024 * 1024 }, (err, stdout, stderr) => {
+      if (socket.destroyed) return;
+      sendJson(socket, {
+        id,
+        stdout: stdout.toString(),
+        stderr: stderr.toString(),
+        exitCode: err ? ((err as ExecException).code ?? 1) : 0,
+      });
+    });
+  };
+
+  socket.on("data", (chunk: Buffer) => {
+    buffer = Buffer.concat([buffer, chunk]);
+    while (buffer.length >= 2) {
+      const fin = (buffer[0]! & 0x80) !== 0;
+      const opcode = buffer[0]! & 0x0f;
+      const masked = (buffer[1]! & 0x80) !== 0;
+      let payloadLength = buffer[1]! & 0x7f;
+      let offset = 2;
+      if (payloadLength === 126) {
+        if (buffer.length < 4) return;
+        payloadLength = buffer.readUInt16BE(2);
+        offset = 4;
+      } else if (payloadLength === 127) {
+        if (buffer.length < 10) return;
+        const big = buffer.readBigUInt64BE(2);
+        if (big > BigInt(MAX_FRAME_BYTES)) {
+          closeSocket(socket);
+          return;
+        }
+        payloadLength = Number(big);
+        offset = 10;
+      }
+      if (payloadLength > MAX_FRAME_BYTES) {
+        closeSocket(socket);
+        return;
+      }
+      let maskKey: Buffer | null = null;
+      if (masked) {
+        if (buffer.length < offset + 4) return;
+        maskKey = buffer.subarray(offset, offset + 4);
+        offset += 4;
+      }
+      if (buffer.length < offset + payloadLength) return;
+      const payload = Buffer.from(buffer.subarray(offset, offset + payloadLength));
+      buffer = buffer.subarray(offset + payloadLength);
+      if (maskKey) {
+        for (let i = 0; i < payload.length; i++) payload[i]! ^= maskKey[i % 4]!;
+      }
+
+      if (opcode === 0x8) {
+        closeSocket(socket);
+        return;
+      }
+      if (opcode === 0x9) {
+        sendFrame(socket, 0xa, payload);
+        continue;
+      }
+      if (opcode === 0xa) continue; // unsolicited pong
+
+      if (opcode === 0x1 || opcode === 0x2 || opcode === 0x0) {
+        if (opcode !== 0x0) fragmentOpcode = opcode;
+        fragments.push(payload);
+        if (!fin) continue;
+        const message = fragments.length === 1 ? fragments[0]! : Buffer.concat(fragments);
+        fragments = [];
+        if (fragmentOpcode === 0x1) handleMessage(message);
+      }
+    }
+  });
+
+  socket.on("error", () => socket.destroy());
+  socket.on("close", () => {
+    clearTimeout(authTimer);
+    for (const sub of subscriptions.values()) sub.destroy();
+    subscriptions.clear();
+  });
+}
+
+/**
+ * Upgrade handler for `<basePath>/exec-ws`. Returns true when the request was
+ * for the exec channel (and the socket has been taken over), false when the
+ * caller should handle (or destroy) the socket itself.
+ */
+export function createExecUpgradeHandler(opts: {
+  path: string;
+  execToken: string;
+  /** Exact pathnames (query excluded) the channel may proxy as SSE. */
+  ssePrefixes?: string[];
+  /** In-process handler for `{id, ui}` simulator-settings requests. */
+  onUiRequest?: UiRequestHandler;
+}) {
+  return function handleUpgrade(req: IncomingMessage, socket: Duplex, _head: Buffer): boolean {
+    const rawUrl = req.url ?? "";
+    const qIndex = rawUrl.indexOf("?");
+    const url = qIndex === -1 ? rawUrl : rawUrl.slice(0, qIndex);
+    if (url !== opts.path && url !== `${opts.path}/`) return false;
+
+    // Same-origin policy mirrors POST /exec: browsers always send Origin on
+    // WebSocket upgrades, and a cross-origin page's Origin won't match Host.
+    const origin = req.headers.origin;
+    if (origin) {
+      try {
+        if (new URL(origin).host !== req.headers.host) {
+          socket.destroy();
+          return true;
+        }
+      } catch {
+        socket.destroy();
+        return true;
+      }
+    }
+
+    const key = req.headers["sec-websocket-key"];
+    if (typeof key !== "string" || req.headers.upgrade?.toLowerCase() !== "websocket") {
+      socket.destroy();
+      return true;
+    }
+    const accept = createHash("sha1").update(key + WS_GUID).digest("base64");
+    socket.write(
+      "HTTP/1.1 101 Switching Protocols\r\n" +
+        "Upgrade: websocket\r\n" +
+        "Connection: Upgrade\r\n" +
+        `Sec-WebSocket-Accept: ${accept}\r\n\r\n`,
+    );
+    (socket as Duplex & { setNoDelay?: (noDelay: boolean) => void }).setNoDelay?.(true);
+    wireExecSocket(socket, opts.execToken, opts.ssePrefixes ?? [], opts.onUiRequest);
+    return true;
+  };
+}

--- a/packages/serve-sim/src/exec-ws.ts
+++ b/packages/serve-sim/src/exec-ws.ts
@@ -3,13 +3,22 @@ import { createHash, timingSafeEqual } from "crypto";
 import { request as httpRequest, type IncomingMessage } from "http";
 import type { Socket } from "net";
 import type { Duplex } from "stream";
+import { WebSocketServer, type WebSocket } from "ws";
 
 // WebSocket control channel for the preview page. Browsers cap HTTP/1.1 at
 // six connections per origin, and every preview tab used to hold several
 // long-lived requests (MJPEG + 3-4 SSE channels + pooled exec fetches) — with
 // two or more tabs open, new requests queue behind them forever. This channel
-// carries shell execs *and* multiplexes the SSE side-channels, so each tab
-// needs just one pooled connection (the video stream) plus this socket.
+// carries shell execs, simulator-settings requests, and multiplexed SSE
+// subscriptions, so each tab needs just one pooled connection (the video
+// stream) plus this socket.
+//
+// Built on `ws` rather than hand-rolled RFC6455: under Bun, `node:http`
+// emits `upgrade` but raw 101 handshake writes to the socket never flush, so
+// manual framing silently breaks — Bun instead substitutes its own native
+// implementation for the `ws` module, which works. The client is
+// intentionally WS-only (no HTTP fallback): a broken channel must surface as
+// an error, not silent degradation.
 //
 // Wire protocol (all JSON text frames):
 //   client → {token}                  first frame; must match the exec token
@@ -23,45 +32,14 @@ import type { Duplex } from "stream";
 //   server → {sub, end:true}          upstream closed
 //   client → {unsub: sub}             cancel a subscription
 
-const WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 const AUTH_TIMEOUT_MS = 10_000;
-const MAX_FRAME_BYTES = 4 * 1024 * 1024;
+const MAX_MESSAGE_BYTES = 4 * 1024 * 1024;
 
 function tokensMatch(a: string, b: string): boolean {
   // Hash both sides so the comparison is constant-time even when lengths differ.
   const ha = createHash("sha256").update(a).digest();
   const hb = createHash("sha256").update(b).digest();
   return timingSafeEqual(ha, hb);
-}
-
-function sendFrame(socket: Duplex, opcode: number, payload: Buffer): void {
-  const len = payload.length;
-  let header: Buffer;
-  if (len < 126) {
-    header = Buffer.from([0x80 | opcode, len]);
-  } else if (len < 65_536) {
-    header = Buffer.alloc(4);
-    header[0] = 0x80 | opcode;
-    header[1] = 126;
-    header.writeUInt16BE(len, 2);
-  } else {
-    header = Buffer.alloc(10);
-    header[0] = 0x80 | opcode;
-    header[1] = 127;
-    header.writeBigUInt64BE(BigInt(len), 2);
-  }
-  socket.write(Buffer.concat([header, payload]));
-}
-
-function sendJson(socket: Duplex, value: unknown): void {
-  sendFrame(socket, 0x1, Buffer.from(JSON.stringify(value)));
-}
-
-function closeSocket(socket: Duplex): void {
-  try {
-    sendFrame(socket, 0x8, Buffer.alloc(0));
-  } catch {}
-  socket.end();
 }
 
 interface ExecMessage {
@@ -77,20 +55,30 @@ interface ExecMessage {
 /** In-process handler for `{id, ui}` requests; resolves to the reply body. */
 export type UiRequestHandler = (payload: unknown) => Promise<Record<string, unknown>>;
 
+interface ExecChannelOptions {
+  path: string;
+  execToken: string;
+  /** Exact pathnames (query excluded) the channel may proxy as SSE. */
+  ssePrefixes?: string[];
+  /** In-process handler for `{id, ui}` simulator-settings requests. */
+  onUiRequest?: UiRequestHandler;
+}
+
 function wireExecSocket(
-  socket: Duplex,
-  execToken: string,
-  ssePrefixes: string[],
-  onUiRequest?: UiRequestHandler,
+  ws: WebSocket,
+  serverPort: number | undefined,
+  opts: ExecChannelOptions,
 ): void {
-  let buffer = Buffer.alloc(0);
   let authed = false;
-  let fragments: Buffer[] = [];
-  let fragmentOpcode = 0;
   const subscriptions = new Map<number, { destroy: () => void }>();
+  const ssePrefixes = opts.ssePrefixes ?? [];
+
+  const send = (value: unknown) => {
+    if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(value));
+  };
 
   const authTimer = setTimeout(() => {
-    if (!authed) closeSocket(socket);
+    if (!authed) ws.close();
   }, AUTH_TIMEOUT_MS);
   authTimer.unref?.();
 
@@ -101,55 +89,52 @@ function wireExecSocket(
     // direct (tokenless same-origin) GET surface.
     const pathOnly = path.split("?")[0]!;
     if (!path.startsWith("/") || !ssePrefixes.some((p) => pathOnly === p)) {
-      sendJson(socket, { sub, end: true, error: "path not allowed" });
+      send({ sub, end: true, error: "path not allowed" });
       return;
     }
     // Loop the request back through our own HTTP server; server-to-self
     // connections are not subject to the browser's per-origin pool.
-    const port = (socket as Socket).localPort;
-    if (!port) {
-      sendJson(socket, { sub, end: true, error: "no local port" });
+    if (!serverPort) {
+      send({ sub, end: true, error: "no local port" });
       return;
     }
     const upstream = httpRequest(
       {
         host: "127.0.0.1",
-        port,
+        port: serverPort,
         path,
         headers: { accept: "text/event-stream" },
       },
       (res) => {
-        res.on("data", (chunk: Buffer) => {
-          if (!socket.destroyed) sendJson(socket, { sub, data: chunk.toString("utf-8") });
-        });
+        res.on("data", (chunk: Buffer) => send({ sub, data: chunk.toString("utf-8") }));
         res.on("end", () => {
           subscriptions.delete(sub);
-          if (!socket.destroyed) sendJson(socket, { sub, end: true });
+          send({ sub, end: true });
         });
       },
     );
     upstream.on("error", () => {
       subscriptions.delete(sub);
-      if (!socket.destroyed) sendJson(socket, { sub, end: true });
+      send({ sub, end: true });
     });
     upstream.end();
     subscriptions.set(sub, { destroy: () => upstream.destroy() });
   };
 
-  const handleMessage = (payload: Buffer) => {
+  ws.on("message", (data) => {
     let msg: ExecMessage;
     try {
-      msg = JSON.parse(payload.toString("utf-8")) as ExecMessage;
+      msg = JSON.parse(data.toString()) as ExecMessage;
     } catch {
       return;
     }
     if (!authed) {
-      if (typeof msg.token === "string" && tokensMatch(msg.token, execToken)) {
+      if (typeof msg.token === "string" && tokensMatch(msg.token, opts.execToken)) {
         authed = true;
         clearTimeout(authTimer);
-        sendJson(socket, { ready: true });
+        send({ ready: true });
       } else {
-        closeSocket(socket);
+        ws.close();
       }
       return;
     }
@@ -164,19 +149,16 @@ function wireExecSocket(
     }
     if (typeof msg.id === "number" && msg.ui !== undefined) {
       const { id } = msg;
-      if (!onUiRequest) {
-        sendJson(socket, { id, error: "ui requests not supported" });
+      if (!opts.onUiRequest) {
+        send({ id, error: "ui requests not supported" });
         return;
       }
-      onUiRequest(msg.ui)
-        .then((reply) => {
-          if (!socket.destroyed) sendJson(socket, { id, ...reply });
-        })
-        .catch((e: unknown) => {
-          if (!socket.destroyed) {
-            sendJson(socket, { id, error: e instanceof Error ? e.message : String(e) });
-          }
-        });
+      opts
+        .onUiRequest(msg.ui)
+        .then((reply) => send({ id, ...reply }))
+        .catch((e: unknown) =>
+          send({ id, error: e instanceof Error ? e.message : String(e) }),
+        );
       return;
     }
     if (typeof msg.id !== "number" || typeof msg.command !== "string" || !msg.command) {
@@ -184,78 +166,17 @@ function wireExecSocket(
     }
     const { id, command } = msg;
     exec(command, { maxBuffer: 16 * 1024 * 1024 }, (err, stdout, stderr) => {
-      if (socket.destroyed) return;
-      sendJson(socket, {
+      send({
         id,
         stdout: stdout.toString(),
         stderr: stderr.toString(),
         exitCode: err ? ((err as ExecException).code ?? 1) : 0,
       });
     });
-  };
-
-  socket.on("data", (chunk: Buffer) => {
-    buffer = Buffer.concat([buffer, chunk]);
-    while (buffer.length >= 2) {
-      const fin = (buffer[0]! & 0x80) !== 0;
-      const opcode = buffer[0]! & 0x0f;
-      const masked = (buffer[1]! & 0x80) !== 0;
-      let payloadLength = buffer[1]! & 0x7f;
-      let offset = 2;
-      if (payloadLength === 126) {
-        if (buffer.length < 4) return;
-        payloadLength = buffer.readUInt16BE(2);
-        offset = 4;
-      } else if (payloadLength === 127) {
-        if (buffer.length < 10) return;
-        const big = buffer.readBigUInt64BE(2);
-        if (big > BigInt(MAX_FRAME_BYTES)) {
-          closeSocket(socket);
-          return;
-        }
-        payloadLength = Number(big);
-        offset = 10;
-      }
-      if (payloadLength > MAX_FRAME_BYTES) {
-        closeSocket(socket);
-        return;
-      }
-      let maskKey: Buffer | null = null;
-      if (masked) {
-        if (buffer.length < offset + 4) return;
-        maskKey = buffer.subarray(offset, offset + 4);
-        offset += 4;
-      }
-      if (buffer.length < offset + payloadLength) return;
-      const payload = Buffer.from(buffer.subarray(offset, offset + payloadLength));
-      buffer = buffer.subarray(offset + payloadLength);
-      if (maskKey) {
-        for (let i = 0; i < payload.length; i++) payload[i]! ^= maskKey[i % 4]!;
-      }
-
-      if (opcode === 0x8) {
-        closeSocket(socket);
-        return;
-      }
-      if (opcode === 0x9) {
-        sendFrame(socket, 0xa, payload);
-        continue;
-      }
-      if (opcode === 0xa) continue; // unsolicited pong
-
-      if (opcode === 0x1 || opcode === 0x2 || opcode === 0x0) {
-        if (opcode !== 0x0) fragmentOpcode = opcode;
-        fragments.push(payload);
-        if (!fin) continue;
-        const message = fragments.length === 1 ? fragments[0]! : Buffer.concat(fragments);
-        fragments = [];
-        if (fragmentOpcode === 0x1) handleMessage(message);
-      }
-    }
   });
 
-  socket.on("error", () => socket.destroy());
-  socket.on("close", () => {
+  ws.on("error", () => ws.close());
+  ws.on("close", () => {
     clearTimeout(authTimer);
     for (const sub of subscriptions.values()) sub.destroy();
     subscriptions.clear();
@@ -267,15 +188,9 @@ function wireExecSocket(
  * for the exec channel (and the socket has been taken over), false when the
  * caller should handle (or destroy) the socket itself.
  */
-export function createExecUpgradeHandler(opts: {
-  path: string;
-  execToken: string;
-  /** Exact pathnames (query excluded) the channel may proxy as SSE. */
-  ssePrefixes?: string[];
-  /** In-process handler for `{id, ui}` simulator-settings requests. */
-  onUiRequest?: UiRequestHandler;
-}) {
-  return function handleUpgrade(req: IncomingMessage, socket: Duplex, _head: Buffer): boolean {
+export function createExecUpgradeHandler(opts: ExecChannelOptions) {
+  const wss = new WebSocketServer({ noServer: true, maxPayload: MAX_MESSAGE_BYTES });
+  return function handleUpgrade(req: IncomingMessage, socket: Duplex, head: Buffer): boolean {
     const rawUrl = req.url ?? "";
     const qIndex = rawUrl.indexOf("?");
     const url = qIndex === -1 ? rawUrl : rawUrl.slice(0, qIndex);
@@ -296,20 +211,17 @@ export function createExecUpgradeHandler(opts: {
       }
     }
 
-    const key = req.headers["sec-websocket-key"];
-    if (typeof key !== "string" || req.headers.upgrade?.toLowerCase() !== "websocket") {
-      socket.destroy();
-      return true;
+    // Port for SSE loopback requests: prefer the socket's own local port,
+    // fall back to the Host header (Bun's upgrade socket may not expose it).
+    let serverPort = (socket as Socket).localPort;
+    if (!serverPort) {
+      const hostPort = Number((req.headers.host ?? "").split(":")[1]);
+      if (Number.isFinite(hostPort) && hostPort > 0) serverPort = hostPort;
     }
-    const accept = createHash("sha1").update(key + WS_GUID).digest("base64");
-    socket.write(
-      "HTTP/1.1 101 Switching Protocols\r\n" +
-        "Upgrade: websocket\r\n" +
-        "Connection: Upgrade\r\n" +
-        `Sec-WebSocket-Accept: ${accept}\r\n\r\n`,
-    );
-    (socket as Duplex & { setNoDelay?: (noDelay: boolean) => void }).setNoDelay?.(true);
-    wireExecSocket(socket, opts.execToken, opts.ssePrefixes ?? [], opts.onUiRequest);
+
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      wireExecSocket(ws, serverPort, opts);
+    });
     return true;
   };
 }

--- a/packages/serve-sim/src/index.ts
+++ b/packages/serve-sim/src/index.ts
@@ -10,6 +10,7 @@ import { textToKeyEvents, UnsupportedCharacterError, sendKeyEventsToWs } from ".
 import { dirnameOf, sleepSync, isPortFree, servePreview } from "./runtime";
 import { findBootedDevice, resolveDevice } from "./device";
 import { permissions } from "./permissions";
+import { uiSettings } from "./ui-settings";
 import { debugCli, debugHelper, debugState } from "./debug";
 
 // `import.meta.dir` is Bun-only; resolve once via fileURLToPath so the bundled
@@ -2000,5 +2001,13 @@ program
   .helpOption(false)
   .argument("[args...]")
   .action((args: string[]) => permissions(args));
+
+program
+  .command("ui")
+  .description("Get or set simulator-wide UI options (see `ui --help`)")
+  .allowUnknownOption(true)
+  .helpOption(false)
+  .argument("[args...]")
+  .action((args: string[]) => uiSettings(args));
 
 await program.parseAsync(process.argv);

--- a/packages/serve-sim/src/middleware.ts
+++ b/packages/serve-sim/src/middleware.ts
@@ -7,6 +7,8 @@ import { randomBytes, timingSafeEqual } from "crypto";
 import type { IncomingMessage, ServerResponse } from "http";
 import { createAxStreamerCache } from "./ax";
 import { debugMw } from "./debug";
+import { createExecUpgradeHandler, type UiRequestHandler } from "./exec-ws";
+import { UI_OPTIONS, getUiStatus, normalizeUiValue, setUiOption } from "./ui-settings";
 
 type SimReq = IncomingMessage;
 type SimRes = ServerResponse;
@@ -706,7 +708,25 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
   // can't read this value (it's only injected into the preview page's config).
   const execToken = options?.execToken ?? randomBytes(32).toString("base64url");
 
-  return (req: SimReq, res: SimRes, next?: SimNext) => {
+  // Simulator-settings requests run in-process (just the underlying simctl /
+  // ax-tool spawn) instead of round-tripping a full `node <cli>` exec per
+  // sidebar interaction.
+  const handleUiRequest: UiRequestHandler = async (payload) => {
+    const p = (payload ?? {}) as { device?: string; option?: string; value?: string };
+    if (typeof p.device !== "string" || !/^[0-9A-Za-z-]+$/.test(p.device)) {
+      throw new Error("missing or invalid device udid");
+    }
+    if (p.option === undefined) {
+      return { status: await getUiStatus(p.device) };
+    }
+    if (!UI_OPTIONS[p.option]) throw new Error(`unknown option: ${p.option}`);
+    const value = typeof p.value === "string" ? normalizeUiValue(p.option, p.value) : null;
+    if (value === null) throw new Error(`invalid value for ${p.option}: ${p.value}`);
+    await setUiOption(p.device, p.option, value);
+    return { ok: true };
+  };
+
+  const middleware = (req: SimReq, res: SimRes, next?: SimNext) => {
     const rawUrl: string = req.url ?? "";
     const qIndex = rawUrl.indexOf("?");
     const url = qIndex === -1 ? rawUrl : rawUrl.slice(0, qIndex);
@@ -1168,6 +1188,56 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
       return;
     }
 
+    // POST /ui-settings — HTTP fallback for the control-socket `ui` requests
+    // (used when the host server doesn't forward upgrade events). Same
+    // auth/origin gating as /exec.
+    if (url === base + "/ui-settings" && req.method === "POST") {
+      if (!isJsonContentType(req.headers["content-type"])) {
+        res.writeHead(415, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "Unsupported Media Type" }));
+        return;
+      }
+      const uiOrigin = req.headers.origin;
+      if (uiOrigin) {
+        let originOk = false;
+        try {
+          originOk = new URL(uiOrigin).host === req.headers.host;
+        } catch {}
+        if (!originOk) {
+          res.writeHead(403, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "Cross-origin request blocked" }));
+          return;
+        }
+      }
+      const uiAuth = /^Bearer\s+(.+)$/i.exec(req.headers.authorization ?? "");
+      if (!uiAuth || !safeEqualString(uiAuth[1]!.trim(), execToken)) {
+        res.writeHead(401, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "Unauthorized" }));
+        return;
+      }
+      let uiBody = "";
+      req.on("data", (chunk: Buffer | string) => {
+        uiBody += typeof chunk === "string" ? chunk : chunk.toString();
+        if (uiBody.length > 64 * 1024) req.destroy();
+      });
+      req.on("end", () => {
+        let payload: unknown = null;
+        try {
+          payload = JSON.parse(uiBody);
+        } catch {}
+        handleUiRequest(payload)
+          .then((reply) => {
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(JSON.stringify(reply));
+          })
+          .catch((e: unknown) => {
+            res.writeHead(400, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({ error: e instanceof Error ? e.message : String(e) }));
+          });
+      });
+      return;
+    }
+
     // POST /exec — run a shell command on the host. Gated by a per-process
     // bearer token injected only into the same-origin preview HTML, with
     // Content-Type + Origin checks to block CORS-simple CSRF (a malicious
@@ -1390,4 +1460,24 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
     // Not ours — pass through
     if (next) next();
   };
+
+  // WebSocket exec channel — same auth/origin policy as POST /exec, but off
+  // the browser's per-origin HTTP connection pool so multiple preview tabs
+  // (each holding MJPEG + SSE streams) can't starve exec actions. Servers
+  // mounting this middleware should forward `upgrade` events here (the
+  // built-in preview server does); the client falls back to POST /exec when
+  // the upgrade never completes.
+  return Object.assign(middleware, {
+    handleUpgrade: createExecUpgradeHandler({
+      path: `${base}/exec-ws`,
+      execToken,
+      ssePrefixes: [
+        `${base}/api/events`,
+        `${base}/appstate`,
+        `${base}/logs`,
+        `${base}/ax`,
+      ],
+      onUiRequest: handleUiRequest,
+    }),
+  });
 }

--- a/packages/serve-sim/src/middleware.ts
+++ b/packages/serve-sim/src/middleware.ts
@@ -1188,56 +1188,6 @@ export function simMiddleware(options?: SimMiddlewareOptions) {
       return;
     }
 
-    // POST /ui-settings — HTTP fallback for the control-socket `ui` requests
-    // (used when the host server doesn't forward upgrade events). Same
-    // auth/origin gating as /exec.
-    if (url === base + "/ui-settings" && req.method === "POST") {
-      if (!isJsonContentType(req.headers["content-type"])) {
-        res.writeHead(415, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ error: "Unsupported Media Type" }));
-        return;
-      }
-      const uiOrigin = req.headers.origin;
-      if (uiOrigin) {
-        let originOk = false;
-        try {
-          originOk = new URL(uiOrigin).host === req.headers.host;
-        } catch {}
-        if (!originOk) {
-          res.writeHead(403, { "Content-Type": "application/json" });
-          res.end(JSON.stringify({ error: "Cross-origin request blocked" }));
-          return;
-        }
-      }
-      const uiAuth = /^Bearer\s+(.+)$/i.exec(req.headers.authorization ?? "");
-      if (!uiAuth || !safeEqualString(uiAuth[1]!.trim(), execToken)) {
-        res.writeHead(401, { "Content-Type": "application/json" });
-        res.end(JSON.stringify({ error: "Unauthorized" }));
-        return;
-      }
-      let uiBody = "";
-      req.on("data", (chunk: Buffer | string) => {
-        uiBody += typeof chunk === "string" ? chunk : chunk.toString();
-        if (uiBody.length > 64 * 1024) req.destroy();
-      });
-      req.on("end", () => {
-        let payload: unknown = null;
-        try {
-          payload = JSON.parse(uiBody);
-        } catch {}
-        handleUiRequest(payload)
-          .then((reply) => {
-            res.writeHead(200, { "Content-Type": "application/json" });
-            res.end(JSON.stringify(reply));
-          })
-          .catch((e: unknown) => {
-            res.writeHead(400, { "Content-Type": "application/json" });
-            res.end(JSON.stringify({ error: e instanceof Error ? e.message : String(e) }));
-          });
-      });
-      return;
-    }
-
     // POST /exec — run a shell command on the host. Gated by a per-process
     // bearer token injected only into the same-origin preview HTML, with
     // Content-Type + Origin checks to block CORS-simple CSRF (a malicious

--- a/packages/serve-sim/src/runtime.ts
+++ b/packages/serve-sim/src/runtime.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from "url";
 import { dirname } from "path";
 import { createServer as createHttpServer, type IncomingMessage, type ServerResponse } from "http";
 import { createServer as createNetServer } from "net";
+import type { Duplex } from "stream";
 
 export function dirnameOf(metaUrl: string): string {
   return dirname(fileURLToPath(metaUrl));
@@ -28,11 +29,14 @@ export interface PreviewServer {
 }
 
 /** Connect-style middleware signature, matching what `simMiddleware` returns. */
-type ConnectMiddleware = (
+type ConnectMiddleware = ((
   req: IncomingMessage,
   res: ServerResponse,
   next: () => void,
-) => void;
+) => void) & {
+  /** WebSocket upgrade hook (exec channel); returns true when handled. */
+  handleUpgrade?: (req: IncomingMessage, socket: Duplex, head: Buffer) => boolean;
+};
 
 /** Run a Connect-style middleware as an HTTP server. */
 export async function servePreview(opts: {
@@ -51,6 +55,11 @@ export async function servePreview(opts: {
       if (!res.headersSent) res.statusCode = 404;
       res.end("Not found");
     });
+  });
+  // The exec WebSocket channel keeps actions off the browser's per-origin
+  // HTTP connection pool (which the streams below saturate with 2+ tabs).
+  server.on("upgrade", (req, socket, head) => {
+    if (!opts.middleware.handleUpgrade?.(req, socket, head)) socket.destroy();
   });
   // MJPEG streams + SSE log channel are long-lived; clear the default 2-min
   // socket timeout so they don't get torn down mid-stream.

--- a/packages/serve-sim/src/ui-settings.ts
+++ b/packages/serve-sim/src/ui-settings.ts
@@ -1,0 +1,303 @@
+import { execFile } from "child_process";
+import { existsSync } from "fs";
+import { join, resolve } from "path";
+import { findBootedDevice, resolveDevice } from "./device";
+
+// ─── Option catalogue ───
+//
+// Simulator-wide options surfaced in the sidebar, mirroring the Xcode Devices
+// app. Three (`appearance`, `increase-contrast`, `text-size`) ride on
+// `simctl ui`; the rest have no simctl verb, so they go through the
+// sim-ax-settings helper spawned inside the simulator (see
+// Sources/SimAXSettings), which drives the same private libAccessibility /
+// MediaAccessibility setters the Devices app uses.
+
+export const CONTENT_SIZE_CATEGORIES = [
+  "extra-small",
+  "small",
+  "medium",
+  "large",
+  "extra-large",
+  "extra-extra-large",
+  "extra-extra-extra-large",
+  "accessibility-medium",
+  "accessibility-large",
+  "accessibility-extra-large",
+  "accessibility-extra-extra-large",
+  "accessibility-extra-extra-extra-large",
+] as const;
+
+export const COLOR_FILTERS = [
+  "none",
+  "grayscale",
+  "red-green",
+  "green-red",
+  "blue-yellow",
+] as const;
+
+const COLOR_FILTER_ALIASES: Record<string, string> = {
+  protanopia: "red-green",
+  deuteranopia: "green-red",
+  tritanopia: "blue-yellow",
+};
+
+const TOGGLE_VALUES = ["on", "off"] as const;
+
+const ON_SYNONYMS = new Set(["on", "true", "enabled", "1", "yes"]);
+const OFF_SYNONYMS = new Set(["off", "false", "disabled", "0", "no"]);
+
+interface UiOptionSpec {
+  /** `simctl ui` subcommand, or "ax" for the in-sim helper. */
+  via: "appearance" | "increase_contrast" | "content_size" | "ax";
+  values: readonly string[];
+  /** Extra accepted set-values that aren't reported by `get` (text-size). */
+  extraValues?: readonly string[];
+  aliases?: Record<string, string>;
+  toggle?: boolean;
+}
+
+export const UI_OPTIONS: Record<string, UiOptionSpec> = {
+  appearance: { via: "appearance", values: ["light", "dark"] },
+  "liquid-glass": { via: "ax", values: ["clear", "tinted"] },
+  "color-filter": { via: "ax", values: COLOR_FILTERS, aliases: COLOR_FILTER_ALIASES },
+  "text-size": {
+    via: "content_size",
+    values: CONTENT_SIZE_CATEGORIES,
+    extraValues: ["increment", "decrement"],
+  },
+  "reduce-motion": { via: "ax", values: TOGGLE_VALUES, toggle: true },
+  "increase-contrast": { via: "increase_contrast", values: TOGGLE_VALUES, toggle: true },
+  "show-borders": { via: "ax", values: TOGGLE_VALUES, toggle: true },
+  "reduce-transparency": { via: "ax", values: TOGGLE_VALUES, toggle: true },
+  voiceover: { via: "ax", values: TOGGLE_VALUES, toggle: true },
+};
+
+/**
+ * Map a user-supplied value onto its canonical form for the option, or null
+ * when the value isn't valid. Toggles accept the usual on/off synonyms.
+ */
+export function normalizeUiValue(option: string, value: string): string | null {
+  const spec = UI_OPTIONS[option];
+  if (!spec) return null;
+  const v = value.toLowerCase();
+  if (spec.toggle) {
+    if (ON_SYNONYMS.has(v)) return "on";
+    if (OFF_SYNONYMS.has(v)) return "off";
+    return null;
+  }
+  const aliased = spec.aliases?.[v] ?? v;
+  if (spec.values.includes(aliased)) return aliased;
+  if (spec.extraValues?.includes(aliased)) return aliased;
+  return null;
+}
+
+export interface UiArgs {
+  command: "status" | "get" | "set";
+  option?: string;
+  value?: string;
+  device?: string;
+  json: boolean;
+  error?: string;
+}
+
+export function parseUiArgs(args: string[]): UiArgs {
+  const rest: string[] = [];
+  let device: string | undefined;
+  let json = false;
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!;
+    if (a === "-d" || a === "--device") device = args[++i];
+    else if (a === "--json") json = true;
+    else rest.push(a);
+  }
+
+  if (rest.length === 0 || rest[0] === "status") {
+    return { command: "status", json, ...(device ? { device } : {}) };
+  }
+
+  const option = rest[0]!.toLowerCase();
+  if (!UI_OPTIONS[option]) {
+    return { command: "get", json, error: `unknown option: ${option}` };
+  }
+  if (rest.length === 1) {
+    return { command: "get", option, json, ...(device ? { device } : {}) };
+  }
+  const value = normalizeUiValue(option, rest[1]!);
+  if (value === null) {
+    const spec = UI_OPTIONS[option]!;
+    const accepted = [...spec.values, ...(spec.extraValues ?? [])].join("|");
+    return {
+      command: "set",
+      option,
+      json,
+      error: `invalid value for ${option}: ${rest[1]} (accepted: ${accepted})`,
+    };
+  }
+  return { command: "set", option, value, json, ...(device ? { device } : {}) };
+}
+
+// ─── In-sim helper binary ───
+
+export function locateAxSettingsTool(): string | null {
+  const candidates = [
+    join(__dirname, "..", "dist", "simax", "serve-sim-ax-settings"),
+    join(__dirname, "simax", "serve-sim-ax-settings"),
+  ];
+  for (const p of candidates) if (existsSync(p)) return resolve(p);
+  return null;
+}
+
+// One-time build is memoized as a promise so concurrent in-server callers
+// share a single clang invocation instead of racing.
+let axToolPromise: Promise<string> | null = null;
+
+function axSettingsTool(): Promise<string> {
+  axToolPromise ??= (async () => {
+    const located = locateAxSettingsTool();
+    if (located) return located;
+    const buildScript = join(__dirname, "..", "Sources", "SimAXSettings", "build.sh");
+    if (!existsSync(buildScript)) {
+      throw new Error(
+        "sim-ax-settings binary not found — this build of serve-sim does not " +
+          "include the simulator settings helper. Reinstall from a recent release.",
+      );
+    }
+    console.error("[serve-sim] building sim-ax-settings (one-time)…");
+    await run("bash", [buildScript]);
+    const out = locateAxSettingsTool();
+    if (!out) throw new Error("Build succeeded but sim-ax-settings not found.");
+    return out;
+  })();
+  axToolPromise.catch(() => {
+    axToolPromise = null;
+  });
+  return axToolPromise;
+}
+
+// ─── Backends ───
+// Async throughout: these also run inside the preview server's event loop
+// (the sidebar drives them through the control socket), where a blocking
+// execFileSync would stall every stream the server is carrying.
+
+function run(file: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(file, args, { encoding: "utf-8", maxBuffer: 4 * 1024 * 1024 }, (err, stdout, stderr) => {
+      if (err) reject(new Error(String(stderr).trim() || err.message));
+      else resolve(String(stdout).trim());
+    });
+  });
+}
+
+function simctlUi(udid: string, subcommand: string, value?: string): Promise<string> {
+  const args = ["simctl", "ui", udid, subcommand];
+  if (value !== undefined) args.push(value);
+  return run("xcrun", args);
+}
+
+async function axRun(udid: string, ...args: string[]): Promise<string> {
+  const tool = await axSettingsTool();
+  return run("xcrun", ["simctl", "spawn", udid, tool, ...args]);
+}
+
+function toToggle(simctlValue: string): string {
+  return simctlValue === "enabled" ? "on" : "off";
+}
+
+function fromToggle(value: string): string {
+  return value === "on" ? "enabled" : "disabled";
+}
+
+export async function getUiOption(udid: string, option: string): Promise<string> {
+  const spec = UI_OPTIONS[option];
+  if (!spec) throw new Error(`unknown option: ${option}`);
+  if (spec.via === "ax") return axRun(udid, "get", option);
+  // simctl's casing is inconsistent (`content_size` prints "Small" but
+  // "large") — values are canonically lowercase everywhere here.
+  const raw = (await simctlUi(udid, spec.via)).toLowerCase();
+  return spec.toggle ? toToggle(raw) : raw;
+}
+
+export async function setUiOption(udid: string, option: string, value: string): Promise<void> {
+  const spec = UI_OPTIONS[option];
+  if (!spec) throw new Error(`unknown option: ${option}`);
+  if (spec.via === "ax") {
+    await axRun(udid, "set", option, value);
+    return;
+  }
+  await simctlUi(udid, spec.via, spec.toggle ? fromToggle(value) : value);
+}
+
+export async function getUiStatus(udid: string): Promise<Record<string, string>> {
+  // One ax-tool spawn covers all its settings; the simctl-backed reads fan
+  // out in parallel alongside it.
+  const simctlOptions = Object.entries(UI_OPTIONS).filter(([, spec]) => spec.via !== "ax");
+  const [axStatus, ...simctlValues] = await Promise.all([
+    axRun(udid, "status").then((out) => JSON.parse(out) as Record<string, string>),
+    ...simctlOptions.map(([option]) => getUiOption(udid, option)),
+  ]);
+  const status: Record<string, string> = {};
+  for (const [option, spec] of Object.entries(UI_OPTIONS)) {
+    if (spec.via === "ax") status[option] = axStatus[option] ?? "unknown";
+  }
+  simctlOptions.forEach(([option], i) => {
+    status[option] = simctlValues[i]!;
+  });
+  return status;
+}
+
+// ─── CLI entry (`serve-sim ui …`) ───
+
+const USAGE = `Usage: serve-sim ui [status] [--json] [-d udid]
+       serve-sim ui <option> [-d udid]            Print the current value
+       serve-sim ui <option> <value> [-d udid]    Change the value
+
+Simulator-wide UI options:
+  appearance           light | dark
+  liquid-glass         clear | tinted
+  color-filter         none | grayscale | red-green | green-red | blue-yellow
+                       (protanopia/deuteranopia/tritanopia aliases accepted)
+  text-size            ${CONTENT_SIZE_CATEGORIES.slice(0, 4).join(" | ")} | …
+                       (12 content-size categories, or increment | decrement)
+  reduce-motion        on | off
+  increase-contrast    on | off
+  show-borders         on | off
+  reduce-transparency  on | off
+  voiceover            on | off`;
+
+export async function uiSettings(args: string[]): Promise<void> {
+  if (args.includes("-h") || args.includes("--help")) {
+    console.log(USAGE);
+    return;
+  }
+  const parsed = parseUiArgs(args);
+  if (parsed.error) {
+    console.error(parsed.error);
+    console.error(USAGE);
+    process.exit(1);
+  }
+
+  const udid = parsed.device ? resolveDevice(parsed.device) : findBootedDevice();
+  if (!udid) {
+    console.error("No booted simulator found. Boot one or pass -d <udid>.");
+    process.exit(1);
+  }
+
+  if (parsed.command === "status") {
+    const status = await getUiStatus(udid);
+    if (parsed.json) {
+      console.log(JSON.stringify(status));
+    } else {
+      for (const [option, value] of Object.entries(status)) {
+        console.log(`${option.padEnd(20)} ${value}`);
+      }
+    }
+    return;
+  }
+
+  if (parsed.command === "get") {
+    console.log(await getUiOption(udid, parsed.option!));
+    return;
+  }
+
+  await setUiOption(udid, parsed.option!, parsed.value!);
+}

--- a/packages/serve-sim/src/ui-settings.ts
+++ b/packages/serve-sim/src/ui-settings.ts
@@ -106,8 +106,12 @@ export function parseUiArgs(args: string[]): UiArgs {
   let json = false;
   for (let i = 0; i < args.length; i++) {
     const a = args[i]!;
-    if (a === "-d" || a === "--device") device = args[++i];
-    else if (a === "--json") json = true;
+    if (a === "-d" || a === "--device") {
+      if (i + 1 >= args.length) {
+        return { command: "get", json, error: `${a} requires a value` };
+      }
+      device = args[++i];
+    } else if (a === "--json") json = true;
     else rest.push(a);
   }
 


### PR DESCRIPTION
## Summary

- Adds a **Simulator** section to the tools sidebar mirroring the Xcode 26 Devices app: Appearance (Light/Dark), Liquid Glass (Clear/Tinted), Color Filter (protanopia/deuteranopia/tritanopia/grayscale), Text Size slider (7 standard categories with notches + live debounced updates), and toggles for Reduce Motion, Increase Contrast, Show Borders, Reduce Transparency, and VoiceOver.
- New `serve-sim ui <option> [value] [-d udid]` CLI verb. Appearance/contrast/text-size ride on `simctl ui`; the rest drive the same private libAccessibility/MediaAccessibility setters the Devices app uses, via a new `sim-ax-settings` binary (`Sources/SimAXSettings`) spawned inside the simulator, so changes apply live (VoiceOver genuinely launches `com.apple.VoiceOverTouch`).
  - Liquid Glass → `com.apple.UIKit` `UIViewGlassLegibilitySetting` + `UIViewGlassLegibilityUpdateNotification`
  - Color filters → `MADisplayFilterPrefSetType` (grayscale=1, red/green=2, green/red=4, blue/yellow=8, confirmed via disassembly)
- New **WebSocket control channel** (`/exec-ws`): browsers cap HTTP/1.1 at six connections per origin and each preview tab holds several long-lived streams, so pooled `fetch("/exec")` starved with 2+ tabs open (frozen panels, 10s+ stalls). The channel carries shell execs, in-process simulator-settings requests (~390ms vs ~1.2s for a `node <cli>` spawn per update), and multiplexes the SSE side-channels. WS-only by design — no HTTP fallback to hide transport bugs.
- Built on `ws` (new runtime dep, kept external in every bundle): under Bun, `node:http` emits `upgrade` but raw handshake writes never flush, so hand-rolled framing silently hangs; Bun substitutes its native implementation for the `ws` specifier. Verified on node and Bun 1.3.14, including the compiled binary (`--external ws`).
- Tools panel now starts open when the viewport has room; settings rows render disabled (gray, non-interactive) until hydrated and shrink instead of overflowing at narrow panel widths.

## Test plan

- `ui-settings.test.ts` — CLI parser/catalogue unit tests
- `ui-settings.e2e.test.ts` — runs in the existing sim-test.yml flow against a booted sim; asserts each option against the underlying stores (`simctl ui` readback, `defaults read` on com.apple.Accessibility / mediaaccessibility / UIKit)
- `exec-ws.test.ts` — control-channel regression suite (auth, exec round-trip, ui validation, SSE allowlist/streaming) under `bun test`, the runtime where raw framing silently failed
- Browser-verified via agent-browser: every sidebar control round-trips to real sim state; 4 simultaneous tabs hydrate; slider drags apply live with latest-wins ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New serve-sim ui command for inspecting and changing simulator appearance, accessibility, color-filter and text-size options (supports status --json).
  * Added an in-simulator helper CLI and build step to manage AX-backed settings; package now ships compiled helper and WebSocket support.

* **Improvements**
  * Simulator settings panel added to the preview UI with live controls and debounced/latest-wins updates.
  * Unified collapsible tool UI, CSS animations, and tools panel auto-open on wide viewports.
  * WebSocket control channel for command/streaming interactions (exec, UI requests, SSE).

* **Tests**
  * New unit and e2e tests covering UI parsing, settings CLI, exec WebSocket, and end-to-end simulator interactions.

* **Documentation**
  * Docs updated for the new ui subcommand and options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->