### PR TITLE
fix(native): serialize startup frame capture to stop heap corruption on macOS 26

### DIFF
--- a/packages/serve-sim/Sources/SimNative/FrameCapture.swift
+++ b/packages/serve-sim/Sources/SimNative/FrameCapture.swift
@@ -106,7 +106,17 @@ final class FrameCapture {
             }
         }
 
-        captureFrame()
+        // Always run the initial capture on captureQueue, never on the caller
+        // thread. The screen callbacks registered above already dispatch
+        // captureFrame() onto captureQueue, so a direct call here races them:
+        // two captureFrame()/handleFrame() runs execute concurrently at startup
+        // and corrupt the encoder state (notably the VideoEncoder.onEncodedFrame
+        // swap in CaptureEngine.handleFrame), which macOS 26's hardened
+        // allocator detects as heap corruption and aborts (SIGTRAP). Serializing
+        // on captureQueue makes every captureFrame() mutually exclusive.
+        // Observable symptom of the bug: "JPEG encoder ready" logged twice at
+        // startup; with this fix it logs once.
+        captureQueue.async { [weak self] in self?.captureFrame() }
     }
 
     private func findFramebufferDescriptors(io: NSObject) throws -> [NSObject] {

--- a/packages/serve-sim/Sources/SimNative/VideoEncoder.swift
+++ b/packages/serve-sim/Sources/SimNative/VideoEncoder.swift
@@ -7,6 +7,11 @@ import UniformTypeIdentifiers
 /// Encodes CVPixelBuffer frames as JPEG data for MJPEG streaming.
 final class VideoEncoder {
     private var onEncodedFrame: ((Data) -> Void)?
+    // Guards onEncodedFrame: setup()/stop() run on the capture queue (a
+    // resolution change swaps the closure), while encode() reads it on the
+    // encode queue. Without this lock the swap races the read and double-frees
+    // the old closure's context — heap corruption under macOS 26's allocator.
+    private let cbLock = NSLock()
     private let quality: CGFloat
 
     init(quality: CGFloat = 0.7) {
@@ -15,7 +20,9 @@ final class VideoEncoder {
 
     func setup(width: Int32, height: Int32, fps: Int,
                onEncodedFrame: @escaping (Data) -> Void) {
+        cbLock.lock()
         self.onEncodedFrame = onEncodedFrame
+        cbLock.unlock()
         print("[encoder] JPEG encoder ready at \(width)x\(height) (quality: \(quality))")
     }
 
@@ -44,10 +51,15 @@ final class VideoEncoder {
         CGImageDestinationAddImage(dest, cgImage, [kCGImageDestinationLossyCompressionQuality: quality] as CFDictionary)
         guard CGImageDestinationFinalize(dest) else { return }
 
-        onEncodedFrame?(data as Data)
+        cbLock.lock()
+        let callback = onEncodedFrame
+        cbLock.unlock()
+        callback?(data as Data)
     }
 
     func stop() {
+        cbLock.lock()
         onEncodedFrame = nil
+        cbLock.unlock()
     }
 }


### PR DESCRIPTION
## Summary

On macOS 26 (Tahoe), `serve-sim` reliably crashes the host process with a heap-corruption abort shortly after a browser connects:

```
node(…) MallocStackLogging: BUG IN CLIENT OF LIBMALLOC: memory corruption of free block
… _xzm_xzone_malloc_freelist_outlined …  (EXC_BREAKPOINT / SIGTRAP)
… serve-sim-native.node …
```

The crash is intermittent (≈1 in 25 cold starts, but often on the very first browser connect) and is far more likely on the default `--codec auto` (H.264/AVCC) path. MJPEG-only sessions usually survive. It does not reproduce on macOS 15.

## Root cause

A startup data race in `FrameCapture`. `wireUpFramebuffer()` registers the SimulatorKit screen callbacks — which dispatch `captureFrame()` onto `captureQueue` — and **then calls `captureFrame()` directly on the caller thread**:

```swift
for desc in candidates { try registerFrameCallbacks(desc: desc) }  // callbacks start firing on captureQueue
…
captureFrame()   // ← also runs on the caller (JS/NodeActor) thread
```

So two `captureFrame()` → `handleFrame()` runs execute **concurrently** during startup. `handleFrame()` does the first-frame encoder setup (`videoEncoder.stop()` then `videoEncoder.setup(...)`, which swaps the `onEncodedFrame` closure), so the two concurrent runs double-free the old closure's context. On macOS 26 the hardened "xzone" allocator detects the corrupted freelist and aborts; on older allocators the same race was benign. The AVCC path amplifies it by adding `VTCompressionSession` / pixel-buffer-pool / `Data` allocations in the same tiny window.

The observable tell is in the logs: **"JPEG encoder ready" is printed twice at startup** — once per concurrent `handleFrame()`.

(Consistent with `Package.swift`'s `swiftLanguageModes: [.v5]`, chosen so these cross-queue captures stay warnings rather than Swift 6 errors.)

## Fix

- **`FrameCapture.swift`** — dispatch the initial `captureFrame()` onto `captureQueue` (like the callback- and idle-timer-driven captures already do), so every `captureFrame()` is mutually exclusive. `async` is safe in both the `start()` (caller thread) and the self-heal re-wire (already on `captureQueue`) paths.
- **`VideoEncoder.swift`** — guard `onEncodedFrame` with an `NSLock` so the resolution-change swap (capture queue) can't race the read in `encode()` (encode queue). Defensive; same closure-double-free class on a different trigger.

2 files, +24/−2. No behavior change other than the initial frame being captured on the proper queue.

## Verification (macOS 26.5.1, arm64, Xcode 26, Node 22)

| Check | Before | After |
|---|---|---|
| `"JPEG encoder ready"` at startup | logged **2×** (the race) | logged **1×** |
| Startup-race stress (AVCC+AX burst on a freshly started server) | crashes ≈1/25 | **0 crashes / 60 trials** |
| New crash reports | yes | none |
| H.264/AVCC live stream in browser | aborts | renders, stable |

## Notes

This is macOS-26-specific in *manifestation* (the new allocator turns a latent race into a hard abort), but the race itself exists on all versions. No allocator-specific workaround is used — the fix removes the race.


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup and frame-processing stability to prevent concurrent state updates during video capture.
  * Made frame encoding callbacks safer across threads, reducing the risk of race conditions and inconsistent behavior during streaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->