### PR TITLE
Fix infinite resize feedback loop

### DIFF
--- a/packages/serve-sim/src/__tests__/screen-config-state.test.ts
+++ b/packages/serve-sim/src/__tests__/screen-config-state.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { resolveScreenConfigUpdate } from "../client/simulator/screen-config-state";
+
+describe("screen config state", () => {
+  test("adopts parent-provided config without echoing it back", () => {
+    const update = resolveScreenConfigUpdate(
+      null,
+      { width: 1179, height: 2556, orientation: "portrait" },
+      "external",
+    );
+
+    expect(update).toEqual({
+      config: { width: 1179, height: 2556, orientation: "portrait" },
+      notifyParent: false,
+    });
+  });
+
+  test("notifies for sizes reported by the stream itself", () => {
+    const update = resolveScreenConfigUpdate(
+      null,
+      { width: 1179, height: 2556, orientation: "portrait" },
+      "reported",
+    );
+
+    expect(update?.notifyParent).toBe(true);
+  });
+
+  test("keeps prior orientation when image dimensions do not include one", () => {
+    const update = resolveScreenConfigUpdate(
+      { width: 2868, height: 1320, orientation: "landscape_left" },
+      { width: 1320, height: 2868 },
+      "reported",
+    );
+
+    expect(update).toEqual({
+      config: { width: 1320, height: 2868, orientation: "landscape_left" },
+      notifyParent: true,
+    });
+  });
+
+  test("skips identical configs", () => {
+    expect(
+      resolveScreenConfigUpdate(
+        { width: 1179, height: 2556, orientation: "portrait" },
+        { width: 1179, height: 2556, orientation: "portrait" },
+        "reported",
+      ),
+    ).toBeNull();
+  });
+});

--- a/packages/serve-sim/src/client/simulator/SimulatorView.tsx
+++ b/packages/serve-sim/src/client/simulator/SimulatorView.tsx
@@ -17,6 +17,10 @@ import {
 } from "./orientation.js";
 import { digitalCrownDeltaFromWheel } from "./digitalCrown.js";
 import { wheelDeltaToPixels } from "./scroll-wheel.js";
+import {
+  resolveScreenConfigUpdate,
+  type ScreenConfigSource,
+} from "./screen-config-state.js";
 import { useAvccStream } from "./use-avcc-stream.js";
 import { isAvccSupported } from "../avcc-codec.js";
 
@@ -188,24 +192,15 @@ export function SimulatorView({
     setScreenSize(null);
   }, [url]);
 
-  const updateScreenConfig = useCallback((config: StreamConfig | null | undefined) => {
-    if (!config || config.width <= 0 || config.height <= 0) return;
-    const prev = screenSizeRef.current;
-    const next =
-      config.orientation === undefined && prev?.orientation
-        ? { ...config, orientation: prev.orientation }
-        : config;
-    if (
-      prev &&
-      prev.width === next.width &&
-      prev.height === next.height &&
-      prev.orientation === next.orientation
-    ) {
-      return;
-    }
-    screenSizeRef.current = next;
-    setScreenSize(next);
-    onScreenConfigChangeRef.current?.(next);
+  const updateScreenConfig = useCallback((
+    config: StreamConfig | null | undefined,
+    source: ScreenConfigSource = "reported",
+  ) => {
+    const update = resolveScreenConfigUpdate(screenSizeRef.current, config, source);
+    if (!update) return;
+    screenSizeRef.current = update.config;
+    setScreenSize(update.config);
+    if (update.notifyParent) onScreenConfigChangeRef.current?.(update.config);
   }, []);
 
   // Notify parent when streaming state changes
@@ -218,7 +213,7 @@ export function SimulatorView({
   // In relay mode, use streamConfig for screen size
   useEffect(() => {
     if (relayMode && streamConfig) {
-      updateScreenConfig(streamConfig);
+      updateScreenConfig(streamConfig, "external");
     }
   }, [relayMode, streamConfig, updateScreenConfig]);
 

--- a/packages/serve-sim/src/client/simulator/screen-config-state.ts
+++ b/packages/serve-sim/src/client/simulator/screen-config-state.ts
@@ -1,0 +1,32 @@
+import type { StreamConfig } from "../types.js";
+
+export type ScreenConfigSource = "external" | "reported";
+
+export interface ScreenConfigUpdate {
+  config: StreamConfig;
+  notifyParent: boolean;
+}
+
+export function resolveScreenConfigUpdate(
+  prev: StreamConfig | null,
+  config: StreamConfig | null | undefined,
+  source: ScreenConfigSource,
+): ScreenConfigUpdate | null {
+  if (!config || config.width <= 0 || config.height <= 0) return null;
+  const next =
+    config.orientation === undefined && prev?.orientation
+      ? { ...config, orientation: prev.orientation }
+      : config;
+  if (
+    prev &&
+    prev.width === next.width &&
+    prev.height === next.height &&
+    prev.orientation === next.orientation
+  ) {
+    return null;
+  }
+  return {
+    config: next,
+    notifyParent: source === "reported",
+  };
+}


### PR DESCRIPTION
I was occasionally running into an issue where serve-sim's web UI would completely hang. DevTools pointed to the line of `setScreenSize(next)`. A little ~~debugging~~ prompting later it seems the root cause is a feedback loop, where SimulatorView's size briefly disagrees with its caller at startup and they ping pong forever.

Fix summary via GPT-5.5 xhigh:

> Fixes an occasional page-load update loop caused by SimulatorView treating parent-provided streamConfig as if it were newly reported by the stream.
>
> On load, the parent may briefly move between fallback, WebSocket, and live frame dimensions. SimulatorView was consuming streamConfig, calling setScreenSize, and then immediately echoing that same config back through onScreenConfigChange. The parent stored that as liveStreamConfig, which could then change the rendered aspect ratio and feed a slightly different config back down, especially when raw frame dimensions and orientation metadata disagreed during startup.
>
> This change makes the source of screen config explicit: external configs update local display sizing only, while stream-reported dimensions still notify the parent. That breaks the parent/child feedback loop without changing the measured-frame path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screen configuration handling in the simulator so updates are applied more consistently.
  * Prevents redundant updates when the screen size and orientation haven’t actually changed.
  * Preserves the previous orientation when new size data doesn’t include one.
  * Avoids sending unnecessary parent notifications for externally supplied screen settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->