### PR TITLE
fix(cli): gesture accepts an array of steps so drags/swipes work in one call

### DIFF
--- a/packages/serve-sim/src/__tests__/gesture-steps.test.ts
+++ b/packages/serve-sim/src/__tests__/gesture-steps.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "bun:test";
+import { parseGestureSteps, stepPayload, DEFAULT_STEP_DELAY_MS } from "../gesture-steps";
+
+describe("parseGestureSteps", () => {
+  it("accepts a single touch object (back-compat with the one-event form)", () => {
+    expect(parseGestureSteps('{"type":"begin","x":0.5,"y":0.5}')).toEqual([
+      { type: "begin", x: 0.5, y: 0.5 },
+    ]);
+  });
+
+  it("accepts an array of steps in order (the drag/scroll form)", () => {
+    const steps = parseGestureSteps(
+      '[{"type":"begin","x":0.5,"y":0.8},{"type":"move","x":0.5,"y":0.4},{"type":"end","x":0.5,"y":0.4}]',
+    );
+    expect(steps).toHaveLength(3);
+    expect(steps.map((s) => s.type)).toEqual(["begin", "move", "end"]);
+  });
+
+  it("preserves the multi-touch shape (x1/y1/x2/y2)", () => {
+    expect(parseGestureSteps('{"type":"begin","x1":0.4,"y1":0.5,"x2":0.6,"y2":0.5}')).toEqual([
+      { type: "begin", x1: 0.4, y1: 0.5, x2: 0.6, y2: 0.5 },
+    ]);
+  });
+
+  it("preserves edge and per-step delayMs", () => {
+    const [step] = parseGestureSteps('{"type":"begin","x":0,"y":0.5,"edge":1,"delayMs":80}');
+    expect(step).toEqual({ type: "begin", x: 0, y: 0.5, edge: 1, delayMs: 80 });
+  });
+
+  it("rejects invalid JSON with the original argument in the message", () => {
+    expect(() => parseGestureSteps("not json")).toThrow("Invalid JSON: not json");
+  });
+
+  it("rejects an empty array", () => {
+    expect(() => parseGestureSteps("[]")).toThrow("at least one touch step");
+  });
+
+  it("rejects a step with an unknown type, naming the failing step", () => {
+    expect(() =>
+      parseGestureSteps('[{"type":"begin","x":0.5,"y":0.5},{"type":"tap","x":0.5,"y":0.5}]'),
+    ).toThrow('step 2/2: "type" must be one of begin|move|end');
+  });
+
+  it("rejects a step with missing or out-of-range coords", () => {
+    expect(() => parseGestureSteps('{"type":"begin","x":0.5}')).toThrow("normalized 0..1 coords");
+    expect(() => parseGestureSteps('{"type":"begin","x":1.5,"y":0.5}')).toThrow(
+      "normalized 0..1 coords",
+    );
+  });
+
+  it("rejects a negative delayMs", () => {
+    expect(() => parseGestureSteps('{"type":"begin","x":0.5,"y":0.5,"delayMs":-5}')).toThrow(
+      '"delayMs" must be a non-negative number',
+    );
+  });
+
+  it("rejects non-object steps", () => {
+    expect(() => parseGestureSteps('[{"type":"begin","x":0.5,"y":0.5},42]')).toThrow(
+      "step 2/2: expected an object",
+    );
+  });
+});
+
+describe("stepPayload", () => {
+  it("strips the CLI-only delayMs before the wire payload", () => {
+    const payloads = parseGestureSteps('{"type":"move","x":0.5,"y":0.3,"delayMs":80}').map(stepPayload);
+    expect(payloads).toEqual([{ type: "move", x: 0.5, y: 0.3 }]);
+  });
+});
+
+describe("DEFAULT_STEP_DELAY_MS", () => {
+  it("is about one 60fps frame", () => {
+    expect(DEFAULT_STEP_DELAY_MS).toBe(16);
+  });
+});

--- a/packages/serve-sim/src/gesture-steps.ts
+++ b/packages/serve-sim/src/gesture-steps.ts
@@ -1,0 +1,83 @@
+// Parse the `serve-sim gesture <json>` argument into a validated sequence of
+// touch steps for the WS touch opcode (0x03).
+//
+// A complete touch (begin → move × N → end) must ride ONE WebSocket: each CLI
+// invocation opens its own socket, so back-to-back `gesture` calls register as
+// a long-press, never a drag. Accepting an array here lets a single invocation
+// replay the whole sequence on one socket — the only way the CLI can express a
+// drag/scroll/swipe.
+
+const TOUCH_TYPES = ["begin", "move", "end"] as const;
+export type TouchType = (typeof TOUCH_TYPES)[number];
+
+export type SingleTouch = {
+  type: TouchType;
+  x: number;
+  y: number;
+  edge?: number;
+};
+
+export type MultiTouch = {
+  type: TouchType;
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+};
+
+/** One touch event, plus how long to wait after sending it (ms). */
+export type GestureStep = (SingleTouch | MultiTouch) & { delayMs?: number };
+
+/** Inter-step delay when a step doesn't specify `delayMs` (~one 60fps frame). */
+export const DEFAULT_STEP_DELAY_MS = 16;
+
+function isNormalized(v: unknown): v is number {
+  return typeof v === "number" && Number.isFinite(v) && v >= 0 && v <= 1;
+}
+
+function validateStep(step: unknown, index: number, total: number): GestureStep {
+  const label = total > 1 ? `step ${index + 1}/${total}` : "gesture";
+  if (typeof step !== "object" || step === null || Array.isArray(step)) {
+    throw new Error(`Invalid ${label}: expected an object like {"type":"begin","x":0.5,"y":0.5}, got ${JSON.stringify(step)}`);
+  }
+  const { type, x, y, x1, y1, x2, y2, delayMs } = step as Record<string, unknown>;
+  if (typeof type !== "string" || !(TOUCH_TYPES as readonly string[]).includes(type)) {
+    throw new Error(`Invalid ${label}: "type" must be one of ${TOUCH_TYPES.join("|")}, got ${JSON.stringify(type)}`);
+  }
+  const single = isNormalized(x) && isNormalized(y);
+  const multi = isNormalized(x1) && isNormalized(y1) && isNormalized(x2) && isNormalized(y2);
+  if (!single && !multi) {
+    throw new Error(
+      `Invalid ${label}: needs normalized 0..1 coords — either {"x","y"} or {"x1","y1","x2","y2"} — got ${JSON.stringify(step)}`,
+    );
+  }
+  if (delayMs !== undefined && (typeof delayMs !== "number" || !Number.isFinite(delayMs) || delayMs < 0)) {
+    throw new Error(`Invalid ${label}: "delayMs" must be a non-negative number, got ${JSON.stringify(delayMs)}`);
+  }
+  return step as GestureStep;
+}
+
+/**
+ * Parse the gesture CLI argument: a single touch object, or an array of touch
+ * steps replayed in order on one socket. Throws with the failing step's index
+ * and the exact problem.
+ */
+export function parseGestureSteps(jsonStr: string): GestureStep[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonStr);
+  } catch {
+    throw new Error(`Invalid JSON: ${jsonStr}`);
+  }
+  const raw = Array.isArray(parsed) ? parsed : [parsed];
+  if (raw.length === 0) {
+    throw new Error("Gesture array is empty — provide at least one touch step.");
+  }
+  return raw.map((step, i) => validateStep(step, i, raw.length));
+}
+
+/** The wire payload for a step: everything except the CLI-only `delayMs`. */
+export function stepPayload(step: GestureStep): SingleTouch | MultiTouch {
+  const { delayMs: _delayMs, ...touch } = step;
+  return touch;
+}

--- a/packages/serve-sim/src/index.ts
+++ b/packages/serve-sim/src/index.ts
@@ -7,6 +7,7 @@ import { networkInterfaces } from "os";
 import { join, resolve } from "path";
 import { STATE_DIR, stateFileForDevice, listStateFiles, inProcessServeSimState, type ServeSimDeviceState } from "./state";
 import { textToKeyEvents, UnsupportedCharacterError, sendKeyEventsToWs } from "./text-to-keys";
+import { parseGestureSteps, stepPayload, DEFAULT_STEP_DELAY_MS, type GestureStep } from "./gesture-steps";
 import { dirnameOf, sleepSync, isPortFree, servePreview } from "./runtime";
 import { killPortHolder } from "./ports";
 import { findBootedDevice, resolveDevice } from "./device";
@@ -709,11 +710,11 @@ async function gesture(jsonStr: string, deviceArg?: string) {
     process.exit(1);
   }
 
-  let touch: { type: string; x: number; y: number };
+  let steps: GestureStep[];
   try {
-    touch = JSON.parse(jsonStr);
-  } catch {
-    console.error("Invalid JSON:", jsonStr);
+    steps = parseGestureSteps(jsonStr);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
     process.exit(1);
   }
 
@@ -721,12 +722,24 @@ async function gesture(jsonStr: string, deviceArg?: string) {
     const ws = new WebSocket(state.wsUrl);
     ws.binaryType = "arraybuffer";
 
-    ws.onopen = () => {
+    const send = (touch: ReturnType<typeof stepPayload>) => {
       const json = new TextEncoder().encode(JSON.stringify(touch));
       const msg = new Uint8Array(1 + json.length);
       msg[0] = 0x03;
       msg.set(json, 1);
       ws.send(msg);
+    };
+    const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+    // All steps replay on THIS socket: a begin→move×N→end sequence split
+    // across CLI invocations (one socket each) registers as a long-press.
+    ws.onopen = async () => {
+      for (const [i, step] of steps.entries()) {
+        send(stepPayload(step));
+        if (i < steps.length - 1) {
+          await sleep(step.delayMs ?? DEFAULT_STEP_DELAY_MS);
+        }
+      }
       setTimeout(() => { ws.close(); resolve(); }, 50);
     };
 
@@ -1824,8 +1837,11 @@ const deviceOpt = ["-d, --device <udid>", "Target a specific simulator (udid or 
 
 program
   .command("gesture")
-  .description("Send a touch gesture")
-  .argument("<json>", 'Gesture JSON, e.g. \'{"type":"begin","x":0.5,"y":0.5}\'')
+  .description("Send a touch gesture — one event, or an array of steps replayed on one socket (drag/swipe/scroll)")
+  .argument(
+    "<json>",
+    'Touch JSON: \'{"type":"begin","x":0.5,"y":0.5}\' or a sequence \'[{"type":"begin","x":0.5,"y":0.8},{"type":"move","x":0.5,"y":0.4},{"type":"end","x":0.5,"y":0.4}]\' (per-step optional "delayMs", default 16)',
+  )
   .option(...deviceOpt)
   .action((json: string, opts) => gesture(json, opts.device));
 

--- a/skills/serve-sim/SKILL.md
+++ b/skills/serve-sim/SKILL.md
@@ -73,7 +73,7 @@ Key invariants the agent must respect:
 | List running streams | `npx serve-sim --list` | Add `-q` for JSON-only output. |
 | Stop all helpers | `npx serve-sim --kill` | Pass `[device]` to stop a specific one. |
 | Single tap | `npx serve-sim tap <x> <y>` | `<x> <y>` in `0..1`. **Use this, not `gesture`, for plain taps.** See "Critical gotcha" below. |
-| Multi-step gesture | `npx serve-sim gesture '<json>'` | See [references/gestures.md](references/gestures.md). |
+| Drag / swipe / scroll | `npx serve-sim gesture '[<step>, <step>, …]'` | ONE call, JSON array — all steps replay on one socket (per-step `delayMs`, default 16). See [references/gestures.md](references/gestures.md). |
 | Hardware button | `npx serve-sim button <name>` | Names: `home`, `swipe_home`, `app_switcher`, `lock`, `siri`, `side_button`. See [references/buttons-rotation.md](references/buttons-rotation.md). |
 | Rotate device | `npx serve-sim rotate <orientation>` | `portrait`, `portrait_upside_down`, `landscape_left`, `landscape_right`. |
 | Simulate memory warning | `npx serve-sim memory-warning` | Equivalent to Debug → Simulate Memory Warning. |
@@ -89,7 +89,7 @@ Most subcommands accept `-d <udid|name>` to target a specific device when severa
 
 Each `serve-sim gesture` call opens its own WebSocket. If you issue two back-to-back `gesture` calls — one with `{"type":"begin",...}` and one with `{"type":"end",...}` — the simulator receives them with enough latency between them that the touch is interpreted as a **long-press**, not a tap. This is a deliberate constraint of the protocol, not a bug to work around.
 
-**Rule**: for any single-shot tap, use `serve-sim tap <x> <y>`. Only use `gesture` for drags, swipes, or multi-step interactions where you must thread the same socket across `begin` → `move` × N → `end`.
+**Rule**: for any single-shot tap, use `serve-sim tap <x> <y>`. For drags, swipes, and other multi-step interactions, pass the WHOLE `begin` → `move` × N → `end` sequence as a JSON **array** in ONE `gesture` call — the CLI replays it on a single socket. Never split a sequence across multiple `gesture` calls.
 
 ## Targeting a specific device
 

--- a/skills/serve-sim/references/gestures.md
+++ b/skills/serve-sim/references/gestures.md
@@ -87,41 +87,50 @@ Two back-to-back `gesture` calls for `begin` and `end` will be interpreted as a 
 
 ### Drag (vertical scroll down)
 
-A drag is a sequence on a single WebSocket. With the CLI, the simplest correct approach is the streaming server's WebSocket. From an agent that only has the CLI, prefer breaking the drag into a single `gesture` call that contains the full sequence — or use `button swipe_home` for the specific case of swipe-to-home.
-
-For ad-hoc drags via the CLI, this minimal sequence works because it issues one socket call per phase but the simulator coalesces them when issued rapidly:
+A drag is a sequence on a single WebSocket. Pass the whole sequence as a JSON **array** in ONE `gesture` call — the CLI replays every step on the same socket, waiting `delayMs` (default 16ms, ~one 60fps frame) after each step:
 
 ```sh
-npx serve-sim gesture '{"type":"begin","x":0.5,"y":0.2}'
-npx serve-sim gesture '{"type":"move","x":0.5,"y":0.5}'
-npx serve-sim gesture '{"type":"move","x":0.5,"y":0.8}'
-npx serve-sim gesture '{"type":"end","x":0.5,"y":0.8}'
+# scroll DOWN one screen = drag the finger UP
+npx serve-sim gesture '[
+  {"type":"begin","x":0.5,"y":0.8},
+  {"type":"move","x":0.5,"y":0.65},
+  {"type":"move","x":0.5,"y":0.5},
+  {"type":"move","x":0.5,"y":0.35},
+  {"type":"move","x":0.5,"y":0.3,"delayMs":80},
+  {"type":"end","x":0.5,"y":0.3}
+]'
 ```
 
-The agent should accept that this may produce a long-press start on some hosts. For reliable drags, drive the WebSocket directly (see `references/endpoints.md`).
+The `delayMs: 80` settle before `end` makes the touch read as a positional drag; drop it (and use fewer moves) for a momentum flick. Do NOT split the sequence across multiple `gesture` calls — each call opens a fresh WebSocket, so the first call's lone `begin` registers as a long-press (in a webview it triggers text selection) and later calls never scroll.
 
 ### Pinch to zoom in
 
 ```sh
-npx serve-sim gesture '{"type":"begin","x1":0.4,"y1":0.5,"x2":0.6,"y2":0.5}'
-npx serve-sim gesture '{"type":"move","x1":0.25,"y1":0.5,"x2":0.75,"y2":0.5}'
-npx serve-sim gesture '{"type":"end","x1":0.25,"y1":0.5,"x2":0.75,"y2":0.5}'
+npx serve-sim gesture '[
+  {"type":"begin","x1":0.4,"y1":0.5,"x2":0.6,"y2":0.5},
+  {"type":"move","x1":0.25,"y1":0.5,"x2":0.75,"y2":0.5},
+  {"type":"end","x1":0.25,"y1":0.5,"x2":0.75,"y2":0.5}
+]'
 ```
 
 ### Pull down Notification Center (top edge)
 
 ```sh
-npx serve-sim gesture '{"type":"begin","x":0.5,"y":0.02,"edge":2}'
-npx serve-sim gesture '{"type":"move","x":0.5,"y":0.4,"edge":2}'
-npx serve-sim gesture '{"type":"end","x":0.5,"y":0.4,"edge":2}'
+npx serve-sim gesture '[
+  {"type":"begin","x":0.5,"y":0.02,"edge":2},
+  {"type":"move","x":0.5,"y":0.4,"edge":2},
+  {"type":"end","x":0.5,"y":0.4,"edge":2}
+]'
 ```
 
 ### Swipe back from left edge
 
 ```sh
-npx serve-sim gesture '{"type":"begin","x":0.01,"y":0.5,"edge":1}'
-npx serve-sim gesture '{"type":"move","x":0.5,"y":0.5,"edge":1}'
-npx serve-sim gesture '{"type":"end","x":0.5,"y":0.5,"edge":1}'
+npx serve-sim gesture '[
+  {"type":"begin","x":0.01,"y":0.5,"edge":1},
+  {"type":"move","x":0.5,"y":0.5,"edge":1},
+  {"type":"end","x":0.5,"y":0.5,"edge":1}
+]'
 ```
 
 ## Why `tap` is preferred


### PR DESCRIPTION
## Problem

`serve-sim gesture` parses exactly one `{type,x,y}` object, sends a single `0x03` frame, and closes the socket ~50ms later ([`gesture()` in `packages/serve-sim/src/index.ts`](https://github.com/EvanBacon/serve-sim/blob/main/packages/serve-sim/src/index.ts)). Since a complete touch must ride **one** WebSocket, the CLI cannot express a drag/swipe/scroll:

- Splitting `begin`/`move`/`end` across invocations registers as a **long-press** — in a WKWebView it triggers text selection instead of scrolling.
- Passing a JSON **array** of steps parses without error and **silently does nothing**.
- The bundled agent skill's drag recipe recommends the multi-call form and notes it "may produce a long-press start on some hosts" — confirmed, it does.

## Fix

`gesture` now accepts either the existing single-object form (unchanged, back-compat) or a JSON array of steps replayed in order **on one socket**, waiting per-step `delayMs` (default 16ms ≈ one 60fps frame) between sends:

```sh
# scroll DOWN one screen = drag the finger UP
npx serve-sim gesture '[
  {"type":"begin","x":0.5,"y":0.8},
  {"type":"move","x":0.5,"y":0.6},
  {"type":"move","x":0.5,"y":0.4},
  {"type":"move","x":0.5,"y":0.35,"delayMs":80},
  {"type":"end","x":0.5,"y":0.35}
]'
```

The `delayMs: 80` settle before `end` reads as a positional drag; without it you get a momentum flick. Multi-touch (`x1/y1/x2/y2`) and `edge` pass through unchanged. Invalid input now fails loudly, naming the failing step (`step 2/3: "type" must be one of begin|move|end`), instead of silently no-opping.

- New `gesture-steps.ts` module (parse + validate, mirrors the `text-to-keys.ts` pattern) with `bun:test` coverage (12 tests).
- Skill docs updated: drag/pinch/edge recipes now show the single-call array form.

## Verification

- Live on an iPhone 17 Pro simulator (iOS 26.5) against a WKWebView (Capacitor) app: the array form scrolls the page; the previous multi-call recipe long-pressed (text selection) and the array form did nothing.
- `bun run typecheck` clean (incl. `noUncheckedIndexedAccess`), `bun run lint` 0/0, new tests 12/12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEtZcizxUo7x9da5MLpHqC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multi-step gestures, including taps, drags, swipes, scrolling, pinch-to-zoom, and edge gestures.
  * Gesture steps can include custom delays, with a default timing of 16 ms.
  * Existing single-step gesture commands remain supported.
  * Invalid gesture input now reports clear validation errors.

* **Documentation**
  * Updated gesture examples and guidance to use one JSON array for complete gesture sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->