### PR TITLE
ci: build serve-sim native addon before publish e2e tests

### DIFF
--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -93,6 +93,13 @@ jobs:
           open -ga Simulator || true
           echo "udid=$UDID" >> $GITHUB_OUTPUT
 
+      # The serve-sim e2e tests load the in-process native addon
+      # (dist/native/serve-sim-native.node), so build it before running them.
+      # (The publish step below rebuilds after the version bump to embed it.)
+      - name: Build serve-sim
+        run: bun run build.ts
+        working-directory: packages/serve-sim
+
       - name: serve-sim tests (idle floor regression)
         run: bun test packages/serve-sim/src/__tests__/
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -116,6 +116,14 @@ jobs:
           open -ga Simulator || true
           echo "udid=$UDID" >> $GITHUB_OUTPUT
 
+      # The serve-sim e2e tests load the in-process native addon
+      # (dist/native/serve-sim-native.node), so build it before running them.
+      # (The publish step below rebuilds after the version bump to embed it.)
+      - name: Build serve-sim
+        if: steps.changes.outputs.sim == 'true'
+        run: bun run build.ts
+        working-directory: packages/serve-sim
+
       - name: serve-sim tests (idle floor regression)
         if: steps.changes.outputs.sim == 'true'
         run: bun test packages/serve-sim/src/__tests__/


### PR DESCRIPTION
## Problem

The `feat: Migrate to napi` merge (#108) triggered **Publish beta to npm** on main, but it **failed without publishing**: the `serve-sim tests (idle floor regression)` step ran `bun test` with no prior build, so `dist/native/serve-sim-native.node` didn't exist and 5 native-dependent e2e tests failed (AVCC, accessibility, type, idle-frame-floor ×2). The `Build and publish` step was consequently skipped.

This worked before the napi migration because the e2e tests used the committed `bin/serve-sim-bin` helper; now the addon must be built (and `dist/` is gitignored). The `sim-test` PR workflow passes because it has a `Build serve-sim` step before the tests.

## Fix

Add a `Build serve-sim` (`bun run build.ts`) step before the e2e tests in both `publish.yml` and `publish-stable.yml`, mirroring `sim-test.yml`. The post-version-bump `bun run build` in the publish step is kept so the published bundle embeds the bumped version.

After merge, the beta publish can be triggered via `workflow_dispatch` (forces `sim=true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow reliability by ensuring native dependencies are built before test execution in publish workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->