### PR TITLE
feat: add event log

### DIFF
--- a/packages/serve-sim/README.md
+++ b/packages/serve-sim/README.md
@@ -19,6 +19,7 @@ https://github.com/user-attachments/assets/fbf890f4-c8c7-4684-82be-d677b8a188f8
 - Swipe from the bottom to go home.
 - gestures like pinch to zoom by holding the option key.
 - Simulator logs are forwarded to the browser for browser-use MCP tools to read from.
+- Recent simulator actions are available in the browser tools panel and `serve-sim event-log`.
 - Drag and drop videos and images to add them to the simulator device. 
 - Keyboard commands and hot keys are forwarded to the simulator, including CMD+SHIFT+H to go home.
 - Apple Watch, iPad, and iOS support.
@@ -51,6 +52,7 @@ serve-sim ca-debug <option> <on|off> [-d udid]
                                       Toggle a CoreAnimation debug flag
                                       (blended|copies|misaligned|offscreen|slow-animations)
 serve-sim memory-warning [-d udid]    Simulate a memory warning
+serve-sim event-log [-d udid]         Show recent simulator events
 
 serve-sim camera <bundle-id> [-d udid] [source-options]
                                       Inject a synthetic camera feed and (re)launch the app

--- a/packages/serve-sim/src/__tests__/event-log-format.test.ts
+++ b/packages/serve-sim/src/__tests__/event-log-format.test.ts
@@ -16,7 +16,7 @@ function entry(overrides: Partial<EventLogEntry>): EventLogEntry {
 }
 
 describe("formatEventLogLine", () => {
-  test("hides internal source/kind and formats tap coordinates as percentages", () => {
+  test("hides internal source/kind and formats tap coordinates as normalized values", () => {
     expect(
       formatEventLogLine(entry({
         device: "AC78FEE5-C665-4295-889B-F6BCB1A618D5",
@@ -24,7 +24,7 @@ describe("formatEventLogLine", () => {
         summary: "Tap 0.214,0.585",
         details: { current: { x: 0.214, y: 0.585 } },
       }), { deviceLabel: "iPhone 17" }),
-    ).toContain("iPhone 17  Tap at 21%, 59%");
+    ).toContain("iPhone 17  Tap at 0.21, 0.59");
   });
 
   test("formats drags as a sentence", () => {
@@ -38,7 +38,7 @@ describe("formatEventLogLine", () => {
           moveCount: 74,
         },
       })),
-    ).toContain("Drag from 85%, 54% to 100%, 51%");
+    ).toContain("Drag from 0.85, 0.54 to 1.00, 0.51");
   });
 
   test("humanizes key and rotation labels", () => {

--- a/packages/serve-sim/src/__tests__/event-log-format.test.ts
+++ b/packages/serve-sim/src/__tests__/event-log-format.test.ts
@@ -3,12 +3,14 @@ import { formatEventLogLine } from "../event-log-format";
 import type { EventLogEntry } from "../event-log";
 
 function entry(overrides: Partial<EventLogEntry>): EventLogEntry {
+  const summary = overrides.summary ?? "Tap 0.214,0.585";
   return {
     id: 1,
     timestamp: "2026-07-02T14:24:38.000Z",
     source: "hid",
     kind: "tap",
-    summary: "Tap 0.214,0.585",
+    msg: overrides.msg ?? summary,
+    summary,
     ...overrides,
   };
 }

--- a/packages/serve-sim/src/__tests__/event-log-format.test.ts
+++ b/packages/serve-sim/src/__tests__/event-log-format.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { formatEventLogLine } from "../event-log-format";
+import type { EventLogEntry } from "../event-log";
+
+function entry(overrides: Partial<EventLogEntry>): EventLogEntry {
+  return {
+    id: 1,
+    timestamp: "2026-07-02T14:24:38.000Z",
+    source: "hid",
+    kind: "tap",
+    summary: "Tap 0.214,0.585",
+    ...overrides,
+  };
+}
+
+describe("formatEventLogLine", () => {
+  test("hides internal source/kind and formats tap coordinates as percentages", () => {
+    expect(
+      formatEventLogLine(entry({
+        device: "AC78FEE5-C665-4295-889B-F6BCB1A618D5",
+        kind: "tap",
+        summary: "Tap 0.214,0.585",
+        details: { current: { x: 0.214, y: 0.585 } },
+      })),
+    ).toContain("AC78FEE5  Tap at 21%, 59%");
+  });
+
+  test("formats drags as a sentence", () => {
+    expect(
+      formatEventLogLine(entry({
+        kind: "drag",
+        summary: "Drag 0.854,0.542 -> 1,0.51",
+        details: {
+          start: { x: 0.854, y: 0.542 },
+          current: { x: 1, y: 0.51 },
+          moveCount: 74,
+        },
+      })),
+    ).toContain("Drag from 85%, 54% to 100%, 51%");
+  });
+
+  test("humanizes key and rotation labels", () => {
+    expect(
+      formatEventLogLine(entry({
+        kind: "key",
+        action: "up",
+        summary: "Key up MetaLeft",
+        details: { key: "MetaLeft" },
+      })),
+    ).toContain("Key up Left Command");
+    expect(
+      formatEventLogLine(entry({
+        kind: "rotate",
+        action: "landscape_left",
+        summary: "Rotate landscape_left",
+      })),
+    ).toContain("Rotate landscape left");
+  });
+});

--- a/packages/serve-sim/src/__tests__/event-log-format.test.ts
+++ b/packages/serve-sim/src/__tests__/event-log-format.test.ts
@@ -21,8 +21,8 @@ describe("formatEventLogLine", () => {
         kind: "tap",
         summary: "Tap 0.214,0.585",
         details: { current: { x: 0.214, y: 0.585 } },
-      })),
-    ).toContain("AC78FEE5  Tap at 21%, 59%");
+      }), { deviceLabel: "iPhone 17" }),
+    ).toContain("iPhone 17  Tap at 21%, 59%");
   });
 
   test("formats drags as a sentence", () => {

--- a/packages/serve-sim/src/__tests__/event-log.test.ts
+++ b/packages/serve-sim/src/__tests__/event-log.test.ts
@@ -31,8 +31,30 @@ describe("event log store", () => {
     });
 
     expect(readEventLog().map((event) => event.id)).toEqual([1, 2]);
+    expect(readEventLog().map((event) => event.msg)).toEqual(["Home", "Button volume-up"]);
     expect(readEventLog({ device: "DEVICE-B" }).map((event) => event.summary)).toEqual([
       "Button volume-up",
+    ]);
+  });
+
+  test("keeps a bunyan-style msg field on recorded entries", () => {
+    recordEventLogEvent({
+      source: "exec",
+      kind: "button",
+      action: "home",
+      summary: "Home",
+    });
+    recordEventLogEvent({
+      source: "exec",
+      kind: "button",
+      action: "home",
+      summary: "Home",
+      msg: "Pressed Home",
+    });
+
+    expect(readEventLog()).toMatchObject([
+      { summary: "Home", msg: "Home" },
+      { summary: "Home", msg: "Pressed Home" },
     ]);
   });
 
@@ -76,7 +98,7 @@ describe("event log store", () => {
     unsubscribe();
 
     expect(readEventLog()).toMatchObject([
-      { id: entry.id, kind: "tap", action: "tap", summary: "Tap 0.1,0.2" },
+      { id: entry.id, kind: "tap", action: "tap", summary: "Tap 0.1,0.2", msg: "Tap 0.1,0.2" },
     ]);
     expect(seen).toEqual(["Touch begin 0.1,0.2", "Tap 0.1,0.2"]);
   });

--- a/packages/serve-sim/src/__tests__/event-log.test.ts
+++ b/packages/serve-sim/src/__tests__/event-log.test.ts
@@ -115,6 +115,25 @@ describe("eventLogEventForHidMessage", () => {
       details: { screen: { width: 390, height: 844 } },
     });
   });
+
+  test("maps key HID usages to readable labels", () => {
+    expect(
+      eventLogEventForHidMessage("UDID", 0x06, { type: "up", usage: 23 }),
+    ).toMatchObject({
+      device: "UDID",
+      source: "hid",
+      kind: "key",
+      action: "up",
+      summary: "Key up t",
+      details: { usage: 23, key: "t" },
+    });
+    expect(
+      eventLogEventForHidMessage("UDID", 0x06, { type: "down", usage: 0x28 }),
+    ).toMatchObject({
+      summary: "Key down Enter",
+      details: { usage: 0x28, key: "Enter" },
+    });
+  });
 });
 
 describe("eventLogEventForCommand", () => {

--- a/packages/serve-sim/src/__tests__/event-log.test.ts
+++ b/packages/serve-sim/src/__tests__/event-log.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test, beforeEach } from "bun:test";
+import {
+  clearEventLogForTests,
+  eventLogEventForCommand,
+  eventLogEventForHidMessage,
+  readEventLog,
+  recordEventLogEvent,
+  subscribeEventLog,
+} from "../event-log";
+
+beforeEach(() => {
+  clearEventLogForTests();
+});
+
+describe("event log store", () => {
+  test("records entries in order and filters by device", () => {
+    recordEventLogEvent({
+      device: "DEVICE-A",
+      source: "hid",
+      kind: "button",
+      action: "home",
+      summary: "Home",
+    });
+    recordEventLogEvent({
+      device: "DEVICE-B",
+      source: "hid",
+      kind: "button",
+      action: "volume-up",
+      summary: "Button volume-up",
+    });
+
+    expect(readEventLog().map((event) => event.id)).toEqual([1, 2]);
+    expect(readEventLog({ device: "DEVICE-B" }).map((event) => event.summary)).toEqual([
+      "Button volume-up",
+    ]);
+  });
+
+  test("supports since and limit reads", () => {
+    for (let i = 0; i < 5; i++) {
+      recordEventLogEvent({
+        source: "exec",
+        kind: "button",
+        summary: `Event ${i}`,
+      });
+    }
+
+    expect(readEventLog({ sinceId: 2 }).map((event) => event.id)).toEqual([3, 4, 5]);
+    expect(readEventLog({ limit: 2 }).map((event) => event.id)).toEqual([4, 5]);
+  });
+
+  test("notifies subscribers as entries are recorded", () => {
+    const seen: string[] = [];
+    const unsubscribe = subscribeEventLog((event) => seen.push(event.summary));
+    recordEventLogEvent({ source: "exec", kind: "button", summary: "Home" });
+    unsubscribe();
+    recordEventLogEvent({ source: "exec", kind: "button", summary: "Ignored" });
+    expect(seen).toEqual(["Home"]);
+  });
+});
+
+describe("eventLogEventForHidMessage", () => {
+  test("maps button HID payloads", () => {
+    expect(
+      eventLogEventForHidMessage("UDID", 0x04, {
+        button: "volume-up",
+        page: 12,
+        usage: 233,
+        phase: "down",
+      }),
+    ).toMatchObject({
+      device: "UDID",
+      source: "hid",
+      kind: "button",
+      action: "volume-up",
+      summary: "Button volume-up down",
+    });
+  });
+
+  test("maps touch payloads with screen details", () => {
+    expect(
+      eventLogEventForHidMessage("UDID", 0x03, { type: "begin", x: 0.5, y: 0.9 }, {
+        width: 390,
+        height: 844,
+      }),
+    ).toMatchObject({
+      device: "UDID",
+      source: "hid",
+      kind: "touch",
+      action: "begin",
+      summary: "Touch begin 0.5,0.9",
+      details: { screen: { width: 390, height: 844 } },
+    });
+  });
+});
+
+describe("eventLogEventForCommand", () => {
+  test("classifies app installs without logging upload chunks", () => {
+    expect(eventLogEventForCommand("bash -c 'echo abc= | base64 -d > /tmp/app.ipa'")).toBeNull();
+    expect(
+      eventLogEventForCommand("xcrun simctl install DEVICE-A /tmp/MyApp.ipa", { exitCode: 0 }),
+    ).toMatchObject({
+      device: "DEVICE-A",
+      source: "exec",
+      kind: "app",
+      action: "install",
+      status: "ok",
+      summary: "Install app MyApp.ipa",
+    });
+  });
+
+  test("classifies toolbar home and screenshot commands", () => {
+    expect(
+      eventLogEventForCommand("xcrun simctl launch DEVICE-A com.apple.springboard", { exitCode: 0 }),
+    ).toMatchObject({
+      device: "DEVICE-A",
+      kind: "button",
+      action: "home",
+      summary: "Home",
+    });
+    expect(
+      eventLogEventForCommand("xcrun simctl io DEVICE-A screenshot ~/Desktop/shot.png", { exitCode: 1 }),
+    ).toMatchObject({
+      device: "DEVICE-A",
+      kind: "screenshot",
+      status: "error",
+      summary: "Screenshot",
+    });
+  });
+
+  test("classifies serve-sim commands invoked through node", () => {
+    expect(
+      eventLogEventForCommand("node /tmp/dist/serve-sim.js button volume-up -d DEVICE-A"),
+    ).toMatchObject({
+      device: "DEVICE-A",
+      kind: "button",
+      action: "volume-up",
+      summary: "Button volume-up",
+    });
+  });
+});

--- a/packages/serve-sim/src/__tests__/event-log.test.ts
+++ b/packages/serve-sim/src/__tests__/event-log.test.ts
@@ -6,6 +6,7 @@ import {
   readEventLog,
   recordEventLogEvent,
   subscribeEventLog,
+  updateEventLogEvent,
 } from "../event-log";
 
 beforeEach(() => {
@@ -55,6 +56,29 @@ describe("event log store", () => {
     unsubscribe();
     recordEventLogEvent({ source: "exec", kind: "button", summary: "Ignored" });
     expect(seen).toEqual(["Home"]);
+  });
+
+  test("updates entries in place and notifies subscribers", () => {
+    const seen: string[] = [];
+    const unsubscribe = subscribeEventLog((event) => seen.push(event.summary));
+    const entry = recordEventLogEvent({
+      source: "hid",
+      kind: "touch",
+      action: "begin",
+      summary: "Touch begin 0.1,0.2",
+    });
+
+    updateEventLogEvent(entry.id, {
+      kind: "tap",
+      action: "tap",
+      summary: "Tap 0.1,0.2",
+    });
+    unsubscribe();
+
+    expect(readEventLog()).toMatchObject([
+      { id: entry.id, kind: "tap", action: "tap", summary: "Tap 0.1,0.2" },
+    ]);
+    expect(seen).toEqual(["Touch begin 0.1,0.2", "Tap 0.1,0.2"]);
   });
 });
 
@@ -136,5 +160,14 @@ describe("eventLogEventForCommand", () => {
       action: "volume-up",
       summary: "Button volume-up",
     });
+  });
+
+  test("does not log read-only camera polling commands", () => {
+    expect(
+      eventLogEventForCommand("node /tmp/dist/serve-sim.js camera status -d DEVICE-A", { exitCode: 0 }),
+    ).toBeNull();
+    expect(
+      eventLogEventForCommand("node /tmp/dist/serve-sim.js camera --list-webcams", { exitCode: 0 }),
+    ).toBeNull();
   });
 });

--- a/packages/serve-sim/src/__tests__/event-log.test.ts
+++ b/packages/serve-sim/src/__tests__/event-log.test.ts
@@ -222,8 +222,27 @@ describe("eventLogEventForCommand", () => {
       kind: "app",
       action: "install",
       status: "ok",
-      summary: "Install app MyApp.ipa",
+      summary: "Install app",
     });
+  });
+
+  test("does not persist raw exec commands, host paths, or unknown execs", () => {
+    const event = eventLogEventForCommand(
+      "xcrun simctl install DEVICE-A /Users/me/Secrets/MyApp.ipa --token should-not-log",
+      { exitCode: 0 },
+    );
+
+    expect(event).toMatchObject({
+      summary: "Install app",
+      details: { exitCode: 0 },
+    });
+    const serialized = JSON.stringify(event);
+    expect(serialized).not.toContain("/Users/me");
+    expect(serialized).not.toContain("MyApp.ipa");
+    expect(serialized).not.toContain("should-not-log");
+    expect(serialized).not.toContain("command");
+    expect(serialized).not.toContain("path");
+    expect(eventLogEventForCommand("curl https://example.com?token=should-not-log")).toBeNull();
   });
 
   test("classifies toolbar home and screenshot commands", () => {

--- a/packages/serve-sim/src/__tests__/event-log.test.ts
+++ b/packages/serve-sim/src/__tests__/event-log.test.ts
@@ -121,6 +121,35 @@ describe("event log store", () => {
     ]);
     expect(seen).toEqual(["Touch begin 0.1,0.2", "Tap 0.1,0.2"]);
   });
+
+  test("can update entries without notifying subscribers", () => {
+    const seen: string[] = [];
+    const unsubscribe = subscribeEventLog((event) => seen.push(event.summary));
+    const entry = recordEventLogEvent({
+      source: "hid",
+      kind: "drag",
+      action: "drag",
+      summary: "Drag 0.1,0.2 -> 0.3,0.4",
+    });
+
+    updateEventLogEvent(
+      entry.id,
+      {
+        summary: "Drag 0.1,0.2 -> 0.5,0.6",
+      },
+      { notify: false },
+    );
+    unsubscribe();
+
+    expect(readEventLog()).toMatchObject([
+      {
+        id: entry.id,
+        summary: "Drag 0.1,0.2 -> 0.5,0.6",
+        msg: "Drag 0.1,0.2 -> 0.5,0.6",
+      },
+    ]);
+    expect(seen).toEqual(["Drag 0.1,0.2 -> 0.3,0.4"]);
+  });
 });
 
 describe("eventLogEventForHidMessage", () => {

--- a/packages/serve-sim/src/__tests__/event-log.test.ts
+++ b/packages/serve-sim/src/__tests__/event-log.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, beforeEach } from "bun:test";
 import {
   clearEventLogForTests,
+  EVENT_LOG_MAX_ENTRIES,
   eventLogEventForCommand,
   eventLogEventForHidMessage,
   readEventLog,
@@ -71,6 +72,24 @@ describe("event log store", () => {
     expect(readEventLog({ limit: 2 }).map((event) => event.id)).toEqual([4, 5]);
   });
 
+  test("keeps only the newest entries when the store reaches its cap", () => {
+    for (let i = 0; i < EVENT_LOG_MAX_ENTRIES + 3; i++) {
+      recordEventLogEvent({
+        source: "exec",
+        kind: "button",
+        summary: `Event ${i}`,
+      });
+    }
+
+    const events = readEventLog();
+    expect(events).toHaveLength(EVENT_LOG_MAX_ENTRIES);
+    expect(events[0]).toMatchObject({ id: 4, summary: "Event 3" });
+    expect(events.at(-1)).toMatchObject({
+      id: EVENT_LOG_MAX_ENTRIES + 3,
+      summary: `Event ${EVENT_LOG_MAX_ENTRIES + 2}`,
+    });
+  });
+
   test("notifies subscribers as entries are recorded", () => {
     const seen: string[] = [];
     const unsubscribe = subscribeEventLog((event) => seen.push(event.summary));
@@ -138,17 +157,22 @@ describe("eventLogEventForHidMessage", () => {
     });
   });
 
-  test("maps key HID usages to readable labels", () => {
-    expect(
-      eventLogEventForHidMessage("UDID", 0x06, { type: "up", usage: 23 }),
-    ).toMatchObject({
-      device: "UDID",
-      source: "hid",
-      kind: "key",
-      action: "up",
-      summary: "Key up t",
-      details: { usage: 23, key: "t" },
-    });
+  test("redacts printable key HID usages", () => {
+    for (const usage of [23, 0x1e, 0x2d]) {
+      const event = eventLogEventForHidMessage("UDID", 0x06, { type: "up", usage });
+      expect(event).toMatchObject({
+        device: "UDID",
+        source: "hid",
+        kind: "key",
+        action: "up",
+        summary: "Key up character",
+        details: { key: "character", redacted: true },
+      });
+      expect("usage" in event!.details!).toBe(false);
+    }
+  });
+
+  test("maps non-printable key HID usages to readable labels", () => {
     expect(
       eventLogEventForHidMessage("UDID", 0x06, { type: "down", usage: 0x28 }),
     ).toMatchObject({

--- a/packages/serve-sim/src/__tests__/exec-ws.test.ts
+++ b/packages/serve-sim/src/__tests__/exec-ws.test.ts
@@ -151,7 +151,8 @@ describe("exec-ws control channel", () => {
 
     const res = await fetch(`http://127.0.0.1:${PORT}/api/event-log?device=DEVICE-B`);
     expect(res.status).toBe(200);
-    const payload = await res.json() as { events: Array<{ summary: string }> };
+    const payload = await res.json() as { events: Array<{ msg: string; summary: string }> };
+    expect(payload.events.map((event) => event.msg)).toEqual(["Button volume-up"]);
     expect(payload.events.map((event) => event.summary)).toEqual(["Button volume-up"]);
   });
 

--- a/packages/serve-sim/src/__tests__/exec-ws.test.ts
+++ b/packages/serve-sim/src/__tests__/exec-ws.test.ts
@@ -17,7 +17,7 @@ const TOKEN = "exec-ws-test-token";
 let server: PreviewServer;
 
 beforeAll(async () => {
-  const middleware = simMiddleware({ basePath: "/", execToken: TOKEN });
+  const middleware = simMiddleware({ basePath: "/", execToken: TOKEN, device: "DEVICE-A" });
   server = await servePreview({ port: PORT, middleware, host: "127.0.0.1" });
 });
 
@@ -153,6 +153,30 @@ describe("exec-ws control channel", () => {
     expect(res.status).toBe(200);
     const payload = await res.json() as { events: Array<{ summary: string }> };
     expect(payload.events.map((event) => event.summary)).toEqual(["Button volume-up"]);
+  });
+
+  test("event log endpoint only filters when a device query is present", async () => {
+    clearEventLogForTests();
+    recordEventLogEvent({
+      device: "DEVICE-A",
+      source: "hid",
+      kind: "button",
+      summary: "Button home",
+    });
+    recordEventLogEvent({
+      device: "DEVICE-B",
+      source: "hid",
+      kind: "button",
+      summary: "Button volume-up",
+    });
+
+    const res = await fetch(`http://127.0.0.1:${PORT}/api/event-log`);
+    expect(res.status).toBe(200);
+    const payload = await res.json() as { events: Array<{ summary: string }> };
+    expect(payload.events.map((event) => event.summary)).toEqual([
+      "Button home",
+      "Button volume-up",
+    ]);
   });
 
   test("event log sse route is available over the control socket", async () => {

--- a/packages/serve-sim/src/__tests__/exec-ws.test.ts
+++ b/packages/serve-sim/src/__tests__/exec-ws.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { clearEventLogForTests, recordEventLogEvent } from "../event-log";
 import { simMiddleware } from "../middleware";
 import { servePreview, type PreviewServer } from "../runtime";
 
@@ -32,6 +33,7 @@ interface Reply {
   error?: string;
   sub?: number;
   end?: boolean;
+  data?: string;
 }
 
 function connect(token: string): Promise<{
@@ -129,6 +131,53 @@ describe("exec-ws control channel", () => {
     expect(reply.sub).toBe(8);
     expect(typeof (reply as { data?: string }).data).toBe("string");
     channel.send({ unsub: 8 });
+    channel.close();
+  });
+
+  test("event log endpoint filters by device", async () => {
+    clearEventLogForTests();
+    recordEventLogEvent({
+      device: "DEVICE-A",
+      source: "hid",
+      kind: "button",
+      summary: "Button home",
+    });
+    recordEventLogEvent({
+      device: "DEVICE-B",
+      source: "hid",
+      kind: "button",
+      summary: "Button volume-up",
+    });
+
+    const res = await fetch(`http://127.0.0.1:${PORT}/api/event-log?device=DEVICE-B`);
+    expect(res.status).toBe(200);
+    const payload = await res.json() as { events: Array<{ summary: string }> };
+    expect(payload.events.map((event) => event.summary)).toEqual(["Button volume-up"]);
+  });
+
+  test("event log sse route is available over the control socket", async () => {
+    clearEventLogForTests();
+    recordEventLogEvent({
+      device: "DEVICE-A",
+      source: "hid",
+      kind: "button",
+      summary: "Button home",
+    });
+
+    const channel = await connect(TOKEN);
+    await channel.next(); // ready
+    channel.send({ sub: 9, path: "/api/event-log/events?device=DEVICE-A" });
+    let reply = await channel.next();
+    let data = /^data: (.*)$/m.exec(reply.data ?? "")?.[1];
+    if (!data) {
+      reply = await channel.next();
+      data = /^data: (.*)$/m.exec(reply.data ?? "")?.[1];
+    }
+    expect(reply.sub).toBe(9);
+    expect(data).toBeTruthy();
+    const payload = JSON.parse(data!) as { events?: Array<{ summary: string }> };
+    expect(payload.events?.map((event) => event.summary)).toEqual(["Button home"]);
+    channel.send({ unsub: 9 });
     channel.close();
   });
 });

--- a/packages/serve-sim/src/__tests__/exec-ws.test.ts
+++ b/packages/serve-sim/src/__tests__/exec-ws.test.ts
@@ -194,7 +194,7 @@ describe("exec-ws control channel", () => {
     channel.send({ sub: 9, path: "/api/event-log/events?device=DEVICE-A" });
     let reply = await channel.next();
     let data = /^data: (.*)$/m.exec(reply.data ?? "")?.[1];
-    if (!data) {
+    for (let attempts = 0; !data && attempts < 5; attempts++) {
       reply = await channel.next();
       data = /^data: (.*)$/m.exec(reply.data ?? "")?.[1];
     }

--- a/packages/serve-sim/src/__tests__/middleware-selection.test.ts
+++ b/packages/serve-sim/src/__tests__/middleware-selection.test.ts
@@ -48,6 +48,8 @@ describe("previewConfigForState", () => {
       ...state,
       basePath: "/preview",
       appStateEndpoint: "/preview/appstate?device=DEVICE-B",
+      eventLogEndpoint: "/preview/api/event-log?device=DEVICE-B",
+      eventLogEventsEndpoint: "/preview/api/event-log/events?device=DEVICE-B",
       axEndpoint: "/preview/ax?device=DEVICE-B",
       devtoolsEndpoint: "/preview/devtools?device=DEVICE-B",
       serveSimBin: "/bin/serve-sim",

--- a/packages/serve-sim/src/client/client.tsx
+++ b/packages/serve-sim/src/client/client.tsx
@@ -1140,6 +1140,7 @@ function AppWithConfig({
         udid={config.device}
         deviceRuntime={deviceRuntime}
         currentApp={currentApp}
+        eventLogEventsEndpoint={config.eventLogEventsEndpoint}
         axOverlayEnabled={axOverlayEnabled}
         onToggleAxOverlay={() => setAxOverlayEnabled((enabled) => !enabled)}
         codecPreference={codecPreference}

--- a/packages/serve-sim/src/client/components/event-log-tool.tsx
+++ b/packages/serve-sim/src/client/components/event-log-tool.tsx
@@ -90,6 +90,7 @@ export function EventLogTool({
 function EventLogRow({ event }: { event: EventLogEntry }) {
   const time = formatTime(event.timestamp);
   const detail = [event.source, event.kind, event.action].filter(Boolean).join(" / ");
+  const message = event.msg ?? event.summary;
   const statusClass = event.status === "error"
     ? "border-[#ff453a]/50 bg-[#ff453a]/10 text-[#ffb3ad]"
     : "border-white/8 bg-white/[0.04] text-white/50";
@@ -103,7 +104,7 @@ function EventLogRow({ event }: { event: EventLogEntry }) {
       <span className="font-mono text-[10px] text-white/45">{time}</span>
       <span className="min-w-0">
         <span className="block overflow-hidden text-ellipsis whitespace-nowrap text-white/90">
-          {event.summary}
+          {message}
         </span>
         <span className="mt-0.5 block overflow-hidden text-ellipsis whitespace-nowrap font-mono text-[10px] text-white/40">
           {detail}

--- a/packages/serve-sim/src/client/components/event-log-tool.tsx
+++ b/packages/serve-sim/src/client/components/event-log-tool.tsx
@@ -9,6 +9,8 @@ type EventLogPayload = {
   event?: EventLogEntry;
 };
 
+const MAX_EVENT_LOG_ROWS = 500;
+
 export function EventLogTool({
   udid,
   eventsEndpoint,
@@ -34,9 +36,12 @@ export function EventLogTool({
         const payload = JSON.parse(data) as EventLogPayload;
         setErrored(false);
         if (Array.isArray(payload.events)) {
-          setEvents(payload.events);
+          setEvents(payload.events.slice(-MAX_EVENT_LOG_ROWS));
         } else if (payload.event) {
-          setEvents((prev) => [...prev.filter((entry) => entry.id !== payload.event!.id), payload.event!]);
+          setEvents((prev) => {
+            const next = [...prev.filter((entry) => entry.id !== payload.event!.id), payload.event!];
+            return next.slice(-MAX_EVENT_LOG_ROWS);
+          });
         }
       } catch {}
     };

--- a/packages/serve-sim/src/client/components/event-log-tool.tsx
+++ b/packages/serve-sim/src/client/components/event-log-tool.tsx
@@ -27,7 +27,6 @@ export function EventLogTool({
   );
 
   useEffect(() => {
-    if (!open) return;
     setErrored(false);
     setEvents([]);
     const stream = openHostEventStream(path);
@@ -47,7 +46,7 @@ export function EventLogTool({
     };
     stream.onerror = () => setErrored(true);
     return () => stream.close();
-  }, [open, path]);
+  }, [path]);
 
   const visibleEvents = useMemo(() => events.slice().reverse(), [events]);
 

--- a/packages/serve-sim/src/client/components/event-log-tool.tsx
+++ b/packages/serve-sim/src/client/components/event-log-tool.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useMemo, useState } from "react";
+import type { EventLogEntry } from "../../event-log";
+import { openHostEventStream } from "../utils/exec";
+import { simEndpoint } from "../utils/sim-endpoint";
+import { CollapsibleSection } from "./collapsible-section";
+
+type EventLogPayload = {
+  events?: EventLogEntry[];
+  event?: EventLogEntry;
+};
+
+export function EventLogTool({
+  udid,
+  eventsEndpoint,
+}: {
+  udid: string;
+  eventsEndpoint?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [events, setEvents] = useState<EventLogEntry[]>([]);
+  const [errored, setErrored] = useState(false);
+  const path = useMemo(
+    () => eventsEndpoint ?? `${simEndpoint("api/event-log/events")}?device=${encodeURIComponent(udid)}`,
+    [eventsEndpoint, udid],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    setErrored(false);
+    setEvents([]);
+    const stream = openHostEventStream(path);
+    stream.onmessage = ({ data }) => {
+      try {
+        const payload = JSON.parse(data) as EventLogPayload;
+        setErrored(false);
+        if (Array.isArray(payload.events)) {
+          setEvents(payload.events);
+        } else if (payload.event) {
+          setEvents((prev) => [...prev.filter((entry) => entry.id !== payload.event!.id), payload.event!]);
+        }
+      } catch {}
+    };
+    stream.onerror = () => setErrored(true);
+    return () => stream.close();
+  }, [open, path]);
+
+  const visibleEvents = useMemo(() => events.slice().reverse(), [events]);
+
+  return (
+    <CollapsibleSection
+      open={open}
+      onOpenChange={setOpen}
+      data-event-log=""
+      summaryClassName="grid [grid-template-columns:auto_1fr_auto] items-center gap-2 text-left"
+      summary={
+        <>
+          <span className="text-[11px] font-semibold text-white/50 uppercase tracking-[0.08em] leading-none">
+            Event Log
+          </span>
+          <span />
+          <span className="rounded-md border border-white/8 bg-white/[0.04] px-1.5 py-[3px] text-[10px] font-mono text-white/60">
+            {events.length}
+          </span>
+        </>
+      }
+    >
+      {visibleEvents.length === 0 ? (
+        <div
+          role="status"
+          aria-live="polite"
+          className="flex items-center justify-center py-4 text-[12px] text-white/45"
+        >
+          {errored ? "Disconnected" : "No events yet"}
+        </div>
+      ) : (
+        <div className="flex max-h-[320px] flex-col gap-1 overflow-y-auto py-0.5 [scrollbar-width:thin]" role="list">
+          {visibleEvents.map((event) => (
+            <EventLogRow key={event.id} event={event} />
+          ))}
+        </div>
+      )}
+    </CollapsibleSection>
+  );
+}
+
+function EventLogRow({ event }: { event: EventLogEntry }) {
+  const time = formatTime(event.timestamp);
+  const detail = [event.source, event.kind, event.action].filter(Boolean).join(" / ");
+  const statusClass = event.status === "error"
+    ? "border-[#ff453a]/50 bg-[#ff453a]/10 text-[#ffb3ad]"
+    : "border-white/8 bg-white/[0.04] text-white/50";
+
+  return (
+    <div
+      role="listitem"
+      title={detail}
+      className="grid grid-cols-[56px_1fr_auto] items-center gap-2 rounded-md px-1.5 py-1.5 text-[12px] leading-tight hover:bg-white/[0.05]"
+    >
+      <span className="font-mono text-[10px] text-white/45">{time}</span>
+      <span className="min-w-0">
+        <span className="block overflow-hidden text-ellipsis whitespace-nowrap text-white/90">
+          {event.summary}
+        </span>
+        <span className="mt-0.5 block overflow-hidden text-ellipsis whitespace-nowrap font-mono text-[10px] text-white/40">
+          {detail}
+        </span>
+      </span>
+      {event.status ? (
+        <span className={`rounded-md border px-1.5 py-[3px] text-[10px] font-mono ${statusClass}`}>
+          {event.status}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function formatTime(timestamp: string): string {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}

--- a/packages/serve-sim/src/client/components/tools-panel.tsx
+++ b/packages/serve-sim/src/client/components/tools-panel.tsx
@@ -5,6 +5,7 @@ import { AppDetectionTool } from "./app-detection-tool";
 import { AppPermissionsTool } from "./app-permissions-tool";
 import { AxTreeTool } from "./ax-tree-tool";
 import { CameraTool } from "./camera-tool";
+import { EventLogTool } from "./event-log-tool";
 import { PANEL_BACKGROUND } from "./panel-colors";
 import { SimulatorSettingsTool } from "./simulator-settings-tool";
 import { StreamSettingsTool, type CodecPreference } from "./stream-settings-tool";
@@ -15,6 +16,7 @@ export function ToolsPanel({
   udid,
   deviceRuntime,
   currentApp,
+  eventLogEventsEndpoint,
   axOverlayEnabled,
   onToggleAxOverlay,
   codecPreference,
@@ -28,6 +30,7 @@ export function ToolsPanel({
   udid: string;
   deviceRuntime: string | null;
   currentApp: { bundleId: string; isReactNative: boolean; pid?: number } | null;
+  eventLogEventsEndpoint?: string;
   axOverlayEnabled: boolean;
   onToggleAxOverlay: () => void;
   codecPreference: CodecPreference;
@@ -46,6 +49,7 @@ export function ToolsPanel({
       {open && (
         <div className="p-3.5 overflow-y-auto flex-1 flex flex-col gap-3">
           <AppDetectionTool udid={udid} currentApp={currentApp} />
+          <EventLogTool udid={udid} eventsEndpoint={eventLogEventsEndpoint} />
           <SimulatorSettingsTool udid={udid} runtime={deviceRuntime} />
           <AxTreeTool
             overlayEnabled={axOverlayEnabled}

--- a/packages/serve-sim/src/client/utils/sim-endpoint.ts
+++ b/packages/serve-sim/src/client/utils/sim-endpoint.ts
@@ -10,6 +10,8 @@ declare global {
       basePath: string;
       axEndpoint?: string;
       appStateEndpoint?: string;
+      eventLogEndpoint?: string;
+      eventLogEventsEndpoint?: string;
       devtoolsEndpoint?: string;
       gridApiEndpoint?: string;
       gridStartEndpoint?: string;

--- a/packages/serve-sim/src/device-session.ts
+++ b/packages/serve-sim/src/device-session.ts
@@ -420,17 +420,17 @@ export class DeviceSession {
             device: this.udid,
             source: "hid",
             kind: "drag",
-            action: "move",
+            action: "drag",
             summary: touchGestureSummary(gesture),
-            details: this.touchGestureDetails(gesture, "move"),
+            details: this.touchGestureDetails(gesture, "drag", "move"),
           });
           gesture.eventId = entry.id;
         } else {
           updateEventLogEvent(gesture.eventId, {
             kind: "drag",
-            action: "move",
+            action: "drag",
             summary: touchGestureSummary(gesture),
-            details: this.touchGestureDetails(gesture, "move"),
+            details: this.touchGestureDetails(gesture, "drag", "move"),
           });
         }
       }
@@ -449,16 +449,16 @@ export class DeviceSession {
               device: this.udid,
               source: "hid",
               kind: "drag",
-              action: "end",
+              action: "drag",
               summary: touchGestureSummary(gesture),
-              details: this.touchGestureDetails(gesture, "end"),
+              details: this.touchGestureDetails(gesture, "drag", "end"),
             });
           } else {
             updateEventLogEvent(gesture.eventId, {
               kind: "drag",
-              action: "end",
+              action: "drag",
               summary: touchGestureSummary(gesture),
-              details: this.touchGestureDetails(gesture, "end"),
+              details: this.touchGestureDetails(gesture, "drag", "end"),
             });
           }
         } else {
@@ -485,9 +485,14 @@ export class DeviceSession {
       : undefined;
   }
 
-  private touchGestureDetails(gesture: TouchGestureLog, type: string): Record<string, unknown> {
+  private touchGestureDetails(
+    gesture: TouchGestureLog,
+    type: "drag" | "tap",
+    phase?: "move" | "end",
+  ): Record<string, unknown> {
     return {
       type,
+      ...(phase ? { phase } : {}),
       start: { x: gesture.startX, y: gesture.startY },
       current: { x: gesture.lastX, y: gesture.lastY },
       moveCount: gesture.moveCount,

--- a/packages/serve-sim/src/device-session.ts
+++ b/packages/serve-sim/src/device-session.ts
@@ -23,6 +23,7 @@ import {
   axFrontmostAsync,
   type MjpegFrame,
 } from "./native";
+import { eventLogEventForHidMessage, recordEventLogEvent } from "./event-log";
 
 /**
  * Minimal WebSocket surface the HID input channel needs. Satisfied by both the
@@ -272,12 +273,16 @@ export class DeviceSession {
     switch (tag) {
       case 0x03: {
         const m = json<{ type: string; x: number; y: number; edge?: number }>();
-        if (m) this.hid.touch(m.type as "begin" | "move" | "end", m.x, m.y, W, H, m.edge ?? 0);
+        if (m) {
+          this.recordHidEvent(tag, m);
+          this.hid.touch(m.type as "begin" | "move" | "end", m.x, m.y, W, H, m.edge ?? 0);
+        }
         break;
       }
       case 0x04: {
         const m = json<{ button: string; page?: number; usage?: number; phase?: string }>();
         if (!m) break;
+        this.recordHidEvent(tag, m);
         if (m.page != null && m.usage != null) {
           this.hid.buttonHid(m.page, m.usage, (m.phase as "down" | "up" | "press") ?? "press");
         } else {
@@ -287,12 +292,18 @@ export class DeviceSession {
       }
       case 0x05: {
         const m = json<{ type: string; x1: number; y1: number; x2: number; y2: number }>();
-        if (m) this.hid.multiTouch(m.type as "begin" | "move" | "end", m.x1, m.y1, m.x2, m.y2, W, H);
+        if (m) {
+          this.recordHidEvent(tag, m);
+          this.hid.multiTouch(m.type as "begin" | "move" | "end", m.x1, m.y1, m.x2, m.y2, W, H);
+        }
         break;
       }
       case 0x06: {
         const m = json<{ type: string; usage: number }>();
-        if (m) this.hid.key(m.type as "down" | "up", m.usage);
+        if (m) {
+          this.recordHidEvent(tag, m);
+          this.hid.key(m.type as "down" | "up", m.usage);
+        }
         break;
       }
       case 0x07: {
@@ -300,6 +311,7 @@ export class DeviceSession {
         if (!m) break;
         const value = ORIENTATION_BY_NAME[m.orientation];
         if (value != null && await this.hid.orientation(value)) {
+          this.recordHidEvent(tag, m);
           if (m.orientation !== this.orientation) {
             this.orientation = m.orientation;
             this.broadcastConfig();
@@ -309,27 +321,48 @@ export class DeviceSession {
       }
       case 0x08: {
         const m = json<{ option: string; enabled: boolean }>();
-        if (m) this.hid.caDebug(m.option, m.enabled);
+        if (m) {
+          this.recordHidEvent(tag, m);
+          this.hid.caDebug(m.option, m.enabled);
+        }
         break;
       }
       case 0x09:
+        this.recordHidEvent(tag, {});
         this.hid.memoryWarning();
         break;
       case 0x0a: {
         const m = json<{ delta: number }>();
-        if (m) this.hid.digitalCrown(m.delta);
+        if (m) {
+          this.recordHidEvent(tag, m);
+          this.hid.digitalCrown(m.delta);
+        }
         break;
       }
       case 0x0b: {
         // Payload deltas are a fraction of the display; scale to device pixels.
         const m = json<{ dx: number; dy: number; x?: number; y?: number }>();
-        if (m) this.hid.scroll(m.dx * W, m.dy * H, W, H, m.x, m.y);
+        if (m) {
+          this.recordHidEvent(tag, m);
+          this.hid.scroll(m.dx * W, m.dy * H, W, H, m.x, m.y);
+        }
         break;
       }
       case 0x0c:
+        this.recordHidEvent(tag, {});
         this.hid.softwareKeyboard();
         break;
     }
+  }
+
+  private recordHidEvent(tag: number, payload: Record<string, unknown>): void {
+    const event = eventLogEventForHidMessage(
+      this.udid,
+      tag,
+      payload,
+      { width: this.width, height: this.height },
+    );
+    if (event) recordEventLogEvent(event);
   }
 
   // ── Config ───────────────────────────────────────────────────────────────

--- a/packages/serve-sim/src/device-session.ts
+++ b/packages/serve-sim/src/device-session.ts
@@ -23,7 +23,7 @@ import {
   axFrontmostAsync,
   type MjpegFrame,
 } from "./native";
-import { eventLogEventForHidMessage, recordEventLogEvent } from "./event-log";
+import { eventLogEventForHidMessage, recordEventLogEvent, updateEventLogEvent } from "./event-log";
 
 /**
  * Minimal WebSocket surface the HID input channel needs. Satisfied by both the
@@ -52,6 +52,37 @@ const AVCC_SEED_TAG = 0x04;
 const WS_MSG_CONFIG = 0x82;
 
 const MJPEG_TRAILER = Buffer.from("\r\n", "ascii");
+const TOUCH_TAP_MAX_DISTANCE = 0.004;
+
+type TouchGestureLog = {
+  eventId: number;
+  startX: number;
+  startY: number;
+  lastX: number;
+  lastY: number;
+  moveCount: number;
+  edge?: number;
+};
+
+function formatEventLogPoint(x: number, y: number): string {
+  return `${formatEventLogNumber(x)},${formatEventLogNumber(y)}`;
+}
+
+function formatEventLogNumber(value: number): string {
+  if (!Number.isFinite(value)) return "";
+  return value.toFixed(3).replace(/0+$/, "").replace(/\.$/, "");
+}
+
+function touchGestureSummary(gesture: TouchGestureLog): string {
+  const moveLabel = gesture.moveCount === 1 ? "1 move" : `${gesture.moveCount} moves`;
+  return `Drag ${formatEventLogPoint(gesture.startX, gesture.startY)} -> ${formatEventLogPoint(gesture.lastX, gesture.lastY)} (${moveLabel})`;
+}
+
+function touchGestureMoved(gesture: TouchGestureLog): boolean {
+  const dx = gesture.lastX - gesture.startX;
+  const dy = gesture.lastY - gesture.startY;
+  return Math.hypot(dx, dy) > TOUCH_TAP_MAX_DISTANCE;
+}
 
 function mjpegHeader(jpegLength: number): Buffer {
   return Buffer.from(`--frame\r\nContent-Type: image/jpeg\r\nContent-Length: ${jpegLength}\r\n\r\n`, "ascii");
@@ -104,6 +135,7 @@ export class DeviceSession {
   private latestJpegBuffer: Buffer | null = null;
   private latestJpegLength = 0;
   private readonly hidSockets = new Set<HidSocket>();
+  private touchGestureLog?: TouchGestureLog;
 
   constructor(public readonly udid: string) {
     this.hid = new NativeHid(udid);
@@ -274,7 +306,7 @@ export class DeviceSession {
       case 0x03: {
         const m = json<{ type: string; x: number; y: number; edge?: number }>();
         if (m) {
-          this.recordHidEvent(tag, m);
+          this.recordTouchEvent(m);
           this.hid.touch(m.type as "begin" | "move" | "end", m.x, m.y, W, H, m.edge ?? 0);
         }
         break;
@@ -355,12 +387,124 @@ export class DeviceSession {
     }
   }
 
+  private recordTouchEvent(payload: { type: string; x: number; y: number; edge?: number }): void {
+    if (payload.type === "begin") {
+      const event = eventLogEventForHidMessage(
+        this.udid,
+        0x03,
+        payload,
+        this.eventLogScreen(),
+      );
+      if (!event) return;
+      const entry = recordEventLogEvent(event);
+      this.touchGestureLog = {
+        eventId: entry.id,
+        startX: payload.x,
+        startY: payload.y,
+        lastX: payload.x,
+        lastY: payload.y,
+        moveCount: 0,
+        edge: payload.edge,
+      };
+      return;
+    }
+
+    if (payload.type === "move") {
+      let gesture = this.touchGestureLog;
+      if (!gesture) {
+        const entry = recordEventLogEvent({
+          device: this.udid,
+          source: "hid",
+          kind: "drag",
+          action: "move",
+          summary: `Drag ${formatEventLogPoint(payload.x, payload.y)}`,
+          details: this.touchGestureDetails({
+            eventId: 0,
+            startX: payload.x,
+            startY: payload.y,
+            lastX: payload.x,
+            lastY: payload.y,
+            moveCount: 1,
+            edge: payload.edge,
+          }, "move"),
+        });
+        gesture = {
+          eventId: entry.id,
+          startX: payload.x,
+          startY: payload.y,
+          lastX: payload.x,
+          lastY: payload.y,
+          moveCount: 0,
+          edge: payload.edge,
+        };
+        this.touchGestureLog = gesture;
+      }
+
+      gesture.lastX = payload.x;
+      gesture.lastY = payload.y;
+      gesture.moveCount++;
+      if (payload.edge != null) gesture.edge = payload.edge;
+      updateEventLogEvent(gesture.eventId, {
+        kind: "drag",
+        action: "move",
+        summary: touchGestureSummary(gesture),
+        details: this.touchGestureDetails(gesture, "move"),
+      });
+      return;
+    }
+
+    if (payload.type === "end") {
+      const gesture = this.touchGestureLog;
+      if (gesture) {
+        gesture.lastX = payload.x;
+        gesture.lastY = payload.y;
+        if (payload.edge != null) gesture.edge = payload.edge;
+        if (gesture.moveCount > 0 && touchGestureMoved(gesture)) {
+          updateEventLogEvent(gesture.eventId, {
+            kind: "drag",
+            action: "end",
+            summary: touchGestureSummary(gesture),
+            details: this.touchGestureDetails(gesture, "end"),
+          });
+        } else {
+          updateEventLogEvent(gesture.eventId, {
+            kind: "tap",
+            action: "tap",
+            summary: `Tap ${formatEventLogPoint(payload.x, payload.y)}`,
+            details: this.touchGestureDetails(gesture, "tap"),
+          });
+        }
+        this.touchGestureLog = undefined;
+        return;
+      }
+    }
+
+    this.recordHidEvent(0x03, payload);
+  }
+
+  private eventLogScreen(): { width: number; height: number } | undefined {
+    return this.width > 0 && this.height > 0
+      ? { width: this.width, height: this.height }
+      : undefined;
+  }
+
+  private touchGestureDetails(gesture: TouchGestureLog, type: string): Record<string, unknown> {
+    return {
+      type,
+      start: { x: gesture.startX, y: gesture.startY },
+      current: { x: gesture.lastX, y: gesture.lastY },
+      moveCount: gesture.moveCount,
+      ...(gesture.edge != null ? { edge: gesture.edge } : {}),
+      ...(this.eventLogScreen() ? { screen: this.eventLogScreen() } : {}),
+    };
+  }
+
   private recordHidEvent(tag: number, payload: Record<string, unknown>): void {
     const event = eventLogEventForHidMessage(
       this.udid,
       tag,
       payload,
-      { width: this.width, height: this.height },
+      this.eventLogScreen(),
     );
     if (event) recordEventLogEvent(event);
   }

--- a/packages/serve-sim/src/device-session.ts
+++ b/packages/serve-sim/src/device-session.ts
@@ -74,8 +74,7 @@ function formatEventLogNumber(value: number): string {
 }
 
 function touchGestureSummary(gesture: TouchGestureLog): string {
-  const moveLabel = gesture.moveCount === 1 ? "1 move" : `${gesture.moveCount} moves`;
-  return `Drag ${formatEventLogPoint(gesture.startX, gesture.startY)} -> ${formatEventLogPoint(gesture.lastX, gesture.lastY)} (${moveLabel})`;
+  return `Drag ${formatEventLogPoint(gesture.startX, gesture.startY)} -> ${formatEventLogPoint(gesture.lastX, gesture.lastY)}`;
 }
 
 function touchGestureMoved(gesture: TouchGestureLog): boolean {

--- a/packages/serve-sim/src/device-session.ts
+++ b/packages/serve-sim/src/device-session.ts
@@ -55,7 +55,7 @@ const MJPEG_TRAILER = Buffer.from("\r\n", "ascii");
 const TOUCH_TAP_MAX_DISTANCE = 0.004;
 
 type TouchGestureLog = {
-  eventId: number;
+  eventId?: number;
   startX: number;
   startY: number;
   lastX: number;
@@ -81,6 +81,17 @@ function touchGestureMoved(gesture: TouchGestureLog): boolean {
   const dx = gesture.lastX - gesture.startX;
   const dy = gesture.lastY - gesture.startY;
   return Math.hypot(dx, dy) > TOUCH_TAP_MAX_DISTANCE;
+}
+
+function newTouchGesture(payload: { x: number; y: number; edge?: number }): TouchGestureLog {
+  return {
+    startX: payload.x,
+    startY: payload.y,
+    lastX: payload.x,
+    lastY: payload.y,
+    moveCount: 0,
+    edge: payload.edge,
+  };
 }
 
 function mjpegHeader(jpegLength: number): Buffer {
@@ -388,54 +399,14 @@ export class DeviceSession {
 
   private recordTouchEvent(payload: { type: string; x: number; y: number; edge?: number }): void {
     if (payload.type === "begin") {
-      const event = eventLogEventForHidMessage(
-        this.udid,
-        0x03,
-        payload,
-        this.eventLogScreen(),
-      );
-      if (!event) return;
-      const entry = recordEventLogEvent(event);
-      this.touchGestureLog = {
-        eventId: entry.id,
-        startX: payload.x,
-        startY: payload.y,
-        lastX: payload.x,
-        lastY: payload.y,
-        moveCount: 0,
-        edge: payload.edge,
-      };
+      this.touchGestureLog = newTouchGesture(payload);
       return;
     }
 
     if (payload.type === "move") {
       let gesture = this.touchGestureLog;
       if (!gesture) {
-        const entry = recordEventLogEvent({
-          device: this.udid,
-          source: "hid",
-          kind: "drag",
-          action: "move",
-          summary: `Drag ${formatEventLogPoint(payload.x, payload.y)}`,
-          details: this.touchGestureDetails({
-            eventId: 0,
-            startX: payload.x,
-            startY: payload.y,
-            lastX: payload.x,
-            lastY: payload.y,
-            moveCount: 1,
-            edge: payload.edge,
-          }, "move"),
-        });
-        gesture = {
-          eventId: entry.id,
-          startX: payload.x,
-          startY: payload.y,
-          lastX: payload.x,
-          lastY: payload.y,
-          moveCount: 0,
-          edge: payload.edge,
-        };
+        gesture = newTouchGesture(payload);
         this.touchGestureLog = gesture;
       }
 
@@ -443,12 +414,26 @@ export class DeviceSession {
       gesture.lastY = payload.y;
       gesture.moveCount++;
       if (payload.edge != null) gesture.edge = payload.edge;
-      updateEventLogEvent(gesture.eventId, {
-        kind: "drag",
-        action: "move",
-        summary: touchGestureSummary(gesture),
-        details: this.touchGestureDetails(gesture, "move"),
-      });
+      if (touchGestureMoved(gesture)) {
+        if (gesture.eventId == null) {
+          const entry = recordEventLogEvent({
+            device: this.udid,
+            source: "hid",
+            kind: "drag",
+            action: "move",
+            summary: touchGestureSummary(gesture),
+            details: this.touchGestureDetails(gesture, "move"),
+          });
+          gesture.eventId = entry.id;
+        } else {
+          updateEventLogEvent(gesture.eventId, {
+            kind: "drag",
+            action: "move",
+            summary: touchGestureSummary(gesture),
+            details: this.touchGestureDetails(gesture, "move"),
+          });
+        }
+      }
       return;
     }
 
@@ -459,14 +444,27 @@ export class DeviceSession {
         gesture.lastY = payload.y;
         if (payload.edge != null) gesture.edge = payload.edge;
         if (gesture.moveCount > 0 && touchGestureMoved(gesture)) {
-          updateEventLogEvent(gesture.eventId, {
-            kind: "drag",
-            action: "end",
-            summary: touchGestureSummary(gesture),
-            details: this.touchGestureDetails(gesture, "end"),
-          });
+          if (gesture.eventId == null) {
+            recordEventLogEvent({
+              device: this.udid,
+              source: "hid",
+              kind: "drag",
+              action: "end",
+              summary: touchGestureSummary(gesture),
+              details: this.touchGestureDetails(gesture, "end"),
+            });
+          } else {
+            updateEventLogEvent(gesture.eventId, {
+              kind: "drag",
+              action: "end",
+              summary: touchGestureSummary(gesture),
+              details: this.touchGestureDetails(gesture, "end"),
+            });
+          }
         } else {
-          updateEventLogEvent(gesture.eventId, {
+          recordEventLogEvent({
+            device: this.udid,
+            source: "hid",
             kind: "tap",
             action: "tap",
             summary: `Tap ${formatEventLogPoint(payload.x, payload.y)}`,

--- a/packages/serve-sim/src/device-session.ts
+++ b/packages/serve-sim/src/device-session.ts
@@ -417,12 +417,17 @@ export class DeviceSession {
           });
           gesture.eventId = entry.id;
         } else {
-          updateEventLogEvent(gesture.eventId, {
-            kind: "drag",
-            action: "drag",
-            summary: touchGestureSummary(gesture),
-            details: this.touchGestureDetails(gesture, "drag", "move"),
-          });
+          // Keep the stored drag current without streaming every touchmove to the browser.
+          updateEventLogEvent(
+            gesture.eventId,
+            {
+              kind: "drag",
+              action: "drag",
+              summary: touchGestureSummary(gesture),
+              details: this.touchGestureDetails(gesture, "drag", "move"),
+            },
+            { notify: false },
+          );
         }
       }
       return;

--- a/packages/serve-sim/src/device-session.ts
+++ b/packages/serve-sim/src/device-session.ts
@@ -23,7 +23,7 @@ import {
   axFrontmostAsync,
   type MjpegFrame,
 } from "./native";
-import { eventLogEventForHidMessage, recordEventLogEvent, updateEventLogEvent } from "./event-log";
+import { eventLogEventForHidMessage, formatEventLogPoint, recordEventLogEvent, updateEventLogEvent } from "./event-log";
 
 /**
  * Minimal WebSocket surface the HID input channel needs. Satisfied by both the
@@ -63,15 +63,6 @@ type TouchGestureLog = {
   moveCount: number;
   edge?: number;
 };
-
-function formatEventLogPoint(x: number, y: number): string {
-  return `${formatEventLogNumber(x)},${formatEventLogNumber(y)}`;
-}
-
-function formatEventLogNumber(value: number): string {
-  if (!Number.isFinite(value)) return "";
-  return value.toFixed(3).replace(/0+$/, "").replace(/\.$/, "");
-}
 
 function touchGestureSummary(gesture: TouchGestureLog): string {
   return `Drag ${formatEventLogPoint(gesture.startX, gesture.startY)} -> ${formatEventLogPoint(gesture.lastX, gesture.lastY)}`;

--- a/packages/serve-sim/src/event-log-format.ts
+++ b/packages/serve-sim/src/event-log-format.ts
@@ -37,7 +37,7 @@ export function humanEventLogSummary(entry: EventLogEntry): string {
     const orientation = entry.action ? humanizeToken(entry.action) : "";
     return orientation ? `Rotate ${orientation}` : "Rotate";
   }
-  return humanizeSummary(entry.summary);
+  return humanizeSummary(entry.msg ?? entry.summary);
 }
 
 function pointFromDetails(

--- a/packages/serve-sim/src/event-log-format.ts
+++ b/packages/serve-sim/src/event-log-format.ts
@@ -18,13 +18,13 @@ export function formatEventLogLine(
 export function humanEventLogSummary(entry: EventLogEntry): string {
   if (entry.kind === "tap") {
     const point = pointFromDetails(entry.details, "current") ?? pointFromDetails(entry.details, "start");
-    return point ? `Tap at ${formatPercentPoint(point)}` : "Tap";
+    return point ? `Tap at ${formatNormalizedPoint(point)}` : "Tap";
   }
   if (entry.kind === "drag") {
     const start = pointFromDetails(entry.details, "start");
     const current = pointFromDetails(entry.details, "current");
     if (start && current) {
-      return `Drag from ${formatPercentPoint(start)} to ${formatPercentPoint(current)}`;
+      return `Drag from ${formatNormalizedPoint(start)} to ${formatNormalizedPoint(current)}`;
     }
     return "Drag";
   }
@@ -57,13 +57,13 @@ function stringDetail(details: Record<string, unknown> | undefined, key: string)
   return typeof value === "string" && value.length > 0 ? value : null;
 }
 
-function formatPercentPoint(point: { x: number; y: number }): string {
-  return `${formatPercent(point.x)}, ${formatPercent(point.y)}`;
+function formatNormalizedPoint(point: { x: number; y: number }): string {
+  return `${formatNormalized(point.x)}, ${formatNormalized(point.y)}`;
 }
 
-function formatPercent(value: number): string {
+function formatNormalized(value: number): string {
   if (!Number.isFinite(value)) return "?";
-  return `${Math.round(clamp(value, 0, 1) * 100)}%`;
+  return (Math.round((clamp(value, 0, 1) + Number.EPSILON) * 100) / 100).toFixed(2);
 }
 
 function clamp(value: number, min: number, max: number): number {

--- a/packages/serve-sim/src/event-log-format.ts
+++ b/packages/serve-sim/src/event-log-format.ts
@@ -1,11 +1,14 @@
 import type { EventLogEntry } from "./event-log";
 
-export function formatEventLogLine(entry: EventLogEntry): string {
+export function formatEventLogLine(
+  entry: EventLogEntry,
+  options: { deviceLabel?: string | null } = {},
+): string {
   const time = new Date(entry.timestamp);
   const stamp = Number.isNaN(time.getTime())
     ? entry.timestamp
     : time.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
-  const device = entry.device ? entry.device.slice(0, 8) : null;
+  const device = options.deviceLabel ?? (entry.device ? entry.device.slice(0, 8) : null);
   const status = entry.status === "error" ? " failed" : "";
   return [stamp, device, `${humanEventLogSummary(entry)}${status ? ` (${status.trim()})` : ""}`]
     .filter(Boolean)

--- a/packages/serve-sim/src/event-log-format.ts
+++ b/packages/serve-sim/src/event-log-format.ts
@@ -1,0 +1,94 @@
+import type { EventLogEntry } from "./event-log";
+
+export function formatEventLogLine(entry: EventLogEntry): string {
+  const time = new Date(entry.timestamp);
+  const stamp = Number.isNaN(time.getTime())
+    ? entry.timestamp
+    : time.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+  const device = entry.device ? entry.device.slice(0, 8) : null;
+  const status = entry.status === "error" ? " failed" : "";
+  return [stamp, device, `${humanEventLogSummary(entry)}${status ? ` (${status.trim()})` : ""}`]
+    .filter(Boolean)
+    .join("  ");
+}
+
+export function humanEventLogSummary(entry: EventLogEntry): string {
+  if (entry.kind === "tap") {
+    const point = pointFromDetails(entry.details, "current") ?? pointFromDetails(entry.details, "start");
+    return point ? `Tap at ${formatPercentPoint(point)}` : "Tap";
+  }
+  if (entry.kind === "drag") {
+    const start = pointFromDetails(entry.details, "start");
+    const current = pointFromDetails(entry.details, "current");
+    if (start && current) {
+      return `Drag from ${formatPercentPoint(start)} to ${formatPercentPoint(current)}`;
+    }
+    return "Drag";
+  }
+  if (entry.kind === "key") {
+    const key = stringDetail(entry.details, "key") ?? entry.action ?? "key";
+    const action = entry.action === "down" ? "down" : entry.action === "up" ? "up" : entry.action;
+    return action ? `Key ${action} ${humanizeKey(key)}` : `Key ${humanizeKey(key)}`;
+  }
+  if (entry.kind === "rotate") {
+    const orientation = entry.action ? humanizeToken(entry.action) : "";
+    return orientation ? `Rotate ${orientation}` : "Rotate";
+  }
+  return humanizeSummary(entry.summary);
+}
+
+function pointFromDetails(
+  details: Record<string, unknown> | undefined,
+  key: "start" | "current",
+): { x: number; y: number } | null {
+  const value = details?.[key];
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const point = value as Record<string, unknown>;
+  return typeof point.x === "number" && typeof point.y === "number"
+    ? { x: point.x, y: point.y }
+    : null;
+}
+
+function stringDetail(details: Record<string, unknown> | undefined, key: string): string | null {
+  const value = details?.[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function formatPercentPoint(point: { x: number; y: number }): string {
+  return `${formatPercent(point.x)}, ${formatPercent(point.y)}`;
+}
+
+function formatPercent(value: number): string {
+  if (!Number.isFinite(value)) return "?";
+  return `${Math.round(clamp(value, 0, 1) * 100)}%`;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function humanizeSummary(summary: string): string {
+  return summary.replace(/\b[a-z]+(?:_[a-z]+)+\b/g, humanizeToken);
+}
+
+function humanizeToken(value: string): string {
+  return value.replace(/[-_]+/g, " ");
+}
+
+function humanizeKey(value: string): string {
+  const labels: Record<string, string> = {
+    MetaLeft: "Left Command",
+    MetaRight: "Right Command",
+    AltLeft: "Left Option",
+    AltRight: "Right Option",
+    ControlLeft: "Left Control",
+    ControlRight: "Right Control",
+    ShiftLeft: "Left Shift",
+    ShiftRight: "Right Shift",
+    ArrowLeft: "Left Arrow",
+    ArrowRight: "Right Arrow",
+    ArrowUp: "Up Arrow",
+    ArrowDown: "Down Arrow",
+  };
+  return labels[value] ?? value;
+}

--- a/packages/serve-sim/src/event-log.ts
+++ b/packages/serve-sim/src/event-log.ts
@@ -19,6 +19,77 @@ export type EventLogDraft = Omit<EventLogEntry, "id" | "timestamp"> & {
 
 export const EVENT_LOG_MAX_ENTRIES = 500;
 
+const KEY_LABEL_BY_USAGE: Record<number, string> = {
+  0x28: "Enter",
+  0x29: "Escape",
+  0x2a: "Backspace",
+  0x2b: "Tab",
+  0x2c: "Space",
+  0x2d: "-",
+  0x2e: "=",
+  0x2f: "[",
+  0x30: "]",
+  0x31: "\\",
+  0x32: "#",
+  0x33: ";",
+  0x34: "'",
+  0x35: "`",
+  0x36: ",",
+  0x37: ".",
+  0x38: "/",
+  0x39: "CapsLock",
+  0x3a: "F1",
+  0x3b: "F2",
+  0x3c: "F3",
+  0x3d: "F4",
+  0x3e: "F5",
+  0x3f: "F6",
+  0x40: "F7",
+  0x41: "F8",
+  0x42: "F9",
+  0x43: "F10",
+  0x44: "F11",
+  0x45: "F12",
+  0x46: "PrintScreen",
+  0x47: "ScrollLock",
+  0x48: "Pause",
+  0x49: "Insert",
+  0x4a: "Home",
+  0x4b: "PageUp",
+  0x4c: "Delete",
+  0x4d: "End",
+  0x4e: "PageDown",
+  0x4f: "ArrowRight",
+  0x50: "ArrowLeft",
+  0x51: "ArrowDown",
+  0x52: "ArrowUp",
+  0x53: "NumLock",
+  0x54: "NumpadDivide",
+  0x55: "NumpadMultiply",
+  0x56: "NumpadSubtract",
+  0x57: "NumpadAdd",
+  0x58: "NumpadEnter",
+  0x59: "Numpad1",
+  0x5a: "Numpad2",
+  0x5b: "Numpad3",
+  0x5c: "Numpad4",
+  0x5d: "Numpad5",
+  0x5e: "Numpad6",
+  0x5f: "Numpad7",
+  0x60: "Numpad8",
+  0x61: "Numpad9",
+  0x62: "Numpad0",
+  0x63: "NumpadDecimal",
+  0xe0: "ControlLeft",
+  0xe1: "ShiftLeft",
+  0xe2: "AltLeft",
+  0xe3: "MetaLeft",
+  0xe4: "ControlRight",
+  0xe5: "ShiftRight",
+  0xe6: "AltRight",
+  0xe7: "MetaRight",
+};
+
 let nextEventId = 1;
 let entries: EventLogEntry[] = [];
 const subscribers = new Set<(entry: EventLogEntry) => void>();
@@ -140,13 +211,14 @@ export function eventLogEventForHidMessage(
       const type = stringValue(details.type);
       const usage = numberValue(details.usage);
       if (!type || usage == null) return null;
+      const key = keyLabelForUsage(usage);
       return {
         device,
         source: "hid",
         kind: "key",
         action: type,
-        summary: `Key ${type} ${usage}`,
-        details: { ...details, usage },
+        summary: `Key ${type} ${key}`,
+        details: { ...details, usage, key },
       };
     }
     case 0x07: {
@@ -431,6 +503,17 @@ function numberValue(value: unknown): number | null {
 
 function booleanValue(value: unknown): boolean | null {
   return typeof value === "boolean" ? value : null;
+}
+
+function keyLabelForUsage(usage: number): string {
+  if (usage >= 0x04 && usage <= 0x1d) {
+    return String.fromCharCode(0x61 + usage - 0x04);
+  }
+  if (usage >= 0x1e && usage <= 0x26) {
+    return String(usage - 0x1d);
+  }
+  if (usage === 0x27) return "0";
+  return KEY_LABEL_BY_USAGE[usage] ?? `usage ${usage}`;
 }
 
 function withScreen(

--- a/packages/serve-sim/src/event-log.ts
+++ b/packages/serve-sim/src/event-log.ts
@@ -23,6 +23,17 @@ let nextEventId = 1;
 let entries: EventLogEntry[] = [];
 const subscribers = new Set<(entry: EventLogEntry) => void>();
 
+function notifyEventLogSubscribers(entry: EventLogEntry): void {
+  for (const subscriber of subscribers) {
+    try {
+      subscriber(entry);
+    } catch {
+      // Event log observers are diagnostic side-channels. A broken stream must
+      // not make the simulator input/command path fail.
+    }
+  }
+}
+
 export function recordEventLogEvent(draft: EventLogDraft): EventLogEntry {
   const entry: EventLogEntry = {
     ...draft,
@@ -33,14 +44,19 @@ export function recordEventLogEvent(draft: EventLogDraft): EventLogEntry {
   if (entries.length > EVENT_LOG_MAX_ENTRIES) {
     entries = entries.slice(entries.length - EVENT_LOG_MAX_ENTRIES);
   }
-  for (const subscriber of subscribers) {
-    try {
-      subscriber(entry);
-    } catch {
-      // Event log observers are diagnostic side-channels. A broken stream must
-      // not make the simulator input/command path fail.
-    }
-  }
+  notifyEventLogSubscribers(entry);
+  return entry;
+}
+
+export function updateEventLogEvent(
+  id: number,
+  patch: Partial<Omit<EventLogEntry, "id">>,
+): EventLogEntry | null {
+  const index = entries.findIndex((entry) => entry.id === id);
+  if (index < 0) return null;
+  const entry = { ...entries[index]!, ...patch, id };
+  entries[index] = entry;
+  notifyEventLogSubscribers(entry);
   return entry;
 }
 
@@ -355,13 +371,15 @@ export function eventLogEventForCommand(
       };
     }
     if (verb === "camera") {
+      const action = cameraAction(args);
+      if (action === "status" || action === "list-webcams") return null;
       return {
         device,
         source: "exec",
         kind: "camera",
-        action: firstPositional(args) ?? "start",
+        action: action ?? "start",
         status,
-        summary: "Camera",
+        summary: action ? `Camera ${action}` : "Camera",
         details: commandDetail,
       };
     }
@@ -525,6 +543,12 @@ function firstPositional(args: string[]): string | undefined {
     return arg;
   }
   return undefined;
+}
+
+function cameraAction(args: string[]): string | undefined {
+  if (args.includes("--list-webcams")) return "list-webcams";
+  if (args.includes("--stop-webcam")) return "stop-webcam";
+  return firstPositional(args);
 }
 
 function basename(path: string | undefined): string {

--- a/packages/serve-sim/src/event-log.ts
+++ b/packages/serve-sim/src/event-log.ts
@@ -33,7 +33,14 @@ export function recordEventLogEvent(draft: EventLogDraft): EventLogEntry {
   if (entries.length > EVENT_LOG_MAX_ENTRIES) {
     entries = entries.slice(entries.length - EVENT_LOG_MAX_ENTRIES);
   }
-  for (const subscriber of subscribers) subscriber(entry);
+  for (const subscriber of subscribers) {
+    try {
+      subscriber(entry);
+    } catch {
+      // Event log observers are diagnostic side-channels. A broken stream must
+      // not make the simulator input/command path fail.
+    }
+  }
   return entry;
 }
 

--- a/packages/serve-sim/src/event-log.ts
+++ b/packages/serve-sim/src/event-log.ts
@@ -1,0 +1,531 @@
+export type EventLogSource = "hid" | "exec" | "ui";
+export type EventLogStatus = "ok" | "error";
+
+export type EventLogEntry = {
+  id: number;
+  timestamp: string;
+  source: EventLogSource;
+  kind: string;
+  summary: string;
+  device?: string;
+  action?: string;
+  status?: EventLogStatus;
+  details?: Record<string, unknown>;
+};
+
+export type EventLogDraft = Omit<EventLogEntry, "id" | "timestamp"> & {
+  timestamp?: string;
+};
+
+export const EVENT_LOG_MAX_ENTRIES = 500;
+
+let nextEventId = 1;
+let entries: EventLogEntry[] = [];
+const subscribers = new Set<(entry: EventLogEntry) => void>();
+
+export function recordEventLogEvent(draft: EventLogDraft): EventLogEntry {
+  const entry: EventLogEntry = {
+    ...draft,
+    id: nextEventId++,
+    timestamp: draft.timestamp ?? new Date().toISOString(),
+  };
+  entries.push(entry);
+  if (entries.length > EVENT_LOG_MAX_ENTRIES) {
+    entries = entries.slice(entries.length - EVENT_LOG_MAX_ENTRIES);
+  }
+  for (const subscriber of subscribers) subscriber(entry);
+  return entry;
+}
+
+export function readEventLog(options: {
+  device?: string | null;
+  sinceId?: number;
+  limit?: number;
+} = {}): EventLogEntry[] {
+  const { device, sinceId } = options;
+  const limit = clampLimit(options.limit);
+  const filtered = entries.filter((entry) => {
+    if (device && entry.device !== device) return false;
+    if (sinceId != null && entry.id <= sinceId) return false;
+    return true;
+  });
+  return filtered.slice(Math.max(0, filtered.length - limit));
+}
+
+export function subscribeEventLog(
+  subscriber: (entry: EventLogEntry) => void,
+): () => void {
+  subscribers.add(subscriber);
+  return () => subscribers.delete(subscriber);
+}
+
+export function clearEventLogForTests(): void {
+  entries = [];
+  nextEventId = 1;
+}
+
+export function eventLogEventForHidMessage(
+  device: string,
+  tag: number,
+  payload: unknown,
+  screen?: { width: number; height: number },
+): EventLogDraft | null {
+  const details = recordValue(payload);
+  if (!details) return null;
+
+  switch (tag) {
+    case 0x03: {
+      const type = stringValue(details.type);
+      const x = numberValue(details.x);
+      const y = numberValue(details.y);
+      if (!type || x == null || y == null) return null;
+      return {
+        device,
+        source: "hid",
+        kind: "touch",
+        action: type,
+        summary: `Touch ${type} ${formatPoint(x, y)}`,
+        details: withScreen({ ...details, x, y }, screen),
+      };
+    }
+    case 0x04: {
+      const button = stringValue(details.button);
+      if (!button) return null;
+      const phase = stringValue(details.phase) ?? "press";
+      return {
+        device,
+        source: "hid",
+        kind: "button",
+        action: button,
+        summary: phase === "press" ? `Button ${button}` : `Button ${button} ${phase}`,
+        details: { ...details, phase },
+      };
+    }
+    case 0x05: {
+      const type = stringValue(details.type);
+      if (!type) return null;
+      return {
+        device,
+        source: "hid",
+        kind: "multi-touch",
+        action: type,
+        summary: `Multi-touch ${type}`,
+        details: withScreen(details, screen),
+      };
+    }
+    case 0x06: {
+      const type = stringValue(details.type);
+      const usage = numberValue(details.usage);
+      if (!type || usage == null) return null;
+      return {
+        device,
+        source: "hid",
+        kind: "key",
+        action: type,
+        summary: `Key ${type} ${usage}`,
+        details: { ...details, usage },
+      };
+    }
+    case 0x07: {
+      const orientation = stringValue(details.orientation);
+      if (!orientation) return null;
+      return {
+        device,
+        source: "hid",
+        kind: "rotate",
+        action: orientation,
+        summary: `Rotate ${orientation}`,
+        details,
+      };
+    }
+    case 0x08: {
+      const option = stringValue(details.option);
+      const enabled = booleanValue(details.enabled);
+      if (!option || enabled == null) return null;
+      return {
+        device,
+        source: "hid",
+        kind: "ca-debug",
+        action: option,
+        summary: `CoreAnimation ${option} ${enabled ? "on" : "off"}`,
+        details: { ...details, enabled },
+      };
+    }
+    case 0x09:
+      return {
+        device,
+        source: "hid",
+        kind: "memory-warning",
+        action: "trigger",
+        summary: "Memory warning",
+      };
+    case 0x0a: {
+      const delta = numberValue(details.delta);
+      if (delta == null) return null;
+      return {
+        device,
+        source: "hid",
+        kind: "digital-crown",
+        action: "rotate",
+        summary: `Digital Crown ${delta > 0 ? "up" : "down"}`,
+        details: { ...details, delta },
+      };
+    }
+    case 0x0b: {
+      const dx = numberValue(details.dx);
+      const dy = numberValue(details.dy);
+      if (dx == null || dy == null) return null;
+      return {
+        device,
+        source: "hid",
+        kind: "scroll",
+        action: "wheel",
+        summary: `Scroll ${formatDelta(dx, dy)}`,
+        details: withScreen({ ...details, dx, dy }, screen),
+      };
+    }
+    case 0x0c:
+      return {
+        device,
+        source: "hid",
+        kind: "software-keyboard",
+        action: "toggle",
+        summary: "Software keyboard",
+      };
+    default:
+      return null;
+  }
+}
+
+export function eventLogEventForCommand(
+  command: string,
+  result?: { exitCode?: number },
+): EventLogDraft | null {
+  const tokens = tokenizeCommand(command);
+  if (tokens.length === 0) return null;
+  if (isUploadPlumbing(tokens)) return null;
+
+  const status = statusFromExitCode(result?.exitCode);
+  const commandDetail = { command: compactCommand(command), ...(status ? { exitCode: result?.exitCode } : {}) };
+  const simctl = simctlCommand(tokens);
+  if (simctl) {
+    const { verb, args } = simctl;
+    if (verb === "install" && args.length >= 2) {
+      const [device, path] = args;
+      return {
+        device,
+        source: "exec",
+        kind: "app",
+        action: "install",
+        status,
+        summary: `Install app ${basename(path)}`,
+        details: { ...commandDetail, path },
+      };
+    }
+    if (verb === "addmedia" && args.length >= 2) {
+      const [device, path] = args;
+      return {
+        device,
+        source: "exec",
+        kind: "media",
+        action: "addmedia",
+        status,
+        summary: `Add media ${basename(path)}`,
+        details: { ...commandDetail, path },
+      };
+    }
+    if (verb === "launch" && args.length >= 2) {
+      const [device, bundleId] = args;
+      const isHome = bundleId === "com.apple.springboard";
+      return {
+        device,
+        source: "exec",
+        kind: isHome ? "button" : "app",
+        action: isHome ? "home" : "launch",
+        status,
+        summary: isHome ? "Home" : `Launch ${bundleId}`,
+        details: { ...commandDetail, bundleId },
+      };
+    }
+    if (verb === "terminate" && args.length >= 2) {
+      const [device, bundleId] = args;
+      return {
+        device,
+        source: "exec",
+        kind: "app",
+        action: "terminate",
+        status,
+        summary: `Terminate ${bundleId}`,
+        details: { ...commandDetail, bundleId },
+      };
+    }
+    if (verb === "io" && args.length >= 2 && args[1] === "screenshot") {
+      return {
+        device: args[0],
+        source: "exec",
+        kind: "screenshot",
+        action: "capture",
+        status,
+        summary: "Screenshot",
+        details: commandDetail,
+      };
+    }
+  }
+
+  const serveSim = serveSimCommand(tokens);
+  if (serveSim) {
+    const { verb, args } = serveSim;
+    const device = deviceArg(args);
+    if (verb === "button") {
+      const button = firstPositional(args) ?? "home";
+      return {
+        device,
+        source: "exec",
+        kind: "button",
+        action: button,
+        status,
+        summary: `Button ${button}`,
+        details: commandDetail,
+      };
+    }
+    if (verb === "tap") {
+      const [x, y] = args;
+      return {
+        device,
+        source: "exec",
+        kind: "tap",
+        action: "tap",
+        status,
+        summary: `Tap ${formatPoint(Number(x), Number(y))}`,
+        details: commandDetail,
+      };
+    }
+    if (verb === "gesture") {
+      return {
+        device,
+        source: "exec",
+        kind: "gesture",
+        action: "send",
+        status,
+        summary: "Gesture",
+        details: commandDetail,
+      };
+    }
+    if (verb === "rotate") {
+      const orientation = firstPositional(args);
+      return {
+        device,
+        source: "exec",
+        kind: "rotate",
+        action: orientation,
+        status,
+        summary: orientation ? `Rotate ${orientation}` : "Rotate",
+        details: commandDetail,
+      };
+    }
+    if (verb === "memory-warning") {
+      return {
+        device,
+        source: "exec",
+        kind: "memory-warning",
+        action: "trigger",
+        status,
+        summary: "Memory warning",
+        details: commandDetail,
+      };
+    }
+    if (verb === "ca-debug") {
+      const option = firstPositional(args);
+      const enabled = args.find((arg) => arg === "on" || arg === "off");
+      return {
+        device,
+        source: "exec",
+        kind: "ca-debug",
+        action: option,
+        status,
+        summary: `CoreAnimation ${option ?? "debug"}${enabled ? ` ${enabled}` : ""}`,
+        details: commandDetail,
+      };
+    }
+    if (verb === "camera") {
+      return {
+        device,
+        source: "exec",
+        kind: "camera",
+        action: firstPositional(args) ?? "start",
+        status,
+        summary: "Camera",
+        details: commandDetail,
+      };
+    }
+    if (verb === "ui") {
+      const option = firstPositional(args);
+      return {
+        device,
+        source: "exec",
+        kind: "ui-setting",
+        action: option,
+        status,
+        summary: option ? `UI ${option}` : "UI setting",
+        details: commandDetail,
+      };
+    }
+  }
+
+  if (tokens[0] === "osascript" && command.includes('menu item "Home"')) {
+    return {
+      source: "exec",
+      kind: "button",
+      action: "home",
+      status,
+      summary: "Home",
+      details: commandDetail,
+    };
+  }
+
+  return null;
+}
+
+function clampLimit(limit: number | undefined): number {
+  if (!Number.isFinite(limit ?? NaN)) return EVENT_LOG_MAX_ENTRIES;
+  return Math.min(EVENT_LOG_MAX_ENTRIES, Math.max(1, Math.floor(limit!)));
+}
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function numberValue(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function booleanValue(value: unknown): boolean | null {
+  return typeof value === "boolean" ? value : null;
+}
+
+function withScreen(
+  details: Record<string, unknown>,
+  screen: { width: number; height: number } | undefined,
+): Record<string, unknown> {
+  if (!screen || screen.width <= 0 || screen.height <= 0) return details;
+  return { ...details, screen };
+}
+
+function formatPoint(x: number, y: number): string {
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return "";
+  return `${formatNumber(x)},${formatNumber(y)}`;
+}
+
+function formatDelta(dx: number, dy: number): string {
+  return `${formatSigned(dx)},${formatSigned(dy)}`;
+}
+
+function formatNumber(value: number): string {
+  return value.toFixed(3).replace(/0+$/, "").replace(/\.$/, "");
+}
+
+function formatSigned(value: number): string {
+  const formatted = formatNumber(value);
+  return value > 0 ? `+${formatted}` : formatted;
+}
+
+function statusFromExitCode(exitCode: number | undefined): EventLogStatus | undefined {
+  if (exitCode == null) return undefined;
+  return exitCode === 0 ? "ok" : "error";
+}
+
+function tokenizeCommand(command: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  let escaped = false;
+
+  for (const ch of command) {
+    if (escaped) {
+      current += ch;
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\" && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if ((ch === "'" || ch === '"') && quote === null) {
+      quote = ch;
+      continue;
+    }
+    if (ch === quote) {
+      quote = null;
+      continue;
+    }
+    if (/\s/.test(ch) && quote === null) {
+      if (current) {
+        tokens.push(current);
+        current = "";
+      }
+      continue;
+    }
+    current += ch;
+  }
+  if (current) tokens.push(current);
+  return tokens;
+}
+
+function isUploadPlumbing(tokens: string[]): boolean {
+  if (tokens[0] === "bash" && tokens[1] === "-c" && tokens[2]?.startsWith("echo ")) return true;
+  if (tokens[0] === "bash" && tokens[1] === "-c" && tokens[2]?.startsWith("rm -f ")) return true;
+  if (tokens[0] === "rm" && tokens[1] === "-f") return true;
+  return false;
+}
+
+function simctlCommand(tokens: string[]): { verb: string; args: string[] } | null {
+  const i = tokens.findIndex((token) => token === "simctl");
+  if (i < 0 || tokens[i - 1] !== "xcrun") return null;
+  const verb = tokens[i + 1];
+  if (!verb) return null;
+  return { verb, args: tokens.slice(i + 2) };
+}
+
+function serveSimCommand(tokens: string[]): { verb: string; args: string[] } | null {
+  const i = tokens.findIndex((token) => token === "serve-sim" || /(?:^|\/)serve-sim(?:\.js)?$/.test(token));
+  if (i < 0) return null;
+  const verb = tokens[i + 1];
+  if (!verb) return null;
+  return { verb, args: tokens.slice(i + 2) };
+}
+
+function deviceArg(args: string[]): string | undefined {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if ((arg === "-d" || arg === "--device") && args[i + 1]) return args[i + 1];
+  }
+  return undefined;
+}
+
+function firstPositional(args: string[]): string | undefined {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    if (arg === "-d" || arg === "--device") {
+      i++;
+      continue;
+    }
+    if (arg.startsWith("-")) continue;
+    return arg;
+  }
+  return undefined;
+}
+
+function basename(path: string | undefined): string {
+  if (!path) return "";
+  return path.split("/").filter(Boolean).pop() ?? path;
+}
+
+function compactCommand(command: string): string {
+  const normalized = command.replace(/\s+/g, " ").trim();
+  return normalized.length <= 240 ? normalized : `${normalized.slice(0, 237)}...`;
+}

--- a/packages/serve-sim/src/event-log.ts
+++ b/packages/serve-sim/src/event-log.ts
@@ -6,6 +6,7 @@ export type EventLogEntry = {
   timestamp: string;
   source: EventLogSource;
   kind: string;
+  msg: string;
   summary: string;
   device?: string;
   action?: string;
@@ -13,8 +14,9 @@ export type EventLogEntry = {
   details?: Record<string, unknown>;
 };
 
-export type EventLogDraft = Omit<EventLogEntry, "id" | "timestamp"> & {
+export type EventLogDraft = Omit<EventLogEntry, "id" | "timestamp" | "msg"> & {
   timestamp?: string;
+  msg?: string;
 };
 
 export const EVENT_LOG_MAX_ENTRIES = 500;
@@ -110,6 +112,7 @@ export function recordEventLogEvent(draft: EventLogDraft): EventLogEntry {
     ...draft,
     id: nextEventId++,
     timestamp: draft.timestamp ?? new Date().toISOString(),
+    msg: draft.msg ?? draft.summary,
   };
   entries.push(entry);
   if (entries.length > EVENT_LOG_MAX_ENTRIES) {
@@ -125,7 +128,12 @@ export function updateEventLogEvent(
 ): EventLogEntry | null {
   const index = entries.findIndex((entry) => entry.id === id);
   if (index < 0) return null;
-  const entry = { ...entries[index]!, ...patch, id };
+  const entry = {
+    ...entries[index]!,
+    ...patch,
+    id,
+    ...(patch.summary != null && patch.msg == null ? { msg: patch.summary } : {}),
+  };
   entries[index] = entry;
   notifyEventLogSubscribers(entry);
   return entry;

--- a/packages/serve-sim/src/event-log.ts
+++ b/packages/serve-sim/src/event-log.ts
@@ -186,7 +186,7 @@ export function eventLogEventForHidMessage(
         source: "hid",
         kind: "touch",
         action: type,
-        summary: `Touch ${type} ${formatPoint(x, y)}`,
+        summary: `Touch ${type} ${formatEventLogPoint(x, y)}`,
         details: withScreen({ ...details, x, y }, screen),
       };
     }
@@ -220,13 +220,23 @@ export function eventLogEventForHidMessage(
       const usage = numberValue(details.usage);
       if (!type || usage == null) return null;
       const key = keyLabelForUsage(usage);
+      const printable = isPrintableKeyUsage(usage);
+      const eventDetails = { ...details };
+      if (printable) {
+        delete eventDetails.usage;
+        eventDetails.key = "character";
+        eventDetails.redacted = true;
+      } else {
+        eventDetails.usage = usage;
+        eventDetails.key = key;
+      }
       return {
         device,
         source: "hid",
         kind: "key",
         action: type,
-        summary: `Key ${type} ${key}`,
-        details: { ...details, usage, key },
+        summary: printable ? `Key ${type} character` : `Key ${type} ${key}`,
+        details: eventDetails,
       };
     }
     case 0x07: {
@@ -399,7 +409,7 @@ export function eventLogEventForCommand(
         kind: "tap",
         action: "tap",
         status,
-        summary: `Tap ${formatPoint(Number(x), Number(y))}`,
+        summary: `Tap ${formatEventLogPoint(Number(x), Number(y))}`,
         details: commandDetail,
       };
     }
@@ -524,6 +534,15 @@ function keyLabelForUsage(usage: number): string {
   return KEY_LABEL_BY_USAGE[usage] ?? `usage ${usage}`;
 }
 
+function isPrintableKeyUsage(usage: number): boolean {
+  return (
+    (usage >= 0x04 && usage <= 0x27) ||
+    (usage >= 0x2c && usage <= 0x38) ||
+    (usage >= 0x54 && usage <= 0x57) ||
+    (usage >= 0x59 && usage <= 0x63)
+  );
+}
+
 function withScreen(
   details: Record<string, unknown>,
   screen: { width: number; height: number } | undefined,
@@ -532,21 +551,21 @@ function withScreen(
   return { ...details, screen };
 }
 
-function formatPoint(x: number, y: number): string {
+export function formatEventLogPoint(x: number, y: number): string {
   if (!Number.isFinite(x) || !Number.isFinite(y)) return "";
-  return `${formatNumber(x)},${formatNumber(y)}`;
+  return `${formatEventLogNumber(x)},${formatEventLogNumber(y)}`;
 }
 
 function formatDelta(dx: number, dy: number): string {
   return `${formatSigned(dx)},${formatSigned(dy)}`;
 }
 
-function formatNumber(value: number): string {
+function formatEventLogNumber(value: number): string {
   return value.toFixed(3).replace(/0+$/, "").replace(/\.$/, "");
 }
 
 function formatSigned(value: number): string {
-  const formatted = formatNumber(value);
+  const formatted = formatEventLogNumber(value);
   return value > 0 ? `+${formatted}` : formatted;
 }
 

--- a/packages/serve-sim/src/event-log.ts
+++ b/packages/serve-sim/src/event-log.ts
@@ -125,6 +125,7 @@ export function recordEventLogEvent(draft: EventLogDraft): EventLogEntry {
 export function updateEventLogEvent(
   id: number,
   patch: Partial<Omit<EventLogEntry, "id">>,
+  options: { notify?: boolean } = {},
 ): EventLogEntry | null {
   const index = entries.findIndex((entry) => entry.id === id);
   if (index < 0) return null;
@@ -135,7 +136,7 @@ export function updateEventLogEvent(
     ...(patch.summary != null && patch.msg == null ? { msg: patch.summary } : {}),
   };
   entries[index] = entry;
-  notifyEventLogSubscribers(entry);
+  if (options.notify !== false) notifyEventLogSubscribers(entry);
   return entry;
 }
 

--- a/packages/serve-sim/src/event-log.ts
+++ b/packages/serve-sim/src/event-log.ts
@@ -320,32 +320,32 @@ export function eventLogEventForCommand(
   if (isUploadPlumbing(tokens)) return null;
 
   const status = statusFromExitCode(result?.exitCode);
-  const commandDetail = { command: compactCommand(command), ...(status ? { exitCode: result?.exitCode } : {}) };
+  const commandDetail = commandResultDetails(result);
   const simctl = simctlCommand(tokens);
   if (simctl) {
     const { verb, args } = simctl;
     if (verb === "install" && args.length >= 2) {
-      const [device, path] = args;
+      const [device] = args;
       return {
         device,
         source: "exec",
         kind: "app",
         action: "install",
         status,
-        summary: `Install app ${basename(path)}`,
-        details: { ...commandDetail, path },
+        summary: "Install app",
+        details: commandDetail,
       };
     }
     if (verb === "addmedia" && args.length >= 2) {
-      const [device, path] = args;
+      const [device] = args;
       return {
         device,
         source: "exec",
         kind: "media",
         action: "addmedia",
         status,
-        summary: `Add media ${basename(path)}`,
-        details: { ...commandDetail, path },
+        summary: "Add media",
+        details: commandDetail,
       };
     }
     if (verb === "launch" && args.length >= 2) {
@@ -462,7 +462,7 @@ export function eventLogEventForCommand(
       };
     }
     if (verb === "camera") {
-      const action = cameraAction(args);
+      const action = cameraEventAction(args);
       if (action === "status" || action === "list-webcams") return null;
       return {
         device,
@@ -575,6 +575,10 @@ function statusFromExitCode(exitCode: number | undefined): EventLogStatus | unde
   return exitCode === 0 ? "ok" : "error";
 }
 
+function commandResultDetails(result: { exitCode?: number } | undefined): Record<string, unknown> {
+  return statusFromExitCode(result?.exitCode) ? { exitCode: result?.exitCode } : {};
+}
+
 function tokenizeCommand(command: string): string[] {
   const tokens: string[] = [];
   let current = "";
@@ -662,12 +666,8 @@ function cameraAction(args: string[]): string | undefined {
   return firstPositional(args);
 }
 
-function basename(path: string | undefined): string {
-  if (!path) return "";
-  return path.split("/").filter(Boolean).pop() ?? path;
-}
-
-function compactCommand(command: string): string {
-  const normalized = command.replace(/\s+/g, " ").trim();
-  return normalized.length <= 240 ? normalized : `${normalized.slice(0, 237)}...`;
+function cameraEventAction(args: string[]): string | undefined {
+  const action = cameraAction(args);
+  if (action === "status" || action === "list-webcams" || action === "stop-webcam") return action;
+  return "start";
 }

--- a/packages/serve-sim/src/exec-ws.ts
+++ b/packages/serve-sim/src/exec-ws.ts
@@ -54,6 +54,10 @@ interface ExecMessage {
 
 /** In-process handler for `{id, ui}` requests; resolves to the reply body. */
 export type UiRequestHandler = (payload: unknown) => Promise<Record<string, unknown>>;
+export type CommandResultHandler = (
+  command: string,
+  result: { stdout: string; stderr: string; exitCode: number },
+) => void;
 
 interface ExecChannelOptions {
   path: string;
@@ -62,6 +66,8 @@ interface ExecChannelOptions {
   ssePrefixes?: string[];
   /** In-process handler for `{id, ui}` simulator-settings requests. */
   onUiRequest?: UiRequestHandler;
+  /** Optional observer for completed shell commands. */
+  onCommandResult?: CommandResultHandler;
 }
 
 function wireExecSocket(
@@ -166,12 +172,16 @@ function wireExecSocket(
     }
     const { id, command } = msg;
     exec(command, { maxBuffer: 16 * 1024 * 1024 }, (err, stdout, stderr) => {
-      send({
+      const result = {
         id,
         stdout: stdout.toString(),
         stderr: stderr.toString(),
         exitCode: err ? ((err as ExecException).code ?? 1) : 0,
-      });
+      };
+      try {
+        opts.onCommandResult?.(command, result);
+      } catch {}
+      send(result);
     });
   });
 

--- a/packages/serve-sim/src/exec-ws.ts
+++ b/packages/serve-sim/src/exec-ws.ts
@@ -180,7 +180,10 @@ function wireExecSocket(
       };
       try {
         opts.onCommandResult?.(command, result);
-      } catch {}
+      } catch {
+        // Command-result observers are diagnostic side-channels; a failure
+        // here must not break the exec response path.
+      }
       send(result);
     });
   });

--- a/packages/serve-sim/src/index.ts
+++ b/packages/serve-sim/src/index.ts
@@ -659,8 +659,11 @@ async function eventLog(
     console.log("No events.");
     return;
   }
+  const deviceLabels = deviceLabelsForEvents(payload.events);
   for (const entry of payload.events) {
-    console.log(formatEventLogLine(entry));
+    console.log(formatEventLogLine(entry, {
+      deviceLabel: entry.device ? deviceLabels.get(entry.device) : null,
+    }));
   }
 }
 
@@ -672,6 +675,25 @@ function parseEventLogLimit(value: string | undefined): number | undefined {
     process.exit(1);
   }
   return Math.floor(limit);
+}
+
+function deviceLabelsForEvents(events: EventLogEntry[]): Map<string, string> {
+  const devices = [...new Set(events.map((event) => event.device).filter((device): device is string => !!device))];
+  const names = new Map<string, string>();
+  for (const device of devices) {
+    names.set(device, getDeviceName(device) ?? device.slice(0, 8));
+  }
+
+  const counts = new Map<string, number>();
+  for (const name of names.values()) {
+    counts.set(name, (counts.get(name) ?? 0) + 1);
+  }
+
+  const labels = new Map<string, string>();
+  for (const [device, name] of names) {
+    labels.set(device, counts.get(name)! > 1 ? `${name} (${device.slice(0, 8)})` : name);
+  }
+  return labels;
 }
 
 async function gesture(jsonStr: string, deviceArg?: string) {

--- a/packages/serve-sim/src/index.ts
+++ b/packages/serve-sim/src/index.ts
@@ -13,6 +13,7 @@ import { findBootedDevice, resolveDevice } from "./device";
 import { permissions } from "./permissions";
 import { uiSettings } from "./ui-settings";
 import { debugCli, debugHelper, debugState } from "./debug";
+import type { EventLogEntry } from "./event-log";
 
 // `import.meta.dir` is Bun-only; resolve once via fileURLToPath so the bundled
 // CLI works under plain `node` too.
@@ -621,6 +622,65 @@ function killStreams(deviceArg?: string) {
     clearState();
     console.log(JSON.stringify({ disconnected: true, devices }));
   }
+}
+
+async function eventLog(
+  deviceArg?: string,
+  opts: { json?: boolean; limit?: string } = {},
+) {
+  const udid = deviceArg ? resolveDevice(deviceArg) : undefined;
+  const state = readState(udid);
+  if (!state) {
+    console.error("No serve-sim server running. Run `serve-sim` first.");
+    process.exit(1);
+  }
+
+  const url = new URL("/api/event-log", state.url);
+  if (udid) url.searchParams.set("device", state.device);
+  const limit = parseEventLogLimit(opts.limit);
+  if (limit != null) url.searchParams.set("limit", String(limit));
+
+  let payload: { events: EventLogEntry[] };
+  try {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    payload = await res.json() as { events: EventLogEntry[] };
+  } catch (err) {
+    console.error(`Failed to read event log: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+
+  if (opts.json) {
+    console.log(JSON.stringify(payload, null, 2));
+    return;
+  }
+  if (payload.events.length === 0) {
+    console.log("No events.");
+    return;
+  }
+  for (const entry of payload.events) {
+    console.log(formatEventLogLine(entry));
+  }
+}
+
+function parseEventLogLimit(value: string | undefined): number | undefined {
+  if (value == null) return undefined;
+  const limit = Number(value);
+  if (!Number.isFinite(limit) || limit <= 0) {
+    console.error("event-log --limit must be a positive number");
+    process.exit(1);
+  }
+  return Math.floor(limit);
+}
+
+function formatEventLogLine(entry: EventLogEntry): string {
+  const time = new Date(entry.timestamp);
+  const stamp = Number.isNaN(time.getTime())
+    ? entry.timestamp
+    : time.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+  const device = entry.device ? ` ${entry.device.slice(0, 8)}` : "";
+  const status = entry.status && entry.status !== "ok" ? ` [${entry.status}]` : "";
+  return `${stamp}${device} ${entry.source}/${entry.kind}${status} ${entry.summary}`;
 }
 
 async function gesture(jsonStr: string, deviceArg?: string) {
@@ -1802,6 +1862,14 @@ program
   .description("Simulate a memory warning on the device")
   .option(...deviceOpt)
   .action((opts) => memoryWarning(opts.device));
+
+program
+  .command("event-log")
+  .description("Show recent simulator events")
+  .option(...deviceOpt)
+  .option("-j, --json", "Print JSON")
+  .option("-n, --limit <count>", "Maximum number of events")
+  .action((opts) => eventLog(opts.device, { json: opts.json, limit: opts.limit }));
 
 // `camera` and `permissions` keep their own dedicated argument parsers (the
 // camera verb has nested sub-verbs and source flags; permissions has a

--- a/packages/serve-sim/src/index.ts
+++ b/packages/serve-sim/src/index.ts
@@ -14,6 +14,7 @@ import { permissions } from "./permissions";
 import { uiSettings } from "./ui-settings";
 import { debugCli, debugHelper, debugState } from "./debug";
 import type { EventLogEntry } from "./event-log";
+import { formatEventLogLine } from "./event-log-format";
 
 // `import.meta.dir` is Bun-only; resolve once via fileURLToPath so the bundled
 // CLI works under plain `node` too.
@@ -671,16 +672,6 @@ function parseEventLogLimit(value: string | undefined): number | undefined {
     process.exit(1);
   }
   return Math.floor(limit);
-}
-
-function formatEventLogLine(entry: EventLogEntry): string {
-  const time = new Date(entry.timestamp);
-  const stamp = Number.isNaN(time.getTime())
-    ? entry.timestamp
-    : time.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
-  const device = entry.device ? ` ${entry.device.slice(0, 8)}` : "";
-  const status = entry.status && entry.status !== "ok" ? ` [${entry.status}]` : "";
-  return `${stamp}${device} ${entry.source}/${entry.kind}${status} ${entry.summary}`;
 }
 
 async function gesture(jsonStr: string, deviceArg?: string) {

--- a/packages/serve-sim/src/index.ts
+++ b/packages/serve-sim/src/index.ts
@@ -205,6 +205,11 @@ function pickDefaultDevice(): { udid: string; name: string } | null {
 }
 
 function getDeviceName(udid: string): string | null {
+  return readDeviceNamesByUdid().get(udid) ?? null;
+}
+
+function readDeviceNamesByUdid(): Map<string, string> {
+  const names = new Map<string, string>();
   try {
     const output = execSync("xcrun simctl list devices -j", { encoding: "utf-8" });
     const data = JSON.parse(output) as {
@@ -212,11 +217,11 @@ function getDeviceName(udid: string): string | null {
     };
     for (const runtime of Object.values(data.devices)) {
       for (const device of runtime) {
-        if (device.udid === udid) return device.name;
+        names.set(device.udid, device.name);
       }
     }
   } catch {}
-  return null;
+  return names;
 }
 
 function isDeviceBooted(udid: string): boolean {
@@ -680,8 +685,9 @@ function parseEventLogLimit(value: string | undefined): number | undefined {
 function deviceLabelsForEvents(events: EventLogEntry[]): Map<string, string> {
   const devices = [...new Set(events.map((event) => event.device).filter((device): device is string => !!device))];
   const names = new Map<string, string>();
+  const deviceNames = readDeviceNamesByUdid();
   for (const device of devices) {
-    names.set(device, getDeviceName(device) ?? device.slice(0, 8));
+    names.set(device, deviceNames.get(device) ?? device.slice(0, 8));
   }
 
   const counts = new Map<string, number>();

--- a/packages/serve-sim/src/middleware.ts
+++ b/packages/serve-sim/src/middleware.ts
@@ -13,6 +13,12 @@ import type { Socket } from "net";
 import { WebSocket } from "ws";
 import { createAxStreamerCache } from "./ax";
 import { getDeviceSession, closeDeviceSession, type HidSocket } from "./device-session";
+import {
+  eventLogEventForCommand,
+  readEventLog,
+  recordEventLogEvent,
+  subscribeEventLog,
+} from "./event-log";
 import { axFrontmostAsync } from "./native";
 import { inProcessServeSimState, writeServeSimState, type ServeSimDeviceState } from "./state";
 import { debugMw } from "./debug";
@@ -107,6 +113,25 @@ const axStreamerCache = createAxStreamerCache();
 // the partial line is dropped rather than retained indefinitely.
 const SSE_LINE_BUFFER_LIMIT = 1024 * 1024;
 let inspectWebKitBridge: Promise<WebKitBridge> | null = null;
+
+function eventLogLimit(rawUrl: string): number | undefined {
+  const value = new URL(rawUrl, "http://x").searchParams.get("limit");
+  if (!value) return undefined;
+  const limit = Number(value);
+  return Number.isFinite(limit) ? limit : undefined;
+}
+
+function eventLogSinceId(rawUrl: string): number | undefined {
+  const value = new URL(rawUrl, "http://x").searchParams.get("since");
+  if (!value) return undefined;
+  const since = Number(value);
+  return Number.isFinite(since) ? since : undefined;
+}
+
+function recordCommandEvent(command: string, result: { exitCode?: number }): void {
+  const event = eventLogEventForCommand(command, result);
+  if (event) recordEventLogEvent(event);
+}
 
 // Known bundle IDs that are always React Native shells (used as a fallback
 // before the app-container path resolves, since simctl can lag after launch).
@@ -796,6 +821,8 @@ export function previewConfigForState(
 ): ServeSimState & {
   basePath: string;
   appStateEndpoint: string;
+  eventLogEndpoint: string;
+  eventLogEventsEndpoint: string;
   axEndpoint: string;
   devtoolsEndpoint: string;
   serveSimBin: string;
@@ -813,6 +840,8 @@ export function previewConfigForState(
     ...state,
     basePath: base,
     appStateEndpoint: endpoint(base, "/appstate", state.device),
+    eventLogEndpoint: endpoint(base, "/api/event-log", state.device),
+    eventLogEventsEndpoint: endpoint(base, "/api/event-log/events", state.device),
     axEndpoint: endpoint(base, "/ax", state.device),
     devtoolsEndpoint: endpoint(base, "/devtools", state.device),
     serveSimBin,
@@ -1225,6 +1254,15 @@ export function simMiddleware(options?: SimMiddlewareOptions): SimMiddleware {
     const value = typeof p.value === "string" ? normalizeUiValue(p.option, p.value) : null;
     if (value === null) throw new Error(`invalid value for ${p.option}: ${p.value}`);
     await setUiOption(p.device, p.option, value);
+    recordEventLogEvent({
+      device: p.device,
+      source: "ui",
+      kind: "ui-setting",
+      action: p.option,
+      status: "ok",
+      summary: `UI ${p.option} ${value}`,
+      details: { option: p.option, value },
+    });
     return { ok: true };
   };
 
@@ -1612,6 +1650,56 @@ export function simMiddleware(options?: SimMiddlewareOptions): SimMiddleware {
       return;
     }
 
+    // JSON API: recent simulator action log. This is intentionally in-memory and
+    // bounded; it is for live debugging/agent observability, not archival audit.
+    if (url === base + "/api/event-log") {
+      res.writeHead(200, {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-store",
+      });
+      res.end(JSON.stringify({
+        events: readEventLog({
+          device: selectedDevice,
+          sinceId: eventLogSinceId(rawUrl),
+          limit: eventLogLimit(rawUrl),
+        }),
+      }));
+      return;
+    }
+
+    // SSE: action log stream. Sends a snapshot first, then individual new
+    // entries. The exec-ws control channel proxies this route for the browser UI.
+    if (url === base + "/api/event-log/events") {
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache",
+        Connection: "keep-alive",
+        "X-Accel-Buffering": "no",
+      });
+      res.write(":\n\n");
+      res.write("data: " + JSON.stringify({
+        events: readEventLog({
+          device: selectedDevice,
+          sinceId: eventLogSinceId(rawUrl),
+          limit: eventLogLimit(rawUrl),
+        }),
+      }) + "\n\n");
+
+      const unsubscribe = subscribeEventLog((event) => {
+        if (selectedDevice && event.device !== selectedDevice) return;
+        if (res.writableEnded) return;
+        res.write("data: " + JSON.stringify({ event }) + "\n\n");
+      });
+      const heartbeat = setInterval(() => {
+        if (!res.writableEnded) res.write(":\n\n");
+      }, 15000);
+      req.on("close", () => {
+        clearInterval(heartbeat);
+        unsubscribe();
+      });
+      return;
+    }
+
     // SSE: serve-sim state stream. Push replacement for the web UI's old ~1.5s
     // /api poll — the PreviewConfig only changes when a helper boots/shuts down
     // or the device selection changes, so we watch the state dir and emit only
@@ -1786,11 +1874,13 @@ export function simMiddleware(options?: SimMiddlewareOptions): SimMiddleware {
           return;
         }
         exec(command, { maxBuffer: 16 * 1024 * 1024 }, (err, stdout, stderr) => {
+          const exitCode = err ? (err as ExecException).code ?? 1 : 0;
+          recordCommandEvent(command, { exitCode });
           res.writeHead(200, { "Content-Type": "application/json" });
           res.end(JSON.stringify({
             stdout: stdout.toString(),
             stderr: stderr.toString(),
-            exitCode: err ? (err as ExecException).code ?? 1 : 0,
+            exitCode,
           }));
         });
       });
@@ -1930,10 +2020,12 @@ export function simMiddleware(options?: SimMiddlewareOptions): SimMiddleware {
     execToken,
     ssePrefixes: [
       `${base}/api/events`,
+      `${base}/api/event-log/events`,
       `${base}/appstate`,
       `${base}/ax`,
     ],
     onUiRequest: handleUiRequest,
+    onCommandResult: (command, result) => recordCommandEvent(command, result),
   });
 
   // WebSocket upgrades owned by the preview: the authenticated exec/control

--- a/packages/serve-sim/src/middleware.ts
+++ b/packages/serve-sim/src/middleware.ts
@@ -1270,7 +1270,8 @@ export function simMiddleware(options?: SimMiddlewareOptions): SimMiddleware {
     const rawUrl: string = req.url ?? "";
     const qIndex = rawUrl.indexOf("?");
     const url = qIndex === -1 ? rawUrl : rawUrl.slice(0, qIndex);
-    const selectedDevice = queryDevice(rawUrl) ?? options?.device ?? null;
+    const requestedDevice = queryDevice(rawUrl);
+    const selectedDevice = requestedDevice ?? options?.device ?? null;
     const devtoolsFrontendBase = base === "/" ? "/devtools-frontend" : `${base}/devtools-frontend`;
 
     const helperTarget = helperProxyTarget(rawUrl, helperPrefix);
@@ -1659,7 +1660,7 @@ export function simMiddleware(options?: SimMiddlewareOptions): SimMiddleware {
       });
       res.end(JSON.stringify({
         events: readEventLog({
-          device: selectedDevice,
+          device: requestedDevice,
           sinceId: eventLogSinceId(rawUrl),
           limit: eventLogLimit(rawUrl),
         }),
@@ -1679,14 +1680,14 @@ export function simMiddleware(options?: SimMiddlewareOptions): SimMiddleware {
       res.write(":\n\n");
       res.write("data: " + JSON.stringify({
         events: readEventLog({
-          device: selectedDevice,
+          device: requestedDevice,
           sinceId: eventLogSinceId(rawUrl),
           limit: eventLogLimit(rawUrl),
         }),
       }) + "\n\n");
 
       const unsubscribe = subscribeEventLog((event) => {
-        if (selectedDevice && event.device !== selectedDevice) return;
+        if (requestedDevice && event.device !== requestedDevice) return;
         if (res.writableEnded) return;
         res.write("data: " + JSON.stringify({ event }) + "\n\n");
       });

--- a/packages/serve-sim/src/middleware.ts
+++ b/packages/serve-sim/src/middleware.ts
@@ -129,8 +129,12 @@ function eventLogSinceId(rawUrl: string): number | undefined {
 }
 
 function recordCommandEvent(command: string, result: { exitCode?: number }): void {
-  const event = eventLogEventForCommand(command, result);
-  if (event) recordEventLogEvent(event);
+  try {
+    const event = eventLogEventForCommand(command, result);
+    if (event) recordEventLogEvent(event);
+  } catch {
+    // Event-log recording is diagnostic; it must never break the exec path.
+  }
 }
 
 // Known bundle IDs that are always React Native shells (used as a fallback
@@ -1254,15 +1258,19 @@ export function simMiddleware(options?: SimMiddlewareOptions): SimMiddleware {
     const value = typeof p.value === "string" ? normalizeUiValue(p.option, p.value) : null;
     if (value === null) throw new Error(`invalid value for ${p.option}: ${p.value}`);
     await setUiOption(p.device, p.option, value);
-    recordEventLogEvent({
-      device: p.device,
-      source: "ui",
-      kind: "ui-setting",
-      action: p.option,
-      status: "ok",
-      summary: `UI ${p.option} ${value}`,
-      details: { option: p.option, value },
-    });
+    try {
+      recordEventLogEvent({
+        device: p.device,
+        source: "ui",
+        kind: "ui-setting",
+        action: p.option,
+        status: "ok",
+        summary: `UI ${p.option} ${value}`,
+        details: { option: p.option, value },
+      });
+    } catch {
+      // Event-log recording is diagnostic; it must not fail the UI request.
+    }
     return { ok: true };
   };
 


### PR DESCRIPTION
# Why

serve-sim did not have one place to inspect the actions routed through the preview or CLI. When debugging agent-driven sessions, it is useful to see recent simulator actions in order: touches, gestures, hardware buttons, app installs, media drops, UI setting changes, screenshots, and related commands.

For EAS and other automation consumers, JSON events also need a stable message field. Adding a Bunyan-style `msg` field lets logs from serve-sim and other tools be gathered together without every consumer knowing serve-sim-specific display fields.

# How

- Added a bounded in-memory event log for simulator events, exposed through JSON and SSE endpoints.
- Record HID input at the central `DeviceSession` ingress, plus recognized host-side simulator commands from `/exec` and UI setting updates.
- Coalesce touch sequences into readable tap and drag entries instead of logging every move event.
- Redact printable key values so text typed into the simulator is not exposed through the event log.
- Added `msg` to every JSON event entry while keeping `summary` as a compatibility/display alias.
- Added a compact Event Log section to the Tools panel that streams new events live.
- Added `serve-sim event-log [-d udid] [--json] [--limit n]` for CLI and automation consumers.
- Skip upload/base64 plumbing commands so the log shows the user-level action instead of implementation noise.

# Test Plan

- `bunx tsc --noEmit`
- `bun test packages/serve-sim/src/__tests__`
- `bun run packages/serve-sim/build.ts`


https://github.com/user-attachments/assets/e6fe4267-4aad-438f-a872-4731970bb7eb

```json
➜  serve-sim git:(szdziedzic-codex/event-log) node packages/serve-sim/dist/serve-sim.js event-log --json -n 5
{
  "events": [
    {
      "device": "AC78FEE5-C665-4295-889B-F6BCB1A618D5",
      "source": "ui",
      "kind": "ui-setting",
      "action": "appearance",
      "status": "ok",
      "summary": "UI appearance dark",
      "details": {
        "option": "appearance",
        "value": "dark"
      },
      "id": 30,
      "timestamp": "2026-07-02T15:28:28.025Z",
      "msg": "UI appearance dark"
    },
    {
      "device": "AC78FEE5-C665-4295-889B-F6BCB1A618D5",
      "source": "hid",
      "kind": "tap",
      "action": "tap",
      "summary": "Tap 0.225,0.637",
      "details": {
        "type": "tap",
        "start": {
          "x": 0.22482827944379294,
          "y": 0.636982430905168
        },
        "current": {
          "x": 0.22482827944379294,
          "y": 0.636982430905168
        },
        "moveCount": 0,
        "screen": {
          "width": 1206,
          "height": 2622
        }
      },
      "id": 31,
      "timestamp": "2026-07-02T15:28:37.584Z",
      "msg": "Tap 0.225,0.637"
    },
    {
      "device": "AC78FEE5-C665-4295-889B-F6BCB1A618D5",
      "source": "hid",
      "kind": "drag",
      "action": "drag",
      "summary": "Drag 0.736,0.672 -> 0.128,0.66",
      "details": {
        "type": "drag",
        "phase": "end",
        "start": {
          "x": 0.7359133299826883,
          "y": 0.6715041611014075
        },
        "current": {
          "x": 0.12832970346791758,
          "y": 0.659996917702661
        },
        "moveCount": 11,
        "screen": {
          "width": 1206,
          "height": 2622
        }
      },
      "id": 32,
      "timestamp": "2026-07-02T15:28:38.288Z",
      "msg": "Drag 0.736,0.672 -> 0.128,0.66"
    },
    {
      "device": "AC78FEE5-C665-4295-889B-F6BCB1A618D5",
      "source": "hid",
      "kind": "tap",
      "action": "tap",
      "summary": "Tap 0.346,0.624",
      "details": {
        "type": "tap",
        "start": {
          "x": 0.34634500474674706,
          "y": 0.6238312955923148
        },
        "current": {
          "x": 0.34634500474674706,
          "y": 0.6238312955923148
        },
        "moveCount": 0,
        "screen": {
          "width": 1206,
          "height": 2622
        }
      },
      "id": 33,
      "timestamp": "2026-07-02T15:28:39.151Z",
      "msg": "Tap 0.346,0.624"
    },
    {
      "device": "AC78FEE5-C665-4295-889B-F6BCB1A618D5",
      "source": "exec",
      "kind": "button",
      "action": "home",
      "status": "ok",
      "summary": "Home",
      "details": {
        "command": "xcrun simctl launch AC78FEE5-C665-4295-889B-F6BCB1A618D5 com.apple.springboard",
        "exitCode": 0,
        "bundleId": "com.apple.springboard"
      },
      "id": 34,
      "timestamp": "2026-07-02T15:28:40.136Z",
      "msg": "Home"
    }
  ]
}
```

```
➜  serve-sim git:(szdziedzic-codex/event-log) node packages/serve-sim/dist/serve-sim.js event-log           
05:27:39 PM  iPhone 17 Pro  Key down Left Command
05:27:41 PM  iPhone 17 Pro  Key down Left Shift
05:27:48 PM  iPhone 17 Pro  Key up Left Command
05:27:48 PM  iPhone 17 Pro  Key up Left Shift
05:27:50 PM  iPhone 17 Pro  Tap at 0.30, 0.66
05:27:52 PM  iPhone 17 Pro  Tap at 0.30, 0.66
05:27:53 PM  iPhone 17 Pro  Drag from 0.20, 0.67 to 0.00, 0.70
05:27:55 PM  iPhone 17 Pro  Drag from 0.01, 0.70 to 0.16, 0.66
05:28:01 PM  iPhone 17 Pro  Home
05:28:02 PM  iPhone 17 Pro  Screenshot
05:28:05 PM  iPhone 17 Pro  Tap at 0.61, 0.94
05:28:06 PM  iPhone 17 Pro  Tap at 0.47, 0.94
05:28:07 PM  iPhone 17 Pro  Key down character
05:28:07 PM  iPhone 17 Pro  Key up character
05:28:08 PM  iPhone 17 Pro  Key down character
05:28:08 PM  iPhone 17 Pro  Key up character
05:28:08 PM  iPhone 17 Pro  Key down character
05:28:09 PM  iPhone 17 Pro  Key up character
05:28:09 PM  iPhone 17 Pro  Key down character
05:28:09 PM  iPhone 17 Pro  Key up character
05:28:10 PM  iPhone 17 Pro  Key down character
05:28:10 PM  iPhone 17 Pro  Key up character
05:28:10 PM  iPhone 17 Pro  Key down character
05:28:11 PM  iPhone 17 Pro  Key up character
05:28:15 PM  iPhone 17 Pro  Home
05:28:21 PM  iPhone 17 Pro  Rotate landscape left
05:28:22 PM  iPhone 17 Pro  Rotate portrait upside down
05:28:23 PM  iPhone 17 Pro  Rotate landscape right
05:28:24 PM  iPhone 17 Pro  Rotate portrait
05:28:28 PM  iPhone 17 Pro  UI appearance dark
05:28:37 PM  iPhone 17 Pro  Tap at 0.22, 0.64
05:28:38 PM  iPhone 17 Pro  Drag from 0.74, 0.67 to 0.13, 0.66
05:28:39 PM  iPhone 17 Pro  Tap at 0.35, 0.62
05:28:40 PM  iPhone 17 Pro  Home
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added a real-time event log tool to the simulator Tools panel.
  * Introduced `serve-sim event-log` to view recent simulator events (human-readable or JSON) with optional device filtering.
  * Added new server endpoints for retrieving recent events, including a live SSE stream.
* **Bug Fixes**
  * Improved event readability with localized timestamps, clearer device labels, and more human-friendly tap/drag and key/rotation details.
  * Enhanced touch gesture logging by distinguishing tap vs drag and improving drag update behavior.
* **Documentation**
  * Updated the `serve-sim` README with the new tool and CLI usage.
* **Tests**
  * Added coverage for event-log formatting, filtering, pagination, and command/HID event mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
