### PR TITLE
fix(serve-sim): stop close button from killing the whole server

### DIFF
--- a/packages/serve-sim/src/index.ts
+++ b/packages/serve-sim/src/index.ts
@@ -116,6 +116,15 @@ function readStateFile(file: string): ServerState | null {
     // recycle here so --detach / --list always return a working stream.
     const booted = getBootedUdids();
     if (booted && !booted.has(state.device)) {
+      if (state.pid === process.pid) {
+        // The state belongs to *this* process (an in-process/preview server
+        // recorded its own pid via inProcessServeSimState). Never SIGTERM
+        // ourselves — that would take the whole server down. Just drop the
+        // stale file; the live server reaps its own sessions on grid polls.
+        debugState("dropping own stale state for non-booted device %s", state.device);
+        try { unlinkSync(file); } catch {}
+        return null;
+      }
       debugState(
         "helper pid %d bound to non-booted device %s — killing stale helper",
         state.pid,

--- a/packages/serve-sim/src/middleware.ts
+++ b/packages/serve-sim/src/middleware.ts
@@ -12,7 +12,7 @@ import type { Socket } from "net";
 // importing the dependency keeps the proxy working regardless of runtime.
 import { WebSocket } from "ws";
 import { createAxStreamerCache } from "./ax";
-import { getDeviceSession, type HidSocket } from "./device-session";
+import { getDeviceSession, closeDeviceSession, type HidSocket } from "./device-session";
 import { axFrontmostAsync } from "./native";
 import { inProcessServeSimState, writeServeSimState, type ServeSimDeviceState } from "./state";
 import { debugMw } from "./debug";
@@ -135,6 +135,30 @@ function isUserFacingBundle(bundleId: string): boolean {
 
 function isSimulatorUdid(value: string): boolean {
   return /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i.test(value);
+}
+
+/** What to do with a persisted device state when reaping during a grid poll. */
+type StaleStateAction = "keep" | "recycle-self" | "recycle-helper";
+
+/**
+ * Decide how to reap a state record whose backing simulator may have been shut
+ * down. A booted device (or a non-simulator/unknown `booted` set) is kept.
+ *
+ * The critical distinction is `recycle-self` vs `recycle-helper`: in in-process
+ * mode `inProcessServeSimState` records the *server's own* pid, so SIGTERMing it
+ * (as we do for a separate stale helper) would kill the whole server — and
+ * index.ts converts SIGTERM into `process.exit`. When the dead device is ours,
+ * we stop just that device's capture session instead of signalling the pid.
+ */
+function classifyStaleState(
+  state: { pid: number; device: string },
+  booted: Set<string> | null,
+  selfPid: number,
+): StaleStateAction {
+  if (booted && isSimulatorUdid(state.device) && !booted.has(state.device)) {
+    return state.pid === selfPid ? "recycle-self" : "recycle-helper";
+  }
+  return "keep";
 }
 
 export function parseForegroundAppLogMessage(message: string): { bundleId: string; pid: number } | null {
@@ -270,13 +294,26 @@ export function readServeSimStates(): ServeSimState[] {
       // would accept connections yet never produce frames, leaving the
       // preview stuck on "Connecting...". Recycle the stale state so the
       // caller can spawn a fresh helper bound to whatever is booted.
-      if (booted && isSimulatorUdid(state.device) && !booted.has(state.device)) {
-        debugMw(
-          "recycling stale helper pid=%d (device %s no longer booted)",
-          state.pid,
-          state.device,
-        );
-        try { process.kill(state.pid, "SIGTERM"); } catch {}
+      const action = classifyStaleState(state, booted, process.pid);
+      if (action !== "keep") {
+        if (action === "recycle-self") {
+          // This device is streamed in-process by *us* (the close button just
+          // shut its sim down). SIGTERMing state.pid would kill the whole
+          // server; instead stop just this device's capture session.
+          debugMw(
+            "closing in-process session for shut-down device %s (own pid %d)",
+            state.device,
+            state.pid,
+          );
+          closeDeviceSession(state.device);
+        } else {
+          debugMw(
+            "recycling stale helper pid=%d (device %s no longer booted)",
+            state.pid,
+            state.device,
+          );
+          try { process.kill(state.pid, "SIGTERM"); } catch {}
+        }
         try { unlinkSync(path); } catch {}
         continue;
       }
@@ -1378,6 +1415,10 @@ export function simMiddleware(options?: SimMiddlewareOptions): SimMiddleware {
           res.end(JSON.stringify({ ok: false, error: "Invalid or missing udid" }));
           return;
         }
+        // Stop our own in-process capture for this device first (no-op if it
+        // isn't streamed here). This frees the native session immediately
+        // rather than waiting for the next poll's reaper to notice.
+        closeDeviceSession(udid);
         // Drop the snapshot so the next /grid/api call re-queries simctl
         // and prunes any helper bound to this now-shutdown device.
         bootedSnapshot = { at: 0, booted: null };


### PR DESCRIPTION
# Why

Clicking the close (X) button on a device in the web UI to shut a simulator down would kill the entire serve-sim process, not just that simulator.

The close button POSTs to `grid/api/shutdown`, which runs `simctl shutdown` and clears the booted cache. That handler is fine on its own. The kill happens on the next `/grid/api` poll inside the stale-helper reaper: it sees the device is no longer booted and `process.kill(state.pid, "SIGTERM")` to recycle what it assumes is a separate helper. But in in-process mode `inProcessServeSimState` records the server's own `process.pid`, so the server SIGTERMs itself, and `index.ts` converts SIGTERM into `process.exit(0)`.

`index.ts` `readStateFile` (the `--list` / `--detach` path) had the identical blind spot.

# How

The reaper now distinguishes a device streamed in-process by this server from a genuinely separate helper process:

- Added `classifyStaleState(state, booted, selfPid)`, which returns `recycle-self` when the dead device is owned by our own pid and `recycle-helper` otherwise.
- `recycle-self` calls `closeDeviceSession(device)` to stop just that device's capture session instead of signalling the pid. `recycle-helper` keeps the existing SIGTERM for real separate processes (still needed for `--detach` helpers).
- The `grid/api/shutdown` handler now calls `closeDeviceSession(udid)` up front so capture stops immediately rather than waiting for the next poll.
- The `--list` / `--detach` `readStateFile` path guards against `state.pid === process.pid` and just drops the stale file instead of killing the process.

# Test Plan

- `bun run lint` and `bun run typecheck` pass.
- Manually exercised: shutting a streamed simulator down via the UI close button now stops that device's stream and leaves the server running; a separately detached helper bound to a shut-down device is still reaped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of stale simulator/device state to avoid accidentally terminating the running server in in-process preview scenarios.
  * Cleaned up stale sessions more safely by removing outdated state files when they belong to the current process.
  * Freed device sessions earlier during shutdown, reducing the chance of lingering simulator capture sessions and improving reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->