### PR TITLE
Add stream codec control with auto-downgrade on decoder error

### DIFF
--- a/packages/serve-sim-client/src/simulator/SimulatorView.tsx
+++ b/packages/serve-sim-client/src/simulator/SimulatorView.tsx
@@ -85,6 +85,12 @@ export interface SimulatorViewProps {
    * `useAvcc` and `useAvccStream` only need `url` to read `/stream.avcc`.
    */
   codec?: "mjpeg" | "avcc";
+  /**
+   * Called when the AVCC (H.264) WebCodecs decoder fails fatally, so the parent
+   * can downgrade to MJPEG instead of retrying hardware decode forever. Fires
+   * only on the AVCC path; inert under MJPEG.
+   */
+  onAvccError?: () => void;
 }
 
 /**
@@ -117,6 +123,7 @@ export function SimulatorView({
   onStreamingChange,
   connectionQuality,
   codec = "avcc",
+  onAvccError,
 }: SimulatorViewProps) {
   const relayMode = !!onStreamTouch;
   // AVCC decode is independent of input relay: the H.264 pipeline only needs
@@ -312,6 +319,7 @@ export function SimulatorView({
     onFirstFrame: onAvccFirstFrame,
     onFrame: onAvccFrame,
     onError: setError,
+    onDecoderError: onAvccError,
   });
 
   const sendTouch = useCallback(

--- a/packages/serve-sim-client/src/simulator/use-avcc-stream.ts
+++ b/packages/serve-sim-client/src/simulator/use-avcc-stream.ts
@@ -19,6 +19,15 @@ export interface UseAvccStreamOptions {
   onFrame?: () => void;
   /** Called with a human-readable message when the decode pipeline fails. */
   onError?: (message: string) => void;
+  /**
+   * Called when the WebCodecs decoder itself fails fatally (a `VideoDecoder`
+   * `error` event or a `configure()` throw) — as opposed to a network/stream
+   * hiccup. When provided it *replaces* {@link onError} for these failures: the
+   * consumer is expected to downgrade to MJPEG (hardware H.264 decode is no
+   * longer viable — e.g. a screen recorder starving VideoToolbox), so the
+   * failure is recovered from rather than surfaced as a user-facing error.
+   */
+  onDecoderError?: () => void;
 }
 
 const RETRY_DELAY_MS = 1000;
@@ -41,10 +50,11 @@ export function useAvccStream({
   onFirstFrame,
   onFrame,
   onError,
+  onDecoderError,
 }: UseAvccStreamOptions): void {
   // Latest-callback ref: keeps the decode effect off the callback identities.
-  const callbacks = useRef({ onFirstFrame, onFrame, onError });
-  callbacks.current = { onFirstFrame, onFrame, onError };
+  const callbacks = useRef({ onFirstFrame, onFrame, onError, onDecoderError });
+  callbacks.current = { onFirstFrame, onFrame, onError, onDecoderError };
 
   useEffect(() => {
     if (!enabled || !url || !isAvccSupported()) return;
@@ -58,6 +68,14 @@ export function useAvccStream({
     let decoder: VideoDecoder | null = null;
 
     const isLive = () => !stopped && !controller.signal.aborted;
+
+    // A fatal decode failure routes to onDecoderError (downgrade to MJPEG) when
+    // a handler is wired, else surfaces as a user-facing error. Routing to both
+    // would flash a red overlay over the stream the parent is about to recover.
+    const reportDecodeFailure = (message: string) => {
+      if (callbacks.current.onDecoderError) callbacks.current.onDecoderError();
+      else callbacks.current.onError?.(message);
+    };
 
     const paint = (source: CanvasImageSource, width: number, height: number) => {
       if (!isLive()) return;
@@ -86,7 +104,7 @@ export function useAvccStream({
             frame.close();
           }
         },
-        error: (err) => callbacks.current.onError?.(`decoder: ${err.message}`),
+        error: (err) => reportDecodeFailure(`decoder: ${err.message}`),
       });
 
     const paintSeed = async (jpeg: Uint8Array) => {
@@ -112,7 +130,7 @@ export function useAvccStream({
           hardwareAcceleration: "prefer-hardware",
         } as VideoDecoderConfig & { optimizeFor: "latency" });
       } catch (err) {
-        callbacks.current.onError?.(`config: ${(err as Error).message}`);
+        reportDecodeFailure(`config: ${(err as Error).message}`);
       }
     };
 

--- a/packages/serve-sim/src/__tests__/avcc-fallback.test.ts
+++ b/packages/serve-sim/src/__tests__/avcc-fallback.test.ts
@@ -33,6 +33,14 @@ describe("avccFallbackReducer", () => {
     expect(run(["frame", "timeout", "timeout"]).fellBack).toBe(false);
   });
 
+  test("error downgrades a working stream where timeout does not", () => {
+    // The one behaviour that distinguishes the two: a transient stall (timeout)
+    // keeps a stream that already painted frames, but a fatal decoder error
+    // (e.g. a screen recorder starving VideoToolbox) downgrades it to MJPEG.
+    expect(run(["frame", "timeout"]).fellBack).toBe(false);
+    expect(run(["frame", "error"]).fellBack).toBe(true);
+  });
+
   test("reset re-arms AVCC after a device switch / reconnect", () => {
     const fellBack = run(["timeout"]);
     expect(fellBack.fellBack).toBe(true);

--- a/packages/serve-sim/src/client/avcc-fallback.ts
+++ b/packages/serve-sim/src/client/avcc-fallback.ts
@@ -26,6 +26,13 @@ export type AvccFallbackEvent =
   | "frame"
   /** The startup window elapsed; fall back unless a frame already arrived. */
   | "timeout"
+  /**
+   * The WebCodecs decoder failed fatally mid-stream. Unlike `timeout`, this
+   * downgrades even after AVCC was working — hardware H.264 decode is no longer
+   * viable (e.g. a screen recorder is starving VideoToolbox), so retrying it
+   * just loops.
+   */
+  | "error"
   /** Target stream changed (device switch / reconnect) — re-arm AVCC. */
   | "reset";
 
@@ -48,6 +55,10 @@ export function avccFallbackReducer(
       return state.streamed || state.fellBack
         ? state
         : { ...state, fellBack: true };
+    case "error":
+      // A fatal decoder error downgrades unconditionally — even mid-stream
+      // after frames were flowing, since hardware decode just failed.
+      return state.fellBack ? state : { ...state, fellBack: true };
     case "reset":
       return initialAvccFallback;
   }

--- a/packages/serve-sim/src/client/client.tsx
+++ b/packages/serve-sim/src/client/client.tsx
@@ -38,6 +38,10 @@ import { ScreenshotToast } from "./components/screenshot-toast";
 import { SimulatorResizeSizeBadge } from "./components/simulator-resize-size-badge";
 import { StreamStatusPill } from "./components/stream-status-pill";
 import { ToolsPanel } from "./components/tools-panel";
+import {
+  CODEC_PREFERENCE_STORAGE_KEY,
+  type CodecPreference,
+} from "./components/stream-settings-tool";
 import { WebKitDevtoolsPanel } from "./components/webkit-devtools-panel";
 import { useMediaDrop } from "./hooks/use-media-drop";
 import { useMjpegStream } from "./hooks/use-mjpeg-stream";
@@ -465,7 +469,19 @@ function AppWithConfig({
   const [forceMjpeg] = useState(
     () => new URLSearchParams(window.location.search).get("codec") === "mjpeg",
   );
-  const useAvccVideo = avcc.supported && !avccFallback.fellBack && !preferMjpeg && !forceMjpeg;
+  // User-selectable codec preference (Video section of the tools panel). "mjpeg"
+  // forces the software path; the H.264 hardware decoder shares the GPU's
+  // VideoToolbox pipeline with screen recorders, so MJPEG is the fix when the
+  // stream stutters/drops while recording the browser window. Persisted so the
+  // choice survives reloads.
+  const [codecPreference, setCodecPreference] = useState<CodecPreference>(
+    () => (window.localStorage.getItem(CODEC_PREFERENCE_STORAGE_KEY) === "mjpeg" ? "mjpeg" : "auto"),
+  );
+  useEffect(() => {
+    window.localStorage.setItem(CODEC_PREFERENCE_STORAGE_KEY, codecPreference);
+  }, [codecPreference]);
+  const useAvccVideo =
+    avcc.supported && !avccFallback.fellBack && !preferMjpeg && !forceMjpeg && codecPreference !== "mjpeg";
   const mjpeg = useMjpegStream(useAvccVideo ? null : config.streamUrl);
 
   // Re-arm AVCC whenever the target stream changes (device switch / reconnect).
@@ -960,6 +976,7 @@ function AppWithConfig({
                 onStreamDigitalCrown={onStreamDigitalCrown}
                 onStreamScroll={onStreamScroll}
                 codec={useAvccVideo ? "avcc" : "mjpeg"}
+                onAvccError={() => dispatchAvccFallback("error")}
                 subscribeFrame={useAvccVideo ? undefined : mjpeg.subscribeFrame}
                 streamFrame={useAvccVideo ? undefined : mjpeg.frame}
                 streamConfig={activeStreamConfig}
@@ -1193,6 +1210,10 @@ function AppWithConfig({
         currentApp={currentApp}
         axOverlayEnabled={axOverlayEnabled}
         onToggleAxOverlay={() => setAxOverlayEnabled((enabled) => !enabled)}
+        codecPreference={codecPreference}
+        onCodecPreferenceChange={setCodecPreference}
+        activeCodec={useAvccVideo ? "h264" : "mjpeg"}
+        avccSupported={avcc.supported}
         width={toolsPanelWidth}
       />
       <ResizeHandle

--- a/packages/serve-sim/src/client/components/simulator-settings-tool.tsx
+++ b/packages/serve-sim/src/client/components/simulator-settings-tool.tsx
@@ -75,7 +75,7 @@ const TOGGLE_OPTIONS = [
   { key: "voiceover", label: "VoiceOver" },
 ] as const;
 
-function SettingRow({
+export function SettingRow({
   icon,
   label,
   children,
@@ -187,7 +187,7 @@ function TextSizeSlider({
   );
 }
 
-function SettingSelect({
+export function SettingSelect({
   label,
   value,
   options,

--- a/packages/serve-sim/src/client/components/stream-settings-tool.tsx
+++ b/packages/serve-sim/src/client/components/stream-settings-tool.tsx
@@ -25,6 +25,13 @@ const VideoIcon = (
   </svg>
 );
 
+/**
+ * Tools-panel section letting the viewer pick the stream codec (H.264 vs MJPEG)
+ * and explaining the trade-off. The control reflects the effective codec —
+ * pinned to MJPEG when the browser can't decode H.264, and surfacing when an
+ * "auto" preference was downgraded mid-stream — so it never misrepresents what
+ * is actually painting.
+ */
 export function StreamSettingsTool({
   preference,
   onPreferenceChange,

--- a/packages/serve-sim/src/client/components/stream-settings-tool.tsx
+++ b/packages/serve-sim/src/client/components/stream-settings-tool.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { CollapsibleSection } from "./collapsible-section";
-import { Select } from "./select";
+import { SettingRow, SettingSelect } from "./simulator-settings-tool";
 
 // Client-side video preference. "auto" decodes H.264 (AVCC via WebCodecs) when
 // the browser supports it; "mjpeg" forces the software JPEG path. H.264 decode
@@ -46,7 +46,9 @@ export function StreamSettingsTool({
   const value: CodecPreference = avccSupported ? preference : "mjpeg";
   // Auto resolved to MJPEG (startup fallback or a helper that doesn't serve
   // /stream.avcc) — surface it so the picker doesn't lie about what's on screen.
-  const downgraded = avccSupported && preference === "auto" && activeCodec === "mjpeg";
+  // `value` is already pinned to "mjpeg" when unsupported, so "auto" here implies
+  // the browser can decode H.264 but this stream fell back anyway.
+  const downgraded = value === "auto" && activeCodec === "mjpeg";
 
   return (
     <CollapsibleSection
@@ -64,22 +66,15 @@ export function StreamSettingsTool({
       }
     >
       <div className="flex flex-col gap-1.5 pb-1.5">
-        <div className="flex items-center justify-between gap-2 min-h-[30px]" data-setting-row="Codec">
-          <span className="flex shrink-0 items-center gap-2 text-[12px] text-white/90 whitespace-nowrap">
-            <span className="flex size-[18px] items-center justify-center text-white">{VideoIcon}</span>
-            Codec
-          </span>
-          <span className="flex min-w-0 justify-end">
-            <Select
-              label="Codec"
-              value={value}
-              options={CODEC_OPTIONS}
-              disabled={!avccSupported}
-              onChange={(v) => onPreferenceChange(v as CodecPreference)}
-              className="bg-white/[0.06] border border-white/10 rounded-md text-white/90 text-[12px] py-0.5 px-2 min-w-0 max-w-[150px] disabled:text-white/40"
-            />
-          </span>
-        </div>
+        <SettingRow icon={VideoIcon} label="Codec">
+          <SettingSelect
+            label="Codec"
+            value={value}
+            options={CODEC_OPTIONS}
+            disabled={!avccSupported}
+            onChange={(v) => onPreferenceChange(v as CodecPreference)}
+          />
+        </SettingRow>
         <p className="text-[11px] text-white/55 leading-snug px-0.5">
           {!avccSupported
             ? "This browser can't decode H.264, so the stream uses MJPEG."

--- a/packages/serve-sim/src/client/components/stream-settings-tool.tsx
+++ b/packages/serve-sim/src/client/components/stream-settings-tool.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import { CollapsibleSection } from "./collapsible-section";
+import { Select } from "./select";
+
+// Client-side video preference. "auto" decodes H.264 (AVCC via WebCodecs) when
+// the browser supports it; "mjpeg" forces the software JPEG path. H.264 decode
+// runs through the GPU's VideoToolbox pipeline, which a concurrent screen
+// recorder (Screen Studio, QuickTime, …) can starve — producing stutter and
+// reconnect loops. MJPEG decodes in software and is immune to that contention,
+// so it's the escape hatch when recording the browser window.
+export type CodecPreference = "auto" | "mjpeg";
+
+export const CODEC_PREFERENCE_STORAGE_KEY = "serve-sim:codec";
+
+const CODEC_OPTIONS = [
+  { value: "auto", label: "H.264 (Hardware)" },
+  { value: "mjpeg", label: "MJPEG (Compatibility)" },
+];
+
+// Inline 14px glyph, stroked at full opacity (no dimmed icons).
+const VideoIcon = (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="m16 13 5.223 3.482a.5.5 0 0 0 .777-.416V7.87a.5.5 0 0 0-.752-.432L16 10.5" />
+    <rect x="2" y="6" width="14" height="12" rx="2" />
+  </svg>
+);
+
+export function StreamSettingsTool({
+  preference,
+  onPreferenceChange,
+  activeCodec,
+  avccSupported,
+}: {
+  /** The user's saved codec preference. */
+  preference: CodecPreference;
+  onPreferenceChange: (next: CodecPreference) => void;
+  /** The codec actually painting frames right now. */
+  activeCodec: "h264" | "mjpeg";
+  /** Whether this browser can decode H.264 (WebCodecs available). */
+  avccSupported: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+
+  // Without WebCodecs the only option is MJPEG; reflect that in the control so
+  // it never reads as if H.264 were a live choice.
+  const value: CodecPreference = avccSupported ? preference : "mjpeg";
+  // Auto resolved to MJPEG (startup fallback or a helper that doesn't serve
+  // /stream.avcc) — surface it so the picker doesn't lie about what's on screen.
+  const downgraded = avccSupported && preference === "auto" && activeCodec === "mjpeg";
+
+  return (
+    <CollapsibleSection
+      open={open}
+      onOpenChange={setOpen}
+      data-stream-settings=""
+      summaryClassName="grid [grid-template-columns:auto_1fr_auto] items-center gap-2 text-left"
+      summary={
+        <>
+          <span className="text-[11px] font-semibold text-white/50 uppercase tracking-[0.08em] leading-none inline-flex items-center">
+            Stream
+          </span>
+          <span />
+        </>
+      }
+    >
+      <div className="flex flex-col gap-1.5 pb-1.5">
+        <div className="flex items-center justify-between gap-2 min-h-[30px]" data-setting-row="Codec">
+          <span className="flex shrink-0 items-center gap-2 text-[12px] text-white/90 whitespace-nowrap">
+            <span className="flex size-[18px] items-center justify-center text-white">{VideoIcon}</span>
+            Codec
+          </span>
+          <span className="flex min-w-0 justify-end">
+            <Select
+              label="Codec"
+              value={value}
+              options={CODEC_OPTIONS}
+              disabled={!avccSupported}
+              onChange={(v) => onPreferenceChange(v as CodecPreference)}
+              className="bg-white/[0.06] border border-white/10 rounded-md text-white/90 text-[12px] py-0.5 px-2 min-w-0 max-w-[150px] disabled:text-white/40"
+            />
+          </span>
+        </div>
+        <p className="text-[11px] text-white/55 leading-snug px-0.5">
+          {!avccSupported
+            ? "This browser can't decode H.264, so the stream uses MJPEG."
+            : downgraded
+              ? "H.264 was unavailable for this stream, so it fell back to MJPEG."
+              : "Switch to MJPEG if the stream stutters or drops while screen recording the browser window."}
+        </p>
+      </div>
+    </CollapsibleSection>
+  );
+}

--- a/packages/serve-sim/src/client/components/tools-panel.tsx
+++ b/packages/serve-sim/src/client/components/tools-panel.tsx
@@ -6,6 +6,7 @@ import { AppPermissionsTool } from "./app-permissions-tool";
 import { AxTreeTool } from "./ax-tree-tool";
 import { CameraTool } from "./camera-tool";
 import { SimulatorSettingsTool } from "./simulator-settings-tool";
+import { StreamSettingsTool, type CodecPreference } from "./stream-settings-tool";
 
 export function ToolsPanel({
   open,
@@ -15,6 +16,10 @@ export function ToolsPanel({
   currentApp,
   axOverlayEnabled,
   onToggleAxOverlay,
+  codecPreference,
+  onCodecPreferenceChange,
+  activeCodec,
+  avccSupported,
   width,
 }: {
   open: boolean;
@@ -24,6 +29,10 @@ export function ToolsPanel({
   currentApp: { bundleId: string; isReactNative: boolean; pid?: number } | null;
   axOverlayEnabled: boolean;
   onToggleAxOverlay: () => void;
+  codecPreference: CodecPreference;
+  onCodecPreferenceChange: (next: CodecPreference) => void;
+  activeCodec: "h264" | "mjpeg";
+  avccSupported: boolean;
   width: number;
 }) {
   return (
@@ -44,6 +53,12 @@ export function ToolsPanel({
           <CameraTool udid={udid} bundleId={currentApp?.bundleId ?? null} />
           <LocationEmulationTool udid={udid} exec={execOnHost} />
           <AppPermissionsTool udid={udid} bundleId={currentApp?.bundleId ?? null} />
+          <StreamSettingsTool
+            preference={codecPreference}
+            onPreferenceChange={onCodecPreferenceChange}
+            activeCodec={activeCodec}
+            avccSupported={avccSupported}
+          />
         </div>
       )}
     </Panel>


### PR DESCRIPTION
# Why

The simulator stream became laggy and repeatedly disconnected while a screen recorder (Screen Studio, QuickTime) was capturing the browser window. This started when H.264 (AVCC via WebCodecs) became the default codec: the browser decodes through the GPU's VideoToolbox pipeline, which a concurrent recorder starves. Once AVCC had painted a frame the client was latched to it for the session, so a mid-stream hardware-decode failure just looped on a 1s AVCC reconnect instead of recovering.

# How

Two parts:

1. A user-facing Stream section in the tools panel with a Codec control (H.264 vs MJPEG). MJPEG decodes in software and is immune to VideoToolbox contention, so it is the escape hatch when recording the window. The choice persists across reloads. The section sits last in the panel.

2. Automatic recovery: when the WebCodecs decoder fails fatally mid-stream (a VideoDecoder error event or a configure throw), the client now downgrades to MJPEG instead of retrying AVCC forever. The fatal-failure path routes to a single handler that downgrades when wired, so the recovered failure no longer paints a red error overlay over the now-live MJPEG stream. The user preference stays on H.264, so a device switch or reconnect re-arms hardware decode. A transient stall (timeout) still keeps a working stream; only a real decoder error downgrades.

# Test Plan

- Unit tests for the fallback reducer cover the key distinction: a decoder error downgrades a stream that was already working, where a timeout does not.
- Manually verified end to end against a booted simulator: the Codec switch toggles the live stream between the canvas (AVCC) and img (MJPEG) paths with no reconnect, persists to localStorage, and forcing the decoder's configure to throw auto-switches to MJPEG with no error overlay while the preference stays H.264.
- Typecheck, lint, and the serve-sim / serve-sim-client unit suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user-selectable codec preference (auto/MJPEG) with persistent browser storage.
  * Added codec settings to the tools panel, including compatibility-aware selection and guidance.

* **Bug Fixes / Improvements**
  * Improved AVCC (H.264/WebCodecs) robustness: if a fatal decoder failure occurs mid-stream, the stream permanently downgrades to MJPEG.
  * AVCC is now enabled only when the saved preference isn’t set to MJPEG.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->