### PR TITLE
Fix swiftbuild native build

### DIFF
--- a/packages/serve-sim/Sources/SimNative/build.sh
+++ b/packages/serve-sim/Sources/SimNative/build.sh
@@ -3,11 +3,9 @@
 # spawned serve-sim-bin helper. The JS bindings are written in Swift with
 # node-swift (see ../../Package.swift and sim-module.swift).
 #
-# We use a plain `swift build`, i.e. the NATIVE SwiftPM build system, because
-# that is the only mode that resolves node-swift's #NodeModule macro plugin: both
-# `--arch X --arch Y` (universal) and `--triple <other-arch>` force Xcode's XCBuild,
-# which fails to resolve the NodeAPIMacros plugin on stock toolchains ("missing target
-# NodeAPIMacros" / "unable to resolve module SwiftSyntax").
+# We opt into the new `swiftbuild` build system, because it supports building universal
+# binaries with macros, which neither the legacy `native` build system nor the
+# perennially-janky legacy `xcode` build system had support for.
 #
 # napi_* stay undefined and resolve against the host (Node/Bun) at dlopen via
 # `-undefined dynamic_lookup`.
@@ -24,29 +22,22 @@ if [ ! -d "$PKG/node_modules/node-swift" ]; then
   exit 1
 fi
 
-build_arch() {
-  build_flags=(
-    -c release
-    --enable-experimental-prebuilts
-    --product "$PRODUCT"
-    --package-path "$PKG"
-    --build-path "$BUILD_DIR"
-    --arch "$1"
-  )
-  swift build "${build_flags[@]}" >&2
-  DYLIB="$(swift build --show-bin-path "${build_flags[@]}")/lib${PRODUCT}.dylib"
-  if [ ! -f "$DYLIB" ]; then
-    echo "Expected build product not found at $DYLIB" >&2
-    exit 1
-  fi
-  echo "$DYLIB"
-}
-
-arm64_dylib="$(build_arch arm64)"
-x64_dylib="$(build_arch x86_64)"
+build_flags=(
+  -c release
+  --product "$PRODUCT"
+  --package-path "$PKG"
+  --build-path "$BUILD_DIR"
+  --build-system swiftbuild
+)
+swift build "${build_flags[@]}" >&2
+DYLIB="$(swift build --show-bin-path "${build_flags[@]}")/lib${PRODUCT}.dylib"
+if [ ! -f "$DYLIB" ]; then
+  echo "Expected build product not found at $DYLIB" >&2
+  exit 1
+fi
 
 OUT="$OUT_DIR/${PRODUCT}.node"
-lipo -create -output "$OUT" "$arm64_dylib" "$x64_dylib"
+cp -a "$DYLIB" "$OUT"
 strip -x "$OUT"
 codesign -s - -f "$OUT" 2>/dev/null || true
 


### PR DESCRIPTION
Fix building with swiftbuild (which seems to not like `--arch`). In fact it seems to create a fat binary itself, so we can skip the lipo step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the native build pipeline to use SwiftPM’s `swiftbuild`, enabling smoother creation of universal binaries with the required build configuration.
  * Simplified the build flow by removing separate per-architecture compilation and the manual merging step.
  * The build now verifies the produced `.dylib` output location and copies it into the expected Node target for packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->