### PR TITLE
De-flake shm-shutdown and location-permission sim tests

### DIFF
--- a/packages/serve-sim/src/__tests__/avcc-stream-endpoint.test.ts
+++ b/packages/serve-sim/src/__tests__/avcc-stream-endpoint.test.ts
@@ -77,7 +77,10 @@ describeWithSim(`serve-sim AVCC endpoint (booted sim ${bootedUdid ?? "<skipped>"
 
   afterAll(() => {
     try { execFileSync("bun", ["run", CLI_PATH, "--kill", bootedUdid!], { stdio: "pipe" }); } catch {}
-  });
+    // `bun run <cli> --kill` (bun startup + simctl teardown) can run past bun's
+    // 5s default hook timeout on a loaded CI runner, flaking the whole file with
+    // an "(unnamed) hook timed out". Give the teardown a generous budget.
+  }, 30_000);
 
   test("emits a decoder description and a keyframe", async () => {
     const controller = new AbortController();

--- a/packages/serve-sim/src/__tests__/permissions.e2e.test.ts
+++ b/packages/serve-sim/src/__tests__/permissions.e2e.test.ts
@@ -108,6 +108,20 @@ function locationAuth(bundleId: string): number | null {
   return m ? Number(m[1]) : null;
 }
 
+// `simctl privacy` writes locationd's clients.plist asynchronously, so on a cold
+// CI sim the value can lag the `grant`/`revoke` CLI call returning. Poll the
+// readback until it reaches the expected Authorization rather than asserting on
+// the first (possibly stale) read.
+async function locationAuthEventually(bundleId: string, expected: number): Promise<number | null> {
+  let last: number | null = null;
+  for (let i = 0; i < 40; i++) {
+    last = locationAuth(bundleId);
+    if (last === expected) return last;
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  return last;
+}
+
 // Each case shells the built CLI a few times, and a cold `simctl privacy`
 // call (location) can take several seconds on a fresh CI sim — comfortably
 // past bun's 5s default. The beforeAll reset-all also cascades through every
@@ -170,14 +184,14 @@ describeIfSim("serve-sim permissions (real simulator)", () => {
     expect(bulletinXml()).not.toContain(FAKE_BUNDLE);
   }, T);
 
-  test("grant location --value always writes Authorization=4", () => {
+  test("grant location --value always writes Authorization=4", async () => {
     cli("grant", "location", REAL_APP, "--value", "always");
-    expect(locationAuth(REAL_APP)).toBe(4);
+    expect(await locationAuthEventually(REAL_APP, 4)).toBe(4);
   }, T);
 
-  test("revoke location downgrades Authorization to never (1)", () => {
+  test("revoke location downgrades Authorization to never (1)", async () => {
     cli("revoke", "location", REAL_APP);
-    expect(locationAuth(REAL_APP)).toBe(1);
+    expect(await locationAuthEventually(REAL_APP, 1)).toBe(1);
     cli("reset", "location", REAL_APP);
   }, T);
 
@@ -189,10 +203,12 @@ describeIfSim("serve-sim permissions (real simulator)", () => {
     expect(bulletinXml()).not.toContain(FAKE_BUNDLE);
   }, T);
 
-  test("list reports state under the CLI's own permission names", () => {
+  test("list reports state under the CLI's own permission names", async () => {
     cli("grant", "camera", FAKE_BUNDLE);
     cli("grant", "notifications", FAKE_BUNDLE);
     cli("grant", "location", REAL_APP, "--value", "always");
+    // Wait for locationd to persist the grant before reading it back via `list`.
+    expect(await locationAuthEventually(REAL_APP, 4)).toBe(4);
     const fake = JSON.parse(cli("list", FAKE_BUNDLE));
     expect(fake.tcc.camera).toBe(2);
     expect(fake.notifications.allowsNotifications).toBe(true);

--- a/packages/serve-sim/src/__tests__/shm-probe.integration.test.ts
+++ b/packages/serve-sim/src/__tests__/shm-probe.integration.test.ts
@@ -403,9 +403,17 @@ describeIf("SimCameraHelper shm probe", () => {
     helper = null;
 
     const sys = await loadFfi();
-    const fd = sys.shm_open(Buffer.from(`${SHM_NAME}\0`), 0, 0);
-    if (fd >= 0) {
+    // The helper shm_unlink()s during shutdown, but on a loaded CI runner that
+    // can land a beat after the process-exit event fires. Poll briefly so the
+    // assertion proves "eventually unlinked" rather than racing the cleanup.
+    let fd = -1;
+    for (let i = 0; i < 40; i++) {
+      fd = sys.shm_open(Buffer.from(`${SHM_NAME}\0`), 0, 0);
+      if (fd < 0) break;
       sys.close(fd);
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    if (fd >= 0) {
       sys.shm_unlink(Buffer.from(`${SHM_NAME}\0`));
     }
     expect(fd).toBeLessThan(0);


### PR DESCRIPTION
## Why

`sim-test` (and the `publish` test gate) have been failing intermittently across PRs on two integration tests that race eventually-consistent system state on loaded CI runners — not on the code under test. Observed flaking in different combinations across recent runs on multiple branches.

## What

- **`shm-probe` → "shutdown unmaps shm"**: the helper `shm_unlink()`s during shutdown, but on a loaded runner that can land a beat *after* the process-exit event the test waits on. Now polls `shm_open` for up to ~2s so the assertion proves "eventually unlinked" instead of racing the cleanup.
- **`permissions` → location grant/revoke/list**: `simctl privacy` persists locationd's `clients.plist` asynchronously, so the readback can lag the CLI call returning. Now polls the `Authorization` value until it settles instead of asserting the first (possibly stale) read.

Both keep their real assertions — a genuinely-wrong value still fails after the retry window. This mirrors the existing soft-pass/retry treatment the AX and AVCC-warming sim tests already have.

## Verification

- typecheck, lint clean; both test files pass locally (19/19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of location permission authorization e2e tests by waiting for persisted authorization changes before asserting outcomes.
  * Updated the shared memory shutdown test to retry briefly and handle race conditions before verifying SHM is unmapped/unavailable.
  * Increased teardown timeout for the AVCC stream endpoint test to prevent failures on slower CI environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->