### PR TITLE
[codex] Fix publish workflows after client package removal

### DIFF
--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -7,21 +7,8 @@ permissions:
   contents: read
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-      - run: bun install
-
-      - name: Client tests
-        run: bun test packages/serve-sim-client/src/__tests__/
-
   publish-stable:
     if: github.repository == 'EvanBacon/serve-sim' && github.ref == 'refs/heads/main'
-    needs: [test]
     runs-on: macos-26
     permissions:
       contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     paths:
-      - "packages/**"
+      - "packages/serve-sim/**"
       - ".github/workflows/publish.yml"
   workflow_dispatch: {}
 
@@ -12,21 +12,8 @@ permissions:
   contents: read
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-      - run: bun install
-
-      - name: Client tests
-        run: bun test packages/serve-sim-client/src/__tests__/
-
   publish-beta:
     if: github.repository == 'EvanBacon/serve-sim' && github.ref == 'refs/heads/main'
-    needs: [test]
     runs-on: macos-26
     permissions:
       contents: read
@@ -46,10 +33,10 @@ jobs:
             exit 0
           fi
 
-          # Publish beta if serve-sim or bundled client source changed.
+          # Publish beta if serve-sim source changed.
           CHANGED=$(git diff --name-only HEAD~1 HEAD)
           SOURCE_CHANGED=false
-          if echo "$CHANGED" | grep -Eq "^packages/(serve-sim|serve-sim-client)/"; then
+          if echo "$CHANGED" | grep -Eq "^packages/serve-sim/"; then
             SOURCE_CHANGED=true
           fi
 


### PR DESCRIPTION
## Summary
- Remove the standalone publish workflow test jobs that still targeted the deleted `packages/serve-sim-client` package.
- Narrow beta publish path detection to `packages/serve-sim/**` and remove the stale client-package change detector.

## Root cause
CI was still running `bun test packages/serve-sim-client/src/__tests__/` after the client package was folded into `packages/serve-sim`, so Bun rejected the filter because it no longer matched any test files.

## Validation
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/publish.yml .github/workflows/publish-stable.yml`
- `rg -n "serve-sim-client|Client tests|packages/serve-sim-client" .github packages package.json README.md` returned no matches
- `bun run lint`
- `bun run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the stable release workflow to improve release efficiency by adjusting job sequencing.
  * Refined the beta publish workflow to trigger only on relevant package changes, reducing unnecessary build cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->