### PR TITLE
Gate simulator settings panel to iOS simulators

### DIFF
--- a/packages/serve-sim/src/__tests__/simulator-settings-tool.test.tsx
+++ b/packages/serve-sim/src/__tests__/simulator-settings-tool.test.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { isIosRuntime } from "../client/components/simulator-settings-tool";
+
+// The in-sim settings helper is an iOS-simulator Mach-O; spawning it inside a
+// watchOS / tvOS / visionOS runtime aborts in dyld. The panel gates on the
+// device runtime so non-iOS devices never trigger that spawn.
+describe("isIosRuntime", () => {
+  test("iOS runtimes are supported", () => {
+    expect(isIosRuntime("iOS-26-5")).toBe(true);
+    expect(isIosRuntime("iOS-18-0")).toBe(true);
+  });
+
+  test("non-iOS runtimes are unsupported", () => {
+    expect(isIosRuntime("watchOS-11-2")).toBe(false);
+    expect(isIosRuntime("tvOS-18-0")).toBe(false);
+    expect(isIosRuntime("xrOS-2-0")).toBe(false);
+    expect(isIosRuntime("visionOS-2-0")).toBe(false);
+  });
+
+  test("unknown/null runtime falls back to supported so the panel still renders", () => {
+    expect(isIosRuntime(null)).toBe(true);
+    expect(isIosRuntime("")).toBe(true);
+  });
+});

--- a/packages/serve-sim/src/client/client.tsx
+++ b/packages/serve-sim/src/client/client.tsx
@@ -1164,6 +1164,7 @@ function AppWithConfig({
         open={panelOpen}
         onClose={() => setPanelOpen(false)}
         udid={config.device}
+        deviceRuntime={deviceRuntime}
         currentApp={currentApp}
         axOverlayEnabled={axOverlayEnabled}
         onToggleAxOverlay={() => setAxOverlayEnabled((enabled) => !enabled)}

--- a/packages/serve-sim/src/client/components/simulator-settings-tool.tsx
+++ b/packages/serve-sim/src/client/components/simulator-settings-tool.tsx
@@ -7,6 +7,7 @@ import {
   type ReactNode,
 } from "react";
 import { hostUiRequest } from "../utils/exec";
+import { parseRuntime } from "../utils/grid";
 import { CollapsibleSection } from "./collapsible-section";
 import { Select } from "./select";
 import { SettingSwitch } from "./setting-switch";
@@ -275,11 +276,27 @@ const I = {
   ),
 };
 
-export function SimulatorSettingsTool({ udid }: { udid: string }) {
+// These options drive the iOS accessibility/appearance setters; the in-sim
+// helper is an iOS-simulator binary, so the panel only applies to iOS devices.
+// (`runtime` arrives as `iOS-26-5` / `watchOS-11-2` — simctl's SimRuntime
+// suffix.) Treat an unknown runtime as iOS so the panel still renders.
+export function isIosRuntime(runtime: string | null): boolean {
+  if (!runtime) return true;
+  return parseRuntime(runtime).os.toLowerCase() === "ios";
+}
+
+export function SimulatorSettingsTool({
+  udid,
+  runtime,
+}: {
+  udid: string;
+  runtime: string | null;
+}) {
   const [open, setOpen] = useState(true);
   const [state, setState] = useState<SettingsState | null>(null);
   const [pending, setPending] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const supported = isIosRuntime(runtime);
 
   // Hydration can fail outright (server restarted under the tab, control
   // socket unreachable) or stall — both must land in the error state with a
@@ -306,8 +323,11 @@ export function SimulatorSettingsTool({ udid }: { udid: string }) {
 
   useEffect(() => {
     setState(null);
+    // The in-sim helper can't run on non-iOS runtimes; skip the round-trip
+    // (it would spawn an iOS binary inside e.g. a watchOS sim and abort).
+    if (!supported) return;
     void refresh();
-  }, [refresh]);
+  }, [refresh, supported]);
 
   const apply = useCallback(
     async (option: string, value: string) => {
@@ -382,6 +402,12 @@ export function SimulatorSettingsTool({ udid }: { udid: string }) {
         </>
       }
     >
+      {!supported ? (
+        <div className="text-white/45 text-[11px] px-0.5 py-1">
+          Simulator settings are available on iOS simulators only.
+        </div>
+      ) : (
+        <>
       {error && (
         <div className="bg-danger/10 border border-danger/20 text-danger-soft text-[11px] px-2 py-1.5 rounded-md flex items-center justify-between gap-2">
           <span className="min-w-0">{error}</span>
@@ -459,6 +485,8 @@ export function SimulatorSettingsTool({ udid }: { udid: string }) {
             </SettingRow>
           ))}
         </div>
+        </>
+      )}
     </CollapsibleSection>
   );
 }

--- a/packages/serve-sim/src/client/components/tools-panel.tsx
+++ b/packages/serve-sim/src/client/components/tools-panel.tsx
@@ -11,6 +11,7 @@ export function ToolsPanel({
   open,
   onClose,
   udid,
+  deviceRuntime,
   currentApp,
   axOverlayEnabled,
   onToggleAxOverlay,
@@ -19,6 +20,7 @@ export function ToolsPanel({
   open: boolean;
   onClose: () => void;
   udid: string;
+  deviceRuntime: string | null;
   currentApp: { bundleId: string; isReactNative: boolean; pid?: number } | null;
   axOverlayEnabled: boolean;
   onToggleAxOverlay: () => void;
@@ -34,7 +36,7 @@ export function ToolsPanel({
       {open && (
         <div className="p-3.5 overflow-y-auto flex-1 flex flex-col gap-3">
           <AppDetectionTool udid={udid} currentApp={currentApp} />
-          <SimulatorSettingsTool udid={udid} />
+          <SimulatorSettingsTool udid={udid} runtime={deviceRuntime} />
           <AxTreeTool
             overlayEnabled={axOverlayEnabled}
             onToggleOverlay={onToggleAxOverlay}

--- a/packages/serve-sim/src/ui-settings.ts
+++ b/packages/serve-sim/src/ui-settings.ts
@@ -239,15 +239,21 @@ export async function setUiOption(udid: string, option: string, value: string): 
 
 export async function getUiStatus(udid: string): Promise<Record<string, string>> {
   // One ax-tool spawn covers all its settings; the simctl-backed reads fan
-  // out in parallel alongside it.
+  // out in parallel alongside it. The ax helper is an iOS-simulator Mach-O, so
+  // on watchOS / tvOS / visionOS the spawn aborts in dyld — degrade those
+  // options to "unsupported" instead of failing the whole panel. (The web UI
+  // also gates the panel on the device runtime, so this is the backstop for
+  // direct callers.)
   const simctlOptions = Object.entries(UI_OPTIONS).filter(([, spec]) => spec.via !== "ax");
   const [axStatus, ...simctlValues] = await Promise.all([
-    axRun(udid, "status").then((out) => JSON.parse(out) as Record<string, string>),
-    ...simctlOptions.map(([option]) => getUiOption(udid, option)),
+    axRun(udid, "status")
+      .then((out) => JSON.parse(out) as Record<string, string>)
+      .catch(() => ({}) as Record<string, string>),
+    ...simctlOptions.map(([option]) => getUiOption(udid, option).catch(() => "unsupported")),
   ]);
   const status: Record<string, string> = {};
   for (const [option, spec] of Object.entries(UI_OPTIONS)) {
-    if (spec.via === "ax") status[option] = axStatus[option] ?? "unknown";
+    if (spec.via === "ax") status[option] = axStatus[option] ?? "unsupported";
   }
   simctlOptions.forEach(([option], i) => {
     status[option] = simctlValues[i]!;


### PR DESCRIPTION
# Why

Starting an Apple Watch (or any non-iOS) simulator made the SIMULATOR tools panel throw:

```
dyld[…]: Library not loaded: …/CoreFoundation
  … (have 'watchOS-simulator', need 'iOS-simulator')
Child process terminated with signal 6: Abort trap
```

The in-sim settings helper (`dist/simax/serve-sim-ax-settings`) is built as an iOS-simulator Mach-O. The settings panel loads its state by spawning that binary inside the selected simulator via `simctl spawn`. On a watchOS/tvOS/visionOS runtime, dyld resolves CoreFoundation from that runtime's RuntimeRoot, hits a platform mismatch, and aborts (signal 6) — surfacing as a panel error. Those settings (appearance, liquid glass, color filter, accessibility toggles) are iOS-only concepts anyway.

# How

- Gate the panel on the device runtime, which the client already receives per device from `/grid/api` (no extra `simctl list`). Threaded `deviceRuntime` through `ToolsPanel` into `SimulatorSettingsTool`; on a non-iOS runtime it skips the host round-trip entirely and shows a short "available on iOS simulators only" note.
- Hardened the server as a backstop: `getUiStatus()` now catches a failed ax-helper spawn (and individual simctl reads) and reports those options as `unsupported` instead of letting the SIGABRT fail the whole request — covering any direct CLI/endpoint caller targeting a non-iOS device.

# Test Plan

- Added `simulator-settings-tool.test.tsx` covering `isIosRuntime` classification (iOS supported; watchOS/tvOS/xrOS/visionOS unsupported; null/unknown falls back to supported so the panel still renders).
- `bunx tsc --noEmit` clean.
- Existing `ui-settings.test.ts` still green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Simulator settings now adapt based on device runtime, displaying only on iOS simulators.

* **Improvements**
  * Enhanced error handling for non-iOS simulator types (watchOS, tvOS, xrOS, visionOS).
  * Unsupported simulators display a clear "available on iOS simulators only" message.
  * More robust fallback behavior when helper tools fail to initialize.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->