### PR TITLE
fix: guard in-process HID calls so malformed input can't crash the server

### DIFF
--- a/packages/serve-sim/Sources/SimStreamHelper/HIDInjector.swift
+++ b/packages/serve-sim/Sources/SimStreamHelper/HIDInjector.swift
@@ -2,6 +2,18 @@ import Foundation
 import ObjectiveC
 import Darwin
 
+/// Per-event HID logging is gated behind `SERVE_SIM_DEBUG_HID`. These lines fire
+/// on every touch/move/button/key/crown event — a single drag emits a dozen —
+/// so by default they flood stdout (and anything mirroring it) for no benefit.
+/// Failure diagnostics ("returned nil", "unavailable", "not found") stay on
+/// `print` so real problems are always visible.
+private let hidDebugEnabled = ProcessInfo.processInfo.environment["SERVE_SIM_DEBUG_HID"] != nil
+
+@inline(__always)
+private func hidLog(_ message: @autoclosure () -> String) {
+    if hidDebugEnabled { print(message()) }
+}
+
 /// Injects touch, button, and orientation HID events into the iOS Simulator.
 ///
 /// Uses IndigoHIDMessageForMouseNSEvent to create touch messages and
@@ -70,28 +82,28 @@ final class HIDInjector {
 
         if let buttonPtr = dlsym(UnsafeMutableRawPointer(bitPattern: -2), "IndigoHIDMessageForButton") {
             self.buttonFunc = unsafeBitCast(buttonPtr, to: IndigoButtonFunc.self)
-            print("[hid] IndigoHIDMessageForButton loaded")
+            hidLog("[hid] IndigoHIDMessageForButton loaded")
         } else {
             print("[hid] Warning: IndigoHIDMessageForButton not found")
         }
 
         if let arbPtr = dlsym(UnsafeMutableRawPointer(bitPattern: -2), "IndigoHIDMessageForHIDArbitrary") {
             self.hidArbitraryFunc = unsafeBitCast(arbPtr, to: IndigoHIDArbitraryFunc.self)
-            print("[hid] IndigoHIDMessageForHIDArbitrary loaded")
+            hidLog("[hid] IndigoHIDMessageForHIDArbitrary loaded")
         } else {
             print("[hid] Warning: IndigoHIDMessageForHIDArbitrary not found")
         }
 
         if let keyboardPtr = dlsym(UnsafeMutableRawPointer(bitPattern: -2), "IndigoHIDMessageForKeyboardArbitrary") {
             self.keyboardFunc = unsafeBitCast(keyboardPtr, to: IndigoKeyboardFunc.self)
-            print("[hid] IndigoHIDMessageForKeyboardArbitrary loaded")
+            hidLog("[hid] IndigoHIDMessageForKeyboardArbitrary loaded")
         } else {
             print("[hid] Warning: IndigoHIDMessageForKeyboardArbitrary not found")
         }
 
         if let crownPtr = dlsym(UnsafeMutableRawPointer(bitPattern: -2), "IndigoHIDMessageForDigitalCrownEvent") {
             self.digitalCrownFunc = unsafeBitCast(crownPtr, to: IndigoDigitalCrownFunc.self)
-            print("[hid] IndigoHIDMessageForDigitalCrownEvent loaded")
+            hidLog("[hid] IndigoHIDMessageForDigitalCrownEvent loaded")
         } else {
             print("[hid] Warning: IndigoHIDMessageForDigitalCrownEvent not found")
         }
@@ -120,8 +132,8 @@ final class HIDInjector {
 
         self.hidClient = clientObj
         self.sendSel = NSSelectorFromString("sendWithMessage:freeWhenDone:completionQueue:completion:")
-        print("[hid] SimDeviceLegacyHIDClient created")
-        print("[hid] IndigoHIDMessageForMouseNSEvent loaded (with edge gesture support)")
+        hidLog("[hid] SimDeviceLegacyHIDClient created")
+        hidLog("[hid] IndigoHIDMessageForMouseNSEvent loaded (with edge gesture support)")
     }
 
     // IndigoHIDEdge values (x4 param to IndigoHIDMessageForMouseNSEvent).
@@ -175,7 +187,7 @@ final class HIDInjector {
 
     func sendTouch(type: String, x: Double, y: Double, screenWidth: Int, screenHeight: Int, edge: UInt32 = 0) {
         guard let msg = touchMessage(type: type, x: x, y: y, edge: edge) else { return }
-        print("[hid] Sending \(type) at (\(String(format:"%.3f",x)),\(String(format:"%.3f",y)))\(edge > 0 ? " edge=\(edge)" : "")")
+        hidLog("[hid] Sending \(type) at (\(String(format:"%.3f",x)),\(String(format:"%.3f",y)))\(edge > 0 ? " edge=\(edge)" : "")")
         inputQueue.async { [self] in rawSend(msg) }
     }
 
@@ -197,7 +209,7 @@ final class HIDInjector {
             return
         }
 
-        print("[hid] Multi-touch \(type) f1=(\(String(format:"%.3f",x1)),\(String(format:"%.3f",y1))) f2=(\(String(format:"%.3f",x2)),\(String(format:"%.3f",y2)))")
+        hidLog("[hid] Multi-touch \(type) f1=(\(String(format:"%.3f",x1)),\(String(format:"%.3f",y1))) f2=(\(String(format:"%.3f",x2)),\(String(format:"%.3f",y2)))")
         inputQueue.async { [self] in rawSend(rawMsg) }
     }
 
@@ -257,7 +269,7 @@ final class HIDInjector {
             return
         }
 
-        print("[hid] Key \(type) usage=0x\(String(usage, radix: 16))")
+        hidLog("[hid] Key \(type) usage=0x\(String(usage, radix: 16))")
         inputQueue.async { [self] in rawSend(msg) }
     }
 
@@ -277,7 +289,7 @@ final class HIDInjector {
             return
         }
 
-        print("[hid] Digital Crown delta=\(String(format:"%.4f", delta))")
+        hidLog("[hid] Digital Crown delta=\(String(format:"%.4f", delta))")
         inputQueue.async { [self] in rawSend(msg) }
     }
 
@@ -397,7 +409,7 @@ final class HIDInjector {
             }
             rawSend(msg)
         }
-        print("[hid] HID button page=\(page) usage=\(usage) phase=\(phase)")
+        hidLog("[hid] HID button page=\(page) usage=\(usage) phase=\(phase)")
         inputQueue.async {
             switch phase {
             case "down": emit(1)
@@ -411,7 +423,7 @@ final class HIDInjector {
     }
 
     func sendButton(button: String, deviceUDID: String) {
-        print("[hid] Sending button: \(button)")
+        hidLog("[hid] Sending button: \(button)")
 
         switch button {
         case "home":
@@ -490,7 +502,7 @@ final class HIDInjector {
         let imp = device.method(for: sel)
         let fn = unsafeBitCast(imp, to: Fn.self)
         let result = fn(device, sel, name as NSString, ObjCBool(enabled))
-        print("[sim] setCADebugOption(\(name), \(enabled)) → \(result.boolValue)")
+        hidLog("[sim] setCADebugOption(\(name), \(enabled)) → \(result.boolValue)")
         return result.boolValue
     }
 
@@ -523,7 +535,7 @@ final class HIDInjector {
             return
         }
         _ = device.perform(sel)
-        print("[sim] simulateMemoryWarning dispatched")
+        hidLog("[sim] simulateMemoryWarning dispatched")
     }
 
     /// Synthesize a swipe-up-from-bottom gesture (Face ID "go home" gesture).
@@ -629,7 +641,7 @@ final class HIDInjector {
                 fputs("[hid] sendOrientation: mach_msg_send failed (\(kr))\n", stderr)
                 return false
             } else {
-                print("[hid] Orientation set to \(orientation)")
+                hidLog("[hid] Orientation set to \(orientation)")
                 return true
             }
         }

--- a/packages/serve-sim/src/__tests__/hid-malformed-input.test.ts
+++ b/packages/serve-sim/src/__tests__/hid-malformed-input.test.ts
@@ -65,7 +65,7 @@ describeIfSim(`serve-sim malformed HID input (booted sim ${bootedUdid ?? "<skipp
   let wsUrl: string;
   let configUrl: string;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     try { execFileSync("node", [CLI, "--kill", bootedUdid!], { stdio: "pipe" }); } catch {}
 
     const startPort = 40_000 + Math.floor(Math.random() * 20_000);
@@ -83,6 +83,17 @@ describeIfSim(`serve-sim malformed HID input (booted sim ${bootedUdid ?? "<skipp
     const state = JSON.parse(detach.stdout.trim()) as { wsUrl: string; streamUrl: string };
     wsUrl = state.wsUrl;
     configUrl = state.streamUrl.replace("stream.mjpeg", "config");
+
+    // `--detach` returns once the child is spawned, but on a cold CI runner the
+    // server may not be listening yet. Poll /config until it answers so the
+    // test's "still alive" checks measure crashes, not a slow cold start.
+    const deadline = Date.now() + 20_000;
+    while (Date.now() < deadline) {
+      try {
+        if ((await fetch(configUrl)).ok) break;
+      } catch {}
+      await new Promise((r) => setTimeout(r, 250));
+    }
   }, 60_000);
 
   afterAll(() => {

--- a/packages/serve-sim/src/__tests__/hid-malformed-input.test.ts
+++ b/packages/serve-sim/src/__tests__/hid-malformed-input.test.ts
@@ -1,0 +1,117 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { execFileSync, spawnSync } from "child_process";
+import { existsSync } from "fs";
+import { join } from "path";
+
+/**
+ * Regression test for the in-process HID path (napi migration, #108).
+ *
+ * HID injection used to run in a spawned `serve-sim-bin` helper, so a malformed
+ * input message could at worst crash that helper. Now HID runs in-process: the
+ * N-API binding throws synchronously when a JS value can't be coerced to its
+ * native parameter type (e.g. a touch whose `type` is missing →
+ * "Could not convert parameter 0 to type String"), and an unhandled throw takes
+ * down the WHOLE server — killing the live stream and, if it lands mid-gesture,
+ * leaving the guest with a stuck finger that wedges all touch until reboot.
+ *
+ * `NativeHid` now guards every native call, so a bad frame is ignored instead of
+ * fatal. This test sends a malformed touch frame (tag 0x03, JSON with no `type`)
+ * straight down the real `/ws` HID protocol and asserts the server is still
+ * serving afterward — and that it still accepts a well-formed touch.
+ */
+
+// Drives the built CLI (dist/serve-sim.js) so the test exercises the shipped
+// artifact — the same one CI builds before this directory runs.
+const CLI = join(import.meta.dir, "../../dist/serve-sim.js");
+
+const WS_TAG_TOUCH = 0x03;
+
+function firstBootedIosSim(): string | null {
+  try {
+    const out = execFileSync("xcrun", ["simctl", "list", "devices", "booted", "-j"], { encoding: "utf-8" });
+    const data = JSON.parse(out) as {
+      devices: Record<string, Array<{ udid: string; state: string }>>;
+    };
+    for (const [runtime, devices] of Object.entries(data.devices)) {
+      if (!/iOS/i.test(runtime)) continue;
+      for (const d of devices) if (d.state === "Booted") return d.udid;
+    }
+  } catch {}
+  return null;
+}
+
+/** Open `/ws`, send one `[tag][JSON]` frame, then close. Resolves on close. */
+function sendHidFrame(wsUrl: string, tag: number, payload: unknown): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(wsUrl);
+    ws.binaryType = "arraybuffer";
+    ws.onopen = () => {
+      const json = new TextEncoder().encode(JSON.stringify(payload));
+      const msg = new Uint8Array(1 + json.length);
+      msg[0] = tag;
+      msg.set(json, 1);
+      ws.send(msg);
+      setTimeout(() => { ws.close(); resolve(); }, 50);
+    };
+    ws.onerror = () => reject(new Error(`failed to connect ${wsUrl}`));
+  });
+}
+
+const bootedUdid = firstBootedIosSim();
+// Needs a booted iOS sim and the built CLI; CI builds serve-sim first.
+const describeIfSim = bootedUdid && existsSync(CLI) ? describe : describe.skip;
+
+describeIfSim(`serve-sim malformed HID input (booted sim ${bootedUdid ?? "<skipped>"})`, () => {
+  let wsUrl: string;
+  let configUrl: string;
+
+  beforeAll(() => {
+    try { execFileSync("node", [CLI, "--kill", bootedUdid!], { stdio: "pipe" }); } catch {}
+
+    const startPort = 40_000 + Math.floor(Math.random() * 20_000);
+    const detach = spawnSync("node", [CLI, "--detach", "-p", String(startPort), bootedUdid!], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "inherit"],
+      timeout: 45_000,
+    });
+    if (detach.status !== 0 || !detach.stdout) {
+      throw new Error(
+        `serve-sim --detach failed (exit=${detach.status} signal=${detach.signal})\n` +
+        `stdout: ${detach.stdout ?? "<none>"}`,
+      );
+    }
+    const state = JSON.parse(detach.stdout.trim()) as { wsUrl: string; streamUrl: string };
+    wsUrl = state.wsUrl;
+    configUrl = state.streamUrl.replace("stream.mjpeg", "config");
+  }, 60_000);
+
+  afterAll(() => {
+    try { execFileSync("node", [CLI, "--kill", bootedUdid!], { stdio: "pipe" }); } catch {}
+  }, 30_000);
+
+  async function serverAlive(): Promise<boolean> {
+    try {
+      return (await fetch(configUrl)).ok;
+    } catch {
+      return false;
+    }
+  }
+
+  test("a malformed touch frame does not crash the server", async () => {
+    expect(await serverAlive()).toBe(true);
+
+    // `{x, y}` with no `type` → the native touch() binding throws on the
+    // non-string first parameter. Pre-fix this propagated and killed the server.
+    await sendHidFrame(wsUrl, WS_TAG_TOUCH, { x: 0.5, y: 0.5 });
+
+    // Give an uncaught-exception crash time to take the process down.
+    await new Promise((r) => setTimeout(r, 750));
+    expect(await serverAlive()).toBe(true);
+
+    // The server still accepts a well-formed touch after the bad frame.
+    await sendHidFrame(wsUrl, WS_TAG_TOUCH, { type: "begin", x: 0.5, y: 0.5 });
+    await sendHidFrame(wsUrl, WS_TAG_TOUCH, { type: "end", x: 0.5, y: 0.5 });
+    await new Promise((r) => setTimeout(r, 250));
+    expect(await serverAlive()).toBe(true);
+  }, 30_000);
+});

--- a/packages/serve-sim/src/__tests__/type-command-sim.test.ts
+++ b/packages/serve-sim/src/__tests__/type-command-sim.test.ts
@@ -13,6 +13,9 @@ import { join } from "path";
  * accepted key event, which is what we assert against — proving the event
  * round-tripped all the way to the sim, not just to the helper's WS reader.
  *
+ * Those per-event HID logs are gated behind `SERVE_SIM_DEBUG_HID` (they otherwise
+ * flood stdout), so the server is started with that env set to make them visible.
+ *
  * Skipped automatically when no iOS simulator is booted, so this stays green
  * on machines without one. The macOS CI job boots a sim explicitly and runs
  * `bun test packages/serve-sim/src/__tests__/`, so it runs there.
@@ -48,6 +51,9 @@ describeWithSim(`serve-sim type e2e (booted sim ${bootedUdid ?? "<skipped>"})`, 
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "inherit"],
       timeout: 45_000,
+      // Surface the per-event `[hid] Key …` lines this test asserts on; the
+      // env propagates to the detached `serve` child the CLI re-execs.
+      env: { ...process.env, SERVE_SIM_DEBUG_HID: "1" },
     });
     if (detach.status !== 0 || !detach.stdout) {
       throw new Error(

--- a/packages/serve-sim/src/native.ts
+++ b/packages/serve-sim/src/native.ts
@@ -116,49 +116,65 @@ export class NativeHid {
     this.handle = new (load().SimHID)(udid);
   }
 
+  // The N-API bindings throw synchronously when a JS value can't be coerced to
+  // the native parameter type (e.g. a touch with a non-string `type` →
+  // "Could not convert parameter 0 to type String"). HID now runs in-process,
+  // so an unhandled throw here crashes the whole server — and if it lands
+  // mid-gesture, the guest is left with a stuck finger that wedges input until
+  // the sim reboots. The spawned helper used to absorb this in its own process;
+  // `guard` restores that isolation by swallowing malformed-input errors.
+  private guard<T>(op: string, fn: () => T, fallback: T): T {
+    try {
+      return fn();
+    } catch (err) {
+      console.error(`[hid] ${op} ignored bad input:`, err instanceof Error ? err.message : err);
+      return fallback;
+    }
+  }
+
   touch(type: TouchType, x: number, y: number, w: number, h: number, edge = 0): void {
-    this.handle.touch(type, x, y, w, h, edge);
+    this.guard("touch", () => this.handle.touch(type, x, y, w, h, edge), undefined);
   }
 
   multiTouch(type: TouchType, x1: number, y1: number, x2: number, y2: number, w: number, h: number): void {
-    this.handle.multiTouch(type, x1, y1, x2, y2, w, h);
+    this.guard("multiTouch", () => this.handle.multiTouch(type, x1, y1, x2, y2, w, h), undefined);
   }
 
   button(button: string): void {
-    this.handle.button(button);
+    this.guard("button", () => this.handle.button(button), undefined);
   }
 
   buttonHid(page: number, usage: number, phase: ButtonPhase = "press"): void {
-    this.handle.buttonHid(page, usage, phase);
+    this.guard("buttonHid", () => this.handle.buttonHid(page, usage, phase), undefined);
   }
 
   key(type: KeyType, usage: number): void {
-    this.handle.key(type, usage);
+    this.guard("key", () => this.handle.key(type, usage), undefined);
   }
 
   /** anchorX/anchorY default to screen center when omitted. */
   scroll(dx: number, dy: number, w: number, h: number, anchorX?: number, anchorY?: number): void {
-    this.handle.scroll(dx, dy, anchorX ?? NaN, anchorY ?? NaN, w, h);
+    this.guard("scroll", () => this.handle.scroll(dx, dy, anchorX ?? NaN, anchorY ?? NaN, w, h), undefined);
   }
 
   digitalCrown(delta: number): void {
-    this.handle.digitalCrown(delta);
+    this.guard("digitalCrown", () => this.handle.digitalCrown(delta), undefined);
   }
 
   orientation(orientation: number): boolean {
-    return this.handle.orientation(orientation);
+    return this.guard("orientation", () => this.handle.orientation(orientation), false);
   }
 
   memoryWarning(): void {
-    this.handle.memoryWarning();
+    this.guard("memoryWarning", () => this.handle.memoryWarning(), undefined);
   }
 
   softwareKeyboard(): void {
-    this.handle.softwareKeyboard();
+    this.guard("softwareKeyboard", () => this.handle.softwareKeyboard(), undefined);
   }
 
   caDebug(name: string, enabled: boolean): boolean {
-    return this.handle.caDebug(name, enabled);
+    return this.guard("caDebug", () => this.handle.caDebug(name, enabled), false);
   }
 }
 


### PR DESCRIPTION
## Problem

Reported as "touch gestures don't work in the browser on the latest serve-sim."

Since the napi migration (#108), HID injection runs **in-process** instead of in a spawned `serve-sim-bin` helper. The N-API binding throws synchronously when a JS value can't be coerced to its native parameter type — e.g. a touch frame whose `type` is missing yields `Could not convert parameter 0 to type String`. That unhandled throw took down the **entire server**:

- the live stream dies, and
- if the crash lands mid-gesture (a `begin` was sent but the `end` never is), the guest is left with a **stuck finger** that wedges *all* touch input — including Simulator.app's own native input — until the simulator reboots.

The old spawned helper absorbed such errors in its own process; in-process, nothing did.

## Fix

`NativeHid` now wraps every native call in a `guard` that logs and ignores malformed input instead of letting it propagate, restoring the process-isolation behavior.

## Test

Adds a regression test (`hid-malformed-input.test.ts`) that sends a malformed touch frame (tag `0x03`, JSON with no `type`) down the real `/ws` HID path and asserts the server keeps serving and still accepts well-formed input. It builds on the existing `sim-test.yml` booted-sim flow.

Verified: the test **fails without** the guard (server crashes, `/config` → connection refused) and **passes with** it. Also confirmed end-to-end in the browser on a healthy sim — taps work, and a mid-session malformed frame is now logged as `[hid] ... ignored bad input` while the server stays alive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved simulator HID handling to prevent crashes when native calls fail, returning safe defaults instead of throwing.
* **New Features**
  * Added environment-controlled HID debug logging so per-event HID details are only emitted when explicitly enabled.
* **Tests**
  * Added a regression test ensuring the simulator remains reachable after malformed HID touch frames, and continues working with well-formed frames.
  * Updated the `serve-sim type` test to enable HID debug logging during assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->