### PR TITLE
Screenshot drag-and-drop performance and polish

### DIFF
--- a/packages/serve-sim/src/__tests__/drop-upload.test.ts
+++ b/packages/serve-sim/src/__tests__/drop-upload.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DROP_CHUNK_BYTES,
+  arrayBufferToBase64,
+  uploadDroppedFile,
+  uploadFileToTmp,
+} from "../client/utils/drop";
+import type { ExecResult } from "../client/utils/exec";
+
+const OK: ExecResult = { stdout: "", stderr: "", exitCode: 0 };
+
+function recordingExec(commands: string[]) {
+  return async (command: string): Promise<ExecResult> => {
+    commands.push(command);
+    return OK;
+  };
+}
+
+// Pull the base64 payload back out of a chunk-write command and decode it.
+function decodeChunkCommand(command: string): { bytes: Uint8Array; op: string } {
+  const match = command.match(/^bash -c 'echo ([A-Za-z0-9+/=]+) \| base64 -d (>>?) /);
+  if (!match) throw new Error(`not a chunk write: ${command}`);
+  const bin = atob(match[1]!);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return { bytes, op: match[2]! };
+}
+
+function patternBytes(size: number): Uint8Array<ArrayBuffer> {
+  const bytes = new Uint8Array(new ArrayBuffer(size));
+  for (let i = 0; i < size; i++) bytes[i] = (i * 31 + 7) % 256;
+  return bytes;
+}
+
+describe("arrayBufferToBase64", () => {
+  test("matches btoa for small input", () => {
+    const bytes = new Uint8Array([0, 1, 2, 250, 251, 252, 253, 254, 255]);
+    expect(arrayBufferToBase64(bytes.buffer)).toBe(btoa(String.fromCharCode(...bytes)));
+  });
+
+  test("round-trips across the 32KB block boundary", () => {
+    const bytes = patternBytes(0x8000 * 2 + 13);
+    const decoded = atob(arrayBufferToBase64(bytes.buffer));
+    expect(decoded.length).toBe(bytes.length);
+    for (let i = 0; i < bytes.length; i++) {
+      if (decoded.charCodeAt(i) !== bytes[i]) {
+        throw new Error(`byte ${i} mismatch`);
+      }
+    }
+  });
+});
+
+describe("uploadDroppedFile", () => {
+  test("chunked writes reconstruct the original file, then addmedia + cleanup", async () => {
+    // 2.5 chunks so the loop exercises both the > create and >> append paths.
+    const original = patternBytes(Math.floor(DROP_CHUNK_BYTES * 2.5));
+    const file = new File([original], "shot.png", { type: "image/png" });
+    const commands: string[] = [];
+    const progress: Array<number | null> = [];
+
+    await uploadDroppedFile(file, "media", recordingExec(commands), "UDID", (p) =>
+      progress.push(p),
+    );
+
+    const chunkCommands = commands.filter((c) => c.includes("base64 -d"));
+    expect(chunkCommands.length).toBe(3);
+    expect(decodeChunkCommand(chunkCommands[0]!).op).toBe(">");
+    expect(decodeChunkCommand(chunkCommands[1]!).op).toBe(">>");
+
+    const reassembled = new Uint8Array(original.length);
+    let offset = 0;
+    for (const command of chunkCommands) {
+      const { bytes } = decodeChunkCommand(command);
+      // Each slice is encoded and shipped independently, so no chunk should
+      // ever exceed the slice size (the whole file is never materialized).
+      expect(bytes.length).toBeLessThanOrEqual(DROP_CHUNK_BYTES);
+      reassembled.set(bytes, offset);
+      offset += bytes.length;
+    }
+    expect(offset).toBe(original.length);
+    expect(reassembled).toEqual(original);
+
+    expect(commands.some((c) => c.startsWith("xcrun simctl addmedia UDID "))).toBe(true);
+    expect(commands.some((c) => c.includes("rm -f "))).toBe(true);
+
+    // Progress climbs monotonically, then flips to indeterminate for addmedia.
+    expect(progress[0]).toBe(0);
+    expect(progress[progress.length - 1]).toBeNull();
+    const fractions = progress.filter((p): p is number => p !== null);
+    for (let i = 1; i < fractions.length; i++) {
+      expect(fractions[i]!).toBeGreaterThan(fractions[i - 1]!);
+    }
+    expect(fractions[fractions.length - 1]).toBe(1);
+  });
+
+  test("ipa drops install instead of addmedia", async () => {
+    const file = new File([patternBytes(64)], "app.ipa", { type: "" });
+    const commands: string[] = [];
+    await uploadDroppedFile(file, "ipa", recordingExec(commands), "UDID", () => {});
+    expect(commands.some((c) => c.startsWith("xcrun simctl install UDID "))).toBe(true);
+    expect(commands.some((c) => c.includes("addmedia"))).toBe(false);
+  });
+
+  test("failed chunk write surfaces stderr and still cleans up", async () => {
+    const commands: string[] = [];
+    const exec = async (command: string): Promise<ExecResult> => {
+      commands.push(command);
+      if (command.includes("base64 -d")) {
+        return { stdout: "", stderr: "disk full", exitCode: 1 };
+      }
+      return OK;
+    };
+    const file = new File([patternBytes(64)], "shot.png", { type: "image/png" });
+    await expect(
+      uploadDroppedFile(file, "media", exec, "UDID", () => {}),
+    ).rejects.toThrow("disk full");
+    expect(commands.some((c) => c.includes("rm -f "))).toBe(true);
+  });
+});
+
+describe("uploadFileToTmp", () => {
+  test("stages the file under /tmp with the given prefix and extension", async () => {
+    const original = patternBytes(DROP_CHUNK_BYTES + 100);
+    const file = new File([original], "src.jpg", { type: "image/jpeg" });
+    const commands: string[] = [];
+    const tmpPath = await uploadFileToTmp(file, "serve-sim-camsrc", "jpg", recordingExec(commands));
+    expect(tmpPath).toMatch(/^\/tmp\/serve-sim-camsrc-.*\.jpg$/);
+
+    const chunkCommands = commands.filter((c) => c.includes("base64 -d"));
+    expect(chunkCommands.length).toBe(2);
+    const total = chunkCommands.reduce(
+      (sum, c) => sum + decodeChunkCommand(c).bytes.length,
+      0,
+    );
+    expect(total).toBe(original.length);
+  });
+});

--- a/packages/serve-sim/src/__tests__/screenshot-toast.test.tsx
+++ b/packages/serve-sim/src/__tests__/screenshot-toast.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ScreenshotToast } from "../client/components/screenshot-toast";
+import type { ScreenshotToast as ScreenshotToastState } from "../client/hooks/use-screenshot-toast";
+
+const noop = () => {};
+
+function render(toast: ScreenshotToastState): string {
+  return renderToStaticMarkup(
+    <ScreenshotToast
+      toast={toast}
+      onReveal={noop}
+      onDismiss={noop}
+      onPause={noop}
+      onResume={noop}
+    />,
+  );
+}
+
+describe("ScreenshotToast drag image", () => {
+  test("saved toast with a thumb renders an offscreen drag-image element", () => {
+    const html = render({
+      id: "1",
+      status: "saved",
+      phase: "in",
+      path: "/Users/x/Desktop/shot.png",
+      thumb: "data:image/png;base64,AAAA",
+    });
+    expect(html).toContain('data-testid="drag-image"');
+    // Parked far above the viewport via inline style — a Tailwind class here
+    // can silently miss the build scan, and position:fixed would resolve
+    // against the wrapper's -translate-x-1/2 containing block, both of which
+    // leave the image visible in the page.
+    expect(html).toMatch(/data-testid="drag-image"[^>]*style="[^"]*position:absolute/);
+    expect(html).toMatch(/data-testid="drag-image"[^>]*style="[^"]*top:-9999px/);
+  });
+
+  test("toast without a thumb renders no drag-image element", () => {
+    const html = render({
+      id: "1",
+      status: "saved",
+      phase: "in",
+      path: "/Users/x/Desktop/shot.png",
+    });
+    expect(html).not.toContain('data-testid="drag-image"');
+  });
+});

--- a/packages/serve-sim/src/client/client.tsx
+++ b/packages/serve-sim/src/client/client.tsx
@@ -833,7 +833,10 @@ function AppWithConfig({
           {axOverlayEnabled && <AxDomOverlay />}
           {mediaDrop.isDragOver && (
             <div
-              className="absolute inset-0 flex flex-col items-center justify-center gap-2 border-2 border-dashed border-accent bg-[rgba(99,102,241,0.12)] backdrop-blur-[2px] text-accent pointer-events-none z-20"
+              // No backdrop-blur here: the canvas underneath repaints every
+              // stream frame, and backdrop-filter forces a full re-blur per
+              // frame for the whole drag — the tint alone stays cheap.
+              className="absolute inset-0 flex flex-col items-center justify-center gap-2 border-2 border-dashed border-accent bg-[rgba(99,102,241,0.18)] text-accent pointer-events-none z-20"
               style={{ borderRadius: imgBorderRadius }}
             >
               <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">

--- a/packages/serve-sim/src/client/components/screenshot-toast.tsx
+++ b/packages/serve-sim/src/client/components/screenshot-toast.tsx
@@ -1,4 +1,4 @@
-import type { DragEvent } from "react";
+import { useRef, useState, type DragEvent } from "react";
 import type { ScreenshotToast as ScreenshotToastState } from "../hooks/use-screenshot-toast";
 import { DROP_HOST_PATH_TYPE } from "../utils/drop";
 
@@ -23,6 +23,8 @@ export function ScreenshotToast({
   onPause,
   onResume,
 }: ScreenshotToastProps) {
+  const [dragging, setDragging] = useState(false);
+  const dragImageRef = useRef<HTMLImageElement | null>(null);
   const leaving = toast.phase === "out";
   const animClass = leaving
     ? "animate-[serve-sim-toast-pop-out_0.2s_ease-in_forwards]"
@@ -48,6 +50,19 @@ export function ScreenshotToast({
     // Dropping onto the simulator adds the screenshot to Photos in place.
     e.dataTransfer.setData(DROP_HOST_PATH_TYPE, toast.path);
     e.dataTransfer.effectAllowed = "copy";
+    // Drag the thumbnail, not a snapshot of the pill — the snapshot clips the
+    // pill's box-shadow at its rounded corners.
+    const img = dragImageRef.current;
+    if (img) e.dataTransfer.setDragImage(img, img.offsetWidth / 2, img.offsetHeight / 2);
+    // Hide the pill so the drag image is the only visible instance. Deferred a
+    // frame: the browser captures the drag image synchronously on dragstart,
+    // and hiding the source now would capture a blank.
+    requestAnimationFrame(() => setDragging(true));
+  };
+
+  const handleDragEnd = () => {
+    setDragging(false);
+    onResume();
   };
 
   return (
@@ -56,6 +71,32 @@ export function ScreenshotToast({
       onMouseEnter={onPause}
       onMouseLeave={onResume}
     >
+      {/* Offscreen source for setDragImage. Must stay rendered (not
+          display:none) or the browser captures nothing; parked far above the
+          viewport instead. Absolute, not fixed: the wrapper's -translate-x-1/2
+          makes it the containing block for fixed descendants, which would put
+          a "fixed" image right back into the page. Inline styles, not
+          Tailwind, so the class scan can never miss them. */}
+      {toast.thumb && (
+        <img
+          ref={dragImageRef}
+          data-testid="drag-image"
+          src={toast.thumb}
+          alt=""
+          aria-hidden
+          draggable={false}
+          style={{
+            position: "absolute",
+            top: -9999,
+            left: 0,
+            width: 80,
+            height: 80,
+            borderRadius: 12,
+            objectFit: "cover",
+            pointerEvents: "none",
+          }}
+        />
+      )}
       <div className={animClass} onAnimationEnd={handleAnimationEnd}>
         {toast.status === "error" ? (
           <div className="flex items-center gap-2 px-3.5 py-2.5 bg-panel border border-white/12 rounded-xl text-white/90 text-[12px] shadow-[0_8px_24px_rgba(0,0,0,0.45)]">
@@ -69,10 +110,10 @@ export function ScreenshotToast({
             disabled={toast.status !== "saved"}
             draggable={toast.status === "saved"}
             onDragStart={handleDragStart}
-            onDragEnd={onResume}
+            onDragEnd={handleDragEnd}
             aria-label="Open screenshot in Finder"
             title="Click to reveal in Finder · drag to copy the file"
-            className="group flex items-center gap-3 pl-2 pr-3.5 py-2 bg-panel border border-white/12 rounded-xl shadow-[0_8px_24px_rgba(0,0,0,0.45)] text-left cursor-pointer enabled:hover:bg-[#2a2a2c] disabled:cursor-default [transition:background_0.15s_ease]"
+            className={`group flex items-center gap-3 pl-2 pr-3.5 py-2 bg-panel border border-white/12 rounded-xl shadow-[0_8px_24px_rgba(0,0,0,0.45)] text-left cursor-pointer enabled:hover:bg-[#2a2a2c] disabled:cursor-default [transition:background_0.15s_ease] ${dragging ? "invisible" : ""}`}
           >
             <div className="size-9 rounded-md overflow-hidden bg-white/10 shrink-0 flex items-center justify-center ring-1 ring-white/10 pointer-events-none">
               {toast.thumb ? (

--- a/packages/serve-sim/src/client/hooks/use-screenshot-toast.ts
+++ b/packages/serve-sim/src/client/hooks/use-screenshot-toast.ts
@@ -15,9 +15,10 @@ export type ScreenshotToast = {
   message?: string;
 };
 
-// How long the success pill lingers before auto-dismissing. Long enough to
-// give the user a chance to click "Open in Finder" without it nagging forever.
-const SAVED_DISMISS_MS = 6000;
+// How long the success pill lingers before auto-dismissing. Hovering pauses
+// the timer, so this only needs to be long enough to notice the pill — not to
+// read and act on it.
+const SAVED_DISMISS_MS = 3500;
 const ERROR_DISMISS_MS = 4000;
 
 function timestampSlug(): string {

--- a/packages/serve-sim/src/client/utils/drop.ts
+++ b/packages/serve-sim/src/client/utils/drop.ts
@@ -19,10 +19,11 @@ export const DROP_MEDIA_MIME_TYPES = new Set([
   "video/quicktime",
 ]);
 
-// 256KB per chunk. macOS ARG_MAX is 1MB, so this leaves generous headroom
-// for the bash/echo wrapper while sharply cutting round-trips on large .ipa
-// uploads (100MB → ~400 calls instead of ~3200 at 32KB).
-export const DROP_CHUNK_SIZE = 262144;
+// 192KB of raw bytes per chunk → ~256KB of base64 per exec. macOS ARG_MAX is
+// 1MB, so this leaves generous headroom for the bash/echo wrapper while
+// sharply cutting round-trips on large .ipa uploads. Each chunk is decoded by
+// its own `base64 -d`, so chunks are independent of each other.
+export const DROP_CHUNK_BYTES = 196608;
 export const DROP_MAX_FILE_SIZE = 500 * 1024 * 1024;
 
 // Custom drag flavor carrying a path that already exists on the host (e.g. the
@@ -62,8 +63,41 @@ export function dropKindFor(file: File): DropKind | null {
 export function arrayBufferToBase64(buffer: ArrayBuffer): string {
   const bytes = new Uint8Array(buffer);
   let binary = "";
-  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]!);
+  // 32KB blocks keep fromCharCode's argument count under engine limits while
+  // avoiding a per-byte concat loop that stalls the main thread on big files.
+  for (let i = 0; i < bytes.length; i += 0x8000) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + 0x8000));
+  }
   return btoa(binary);
+}
+
+// Stream `file` into `tmpPath` one slice at a time. Reading and encoding per
+// slice (instead of base64ing the whole file up front) keeps peak memory at
+// one chunk regardless of file size and never blocks the main thread long
+// enough to stall the simulator stream.
+async function streamFileToHostPath(
+  file: File,
+  tmpPath: string,
+  exec: (command: string) => Promise<ExecResult>,
+  onProgress?: (fraction: number) => void,
+): Promise<void> {
+  let lastReportedPct = 0;
+  for (let offset = 0; offset < file.size; offset += DROP_CHUNK_BYTES) {
+    const slice = await file.slice(offset, offset + DROP_CHUNK_BYTES).arrayBuffer();
+    const chunk = arrayBufferToBase64(slice);
+    const op = offset === 0 ? ">" : ">>";
+    const result = await exec(`bash -c 'echo ${chunk} | base64 -d ${op} ${tmpPath}'`);
+    if (result.exitCode !== 0) {
+      throw new Error(result.stderr || `Write failed (exit ${result.exitCode})`);
+    }
+    if (!onProgress) continue;
+    const written = Math.min(offset + DROP_CHUNK_BYTES, file.size);
+    const pct = Math.floor((written / file.size) * 100);
+    if (pct !== lastReportedPct) {
+      lastReportedPct = pct;
+      onProgress(written / file.size);
+    }
+  }
 }
 
 // Stream a file to /tmp via the /exec base64 chunk loop. Used by the camera
@@ -79,16 +113,7 @@ export async function uploadFileToTmp(
     throw new Error("File too large (max 500MB)");
   }
   const tmpPath = `/tmp/${prefix}-${crypto.randomUUID()}.${ext}`;
-  const buffer = await file.arrayBuffer();
-  const b64 = arrayBufferToBase64(buffer);
-  for (let offset = 0; offset < b64.length; offset += DROP_CHUNK_SIZE) {
-    const chunk = b64.slice(offset, offset + DROP_CHUNK_SIZE);
-    const op = offset === 0 ? ">" : ">>";
-    const result = await exec(`bash -c 'echo ${chunk} | base64 -d ${op} ${tmpPath}'`);
-    if (result.exitCode !== 0) {
-      throw new Error(result.stderr || `Write failed (exit ${result.exitCode})`);
-    }
-  }
+  await streamFileToHostPath(file, tmpPath, exec);
   return tmpPath;
 }
 
@@ -109,24 +134,7 @@ export async function uploadDroppedFile(
 
   try {
     onProgress(0);
-    const buffer = await file.arrayBuffer();
-    const b64 = arrayBufferToBase64(buffer);
-
-    let lastReportedPct = 0;
-    for (let offset = 0; offset < b64.length; offset += DROP_CHUNK_SIZE) {
-      const chunk = b64.slice(offset, offset + DROP_CHUNK_SIZE);
-      const op = offset === 0 ? ">" : ">>";
-      const result = await exec(`bash -c 'echo ${chunk} | base64 -d ${op} ${tmpPath}'`);
-      if (result.exitCode !== 0) {
-        throw new Error(result.stderr || `Write failed (exit ${result.exitCode})`);
-      }
-      const written = Math.min(offset + DROP_CHUNK_SIZE, b64.length);
-      const pct = Math.floor((written / b64.length) * 100);
-      if (pct !== lastReportedPct) {
-        lastReportedPct = pct;
-        onProgress(written / b64.length);
-      }
-    }
+    await streamFileToHostPath(file, tmpPath, exec, onProgress);
 
     // install/addmedia gives no progress signal — flip to indeterminate.
     onProgress(null);


### PR DESCRIPTION
## Summary

Fixes the lag when dragging the screenshot pill (or files) over the simulator, plus drag-image polish:

- **Drop overlay**: removed `backdrop-blur` over the live stream canvas — backdrop-filter forced a full re-blur on every stream frame for the whole drag. Tint bumped 0.12 → 0.18 to keep the drop target visible.
- **File uploads stream slice-by-slice**: drops of OS files no longer read the whole file into memory and base64 it in one synchronous pass (which froze the page and peaked at ~3× file size, up to ~1.5GB at the 500MB cap). Uploads now read/encode one 192KB slice at a time with block-wise `fromCharCode`; wire format unchanged.
- **Drag image**: dragging the pill now shows an 80px rounded thumbnail via `setDragImage` instead of a snapshot of the pill (whose box-shadow clipped at the rounded corners), and the pill hides while dragging so there's only one visible instance. The offscreen `setDragImage` source uses inline `position:absolute; top:-9999px` — `fixed` would resolve against the wrapper's `-translate-x-1/2` containing block and land visibly in the page, and Tailwind arbitrary classes can miss the build scan.
- **Auto-dismiss**: success pill lingers 3.5s instead of 6s (hover/drag still pause the timer).

## Tests

- `drop-upload.test.ts`: chunked writes reconstruct the file byte-for-byte, `>`/`>>` ordering, addmedia vs install, cleanup on failure, monotonic progress, base64 block-boundary round-trip.
- `screenshot-toast.test.tsx`: drag-image element renders only with a thumb and is pinned offscreen via inline style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced screenshot drag-and-copy functionality with improved drag preview rendering

* **Improvements**
  * Refined drag-over overlay styling for enhanced visual clarity
  * Reduced screenshot notification auto-dismiss duration for quicker feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->