### PR TITLE
Add sim reboot-and-retry to publish workflow tests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -113,7 +113,23 @@ jobs:
 
       - name: serve-sim tests (idle floor regression)
         if: steps.changes.outputs.sim == 'true'
-        run: bun test packages/serve-sim/src/__tests__/
+        env:
+          UDID: ${{ steps.boot-sim.outputs.udid }}
+        run: |
+          # Mirror sim-test.yml: the sim-backed e2e tests share one simulator,
+          # so a wedge from one test (stuck finger, native crash) cascades into
+          # ConnectionRefused / "server not alive" failures in unrelated later
+          # tests. Reboot for a clean slate and retry once — a transient wedge
+          # clears, a genuine regression reproduces on the second run.
+          run_tests() { bun test packages/serve-sim/src/__tests__/; }
+          if run_tests; then exit 0; fi
+          echo "::warning title=sim e2e retry::test run failed; rebooting $UDID and retrying once"
+          xcrun simctl shutdown "$UDID" 2>/dev/null || true
+          sleep 3
+          xcrun simctl boot "$UDID" || true
+          xcrun simctl bootstatus "$UDID" -b || true
+          open -ga Simulator || true
+          run_tests
 
       - name: Shutdown simulator
         if: always() && steps.boot-sim.outputs.udid != ''


### PR DESCRIPTION
## Problem

CI on `main` is red: the **Publish beta to npm** job failed on both #115 and #116. The native build succeeds, but two sim-backed e2e tests fail:

- `malformed HID input > a malformed touch frame does not crash the server` — fails on its **first** assertion (`serverAlive()`), *before* it sends any bad frame
- `AVCC endpoint > emits a decoder description and a keyframe` — `Unable to connect`

That's the classic shared-simulator wedge cascade: one earlier sim-backed test leaves the simulator/server wedged (stuck finger, native crash) and every later test sees ConnectionRefused.

## Fix

`sim-test.yml` (the PR check) already guards against this with a reboot-and-retry wrapper, but `publish.yml` ran the same suite with a bare `bun test` and no retry — so a transient wedge fails the publish job outright.

This brings the publish job's test step in line with `sim-test.yml`: reboot the shared simulator and retry the suite once. A transient wedge clears; a genuine regression reproduces on the retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the iOS simulator test step by retrying automatically after a simulator hang, reducing false failures during release validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->