### PR TITLE
fix(serve-sim): send plain R to reload RN/Expo bundle

### DIFF
--- a/packages/serve-sim/src/client/client.tsx
+++ b/packages/serve-sim/src/client/client.tsx
@@ -714,17 +714,14 @@ function AppWithConfig({
     return () => { if (timer) clearTimeout(timer); es.close(); };
   }, [config.appStateEndpoint]);
 
-  // Cmd+R to reload the RN/Expo bundle.
+  // R to reload the RN/Expo bundle.
+  // expo-go https://github.com/expo/expo/blob/f043020ffffd39fabb7684d52937d349f1ddc148/apps/expo-go/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m#L236
+  // dev-client https://github.com/expo/expo/blob/f043020ffffd39fabb7684d52937d349f1ddc148/packages/expo-dev-menu/ios/Interceptors/DevMenuKeyCommandsInterceptor.swift#L46
   const sendReactNativeReload = useCallback(async () => {
-    const META = 0xe3;
     const R = 0x15;
-    sendKey("down", META);
-    await new Promise((r) => setTimeout(r, 30));
     sendKey("down", R);
     await new Promise((r) => setTimeout(r, 30));
     sendKey("up", R);
-    await new Promise((r) => setTimeout(r, 30));
-    sendKey("up", META);
   }, [sendKey]);
 
   const simContainerRef = useRef<HTMLDivElement | null>(null);

--- a/packages/serve-sim/src/client/client.tsx
+++ b/packages/serve-sim/src/client/client.tsx
@@ -1058,7 +1058,7 @@ function AppWithConfig({
               {currentApp?.isReactNative && (
                 <SimulatorToolbar.Button
                   aria-label="Reload React Native bundle"
-                  title="Reload (Cmd+R)"
+                  title="Reload (R)"
                   onClick={() => void sendReactNativeReload()}
                 >
                   <ReloadIcon />

--- a/packages/serve-sim/src/client/client.tsx
+++ b/packages/serve-sim/src/client/client.tsx
@@ -717,6 +717,7 @@ function AppWithConfig({
   // R to reload the RN/Expo bundle.
   // expo-go https://github.com/expo/expo/blob/f043020ffffd39fabb7684d52937d349f1ddc148/apps/expo-go/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m#L236
   // dev-client https://github.com/expo/expo/blob/f043020ffffd39fabb7684d52937d349f1ddc148/packages/expo-dev-menu/ios/Interceptors/DevMenuKeyCommandsInterceptor.swift#L46
+  // react-native https://github.com/react/react-native/blob/c1652651c09506b8dda0b9515b5f0e5829220f0d/packages/react-native/React/Base/RCTKeyCommands.m#L69-L74
   const sendReactNativeReload = useCallback(async () => {
     const R = 0x15;
     sendKey("down", R);


### PR DESCRIPTION
## Why

The reload button was sending **Cmd+R** to the simulator, but since **Expo SDK 52** the reload key command is plain **`r`** (no modifier). Sending the Cmd modifier no longer triggers a reload.

This flipped in expo/expo [#33917 — "[expo-go] Fix reloading when typing in text input"](https://github.com/expo/expo/pull/33917), which changed the registered iOS key command from `Cmd+R` → plain `r`. It first shipped in **SDK 53** and was backported to the **SDK 52** release branch.

Plain `r` is also the reload key command in bare **React Native** itself, so this works beyond Expo Go / dev-client.

(Note: on the iOS simulator specifically, plain `r` has worked since ~SDK 43 via a separate simulator-only swizzle — but Cmd+R was the official command on real devices through SDK 51.)

## Change

Send just the `R` key instead of `Cmd`+`R`, and update the button tooltip from `Reload (Cmd+R)` to `Reload (R)`.

## References

- react-native: https://github.com/react/react-native/blob/c1652651c09506b8dda0b9515b5f0e5829220f0d/packages/react-native/React/Base/RCTKeyCommands.m#L69-L74
- expo-go: https://github.com/expo/expo/blob/f043020ffffd39fabb7684d52937d349f1ddc148/apps/expo-go/ios/Exponent/Kernel/DevSupport/EXKernelDevKeyCommands.m#L236
- dev-client: https://github.com/expo/expo/blob/f043020ffffd39fabb7684d52937d349f1ddc148/packages/expo-dev-menu/ios/Interceptors/DevMenuKeyCommandsInterceptor.swift#L46

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified the React Native/Expo reload keyboard input to send only an `R` key press (down → brief delay → up), removing the previous extra modifier and repeated key actions.
* **UI Improvements**
  * Updated the React Native reload toolbar button tooltip/title to display **“Reload (R)”** instead of **“Reload (Cmd+R)”**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->