### PR TITLE
feat: add preview launch configuration

### DIFF
--- a/packages/serve-sim/README.md
+++ b/packages/serve-sim/README.md
@@ -73,6 +73,8 @@ Options:
       --panes <panes> Initially open preview panes: devices, tools, devtools,
                       or none
       --fit           Initially size the simulator to fit the preview viewport
+      --theme <theme> Set simulator appearance before opening the preview:
+                      light or dark
       --codec <codec> Stream codec for the preview UI: 'auto' (H.264 when the
                       browser can decode it) or 'mjpeg' (force software JPEG —
                       e.g. on VMs without H.264 encode)
@@ -100,6 +102,7 @@ serve-sim --detach                     # start a background helper, return JSON
 serve-sim --list                       # show running streams
 serve-sim --kill                       # stop all helpers
 serve-sim --panes devices,tools --fit  # start with selected panes open and fit the simulator
+serve-sim --theme dark                 # start the simulator in Dark Mode
 
 # Type text into the focused field
 serve-sim type "Hello, world!"

--- a/packages/serve-sim/README.md
+++ b/packages/serve-sim/README.md
@@ -70,6 +70,9 @@ Options:
   -d, --detach        Spawn helper and exit (daemon mode)
   -q, --quiet         JSON-only output
       --no-preview    Skip the web UI; stream in foreground only
+      --panes <panes> Initially open preview panes: devices, tools, devtools,
+                      or none
+      --fit           Initially size the simulator to fit the preview viewport
       --codec <codec> Stream codec for the preview UI: 'auto' (H.264 when the
                       browser can decode it) or 'mjpeg' (force software JPEG —
                       e.g. on VMs without H.264 encode)
@@ -96,6 +99,7 @@ serve-sim "iPhone 16 Pro"              # target a specific device
 serve-sim --detach                     # start a background helper, return JSON
 serve-sim --list                       # show running streams
 serve-sim --kill                       # stop all helpers
+serve-sim --panes devices,tools --fit  # start with selected panes open and fit the simulator
 
 # Type text into the focused field
 serve-sim type "Hello, world!"

--- a/packages/serve-sim/src/__tests__/middleware-selection.test.ts
+++ b/packages/serve-sim/src/__tests__/middleware-selection.test.ts
@@ -73,6 +73,20 @@ describe("previewConfigForState", () => {
       previewConfigForState(states[0]!, "/preview", "/bin/serve-sim", "token-xyz", "mjpeg").codec,
     ).toBe("mjpeg");
   });
+
+  test("includes configured preview startup state", () => {
+    expect(
+      previewConfigForState(
+        states[0]!,
+        "/preview",
+        "/bin/serve-sim",
+        "token-xyz",
+        undefined,
+        false,
+        { panes: ["devices", "tools"], fit: true },
+      ).initialState,
+    ).toEqual({ panes: ["devices", "tools"], fit: true });
+  });
 });
 
 describe("rewriteStateForRequestHost", () => {

--- a/packages/serve-sim/src/__tests__/preview-initial-state.test.ts
+++ b/packages/serve-sim/src/__tests__/preview-initial-state.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { parsePreviewPanes } from "../preview-initial-state";
+
+describe("parsePreviewPanes", () => {
+  test("normalizes, de-duplicates, and preserves supported panes", () => {
+    expect(parsePreviewPanes(" tools,DEVTOOLS,tools ")).toEqual(["tools", "devtools"]);
+  });
+
+  test("allows none as the exclusive empty layout", () => {
+    expect(parsePreviewPanes("none")).toEqual([]);
+  });
+
+  test("rejects unknown and ambiguous pane lists", () => {
+    expect(() => parsePreviewPanes("tools,inspector")).toThrow("Unknown pane: inspector");
+    expect(() => parsePreviewPanes("none,tools")).toThrow("Expected 'none'");
+  });
+});

--- a/packages/serve-sim/src/__tests__/preview-initial-state.test.ts
+++ b/packages/serve-sim/src/__tests__/preview-initial-state.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { parsePreviewPanes, parseSimulatorTheme } from "../preview-initial-state";
+import {
+  parsePreviewPanes,
+  parseSimulatorTheme,
+  selectInitialRightPane,
+} from "../preview-initial-state";
 
 describe("parsePreviewPanes", () => {
   test("normalizes, de-duplicates, and preserves supported panes", () => {
@@ -24,5 +28,11 @@ describe("parseSimulatorTheme", () => {
 
   test("rejects unsupported themes", () => {
     expect(() => parseSimulatorTheme("system")).toThrow("Expected simulator theme");
+  });
+});
+
+describe("selectInitialRightPane", () => {
+  test("gives DevTools precedence when both right-side panes are requested", () => {
+    expect(selectInitialRightPane(["tools", "devtools"])).toBe("devtools");
   });
 });

--- a/packages/serve-sim/src/__tests__/preview-initial-state.test.ts
+++ b/packages/serve-sim/src/__tests__/preview-initial-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { parsePreviewPanes } from "../preview-initial-state";
+import { parsePreviewPanes, parseSimulatorTheme } from "../preview-initial-state";
 
 describe("parsePreviewPanes", () => {
   test("normalizes, de-duplicates, and preserves supported panes", () => {
@@ -13,5 +13,16 @@ describe("parsePreviewPanes", () => {
   test("rejects unknown and ambiguous pane lists", () => {
     expect(() => parsePreviewPanes("tools,inspector")).toThrow("Unknown pane: inspector");
     expect(() => parsePreviewPanes("none,tools")).toThrow("Expected 'none'");
+  });
+});
+
+describe("parseSimulatorTheme", () => {
+  test("accepts light and dark regardless of case", () => {
+    expect(parseSimulatorTheme("LIGHT")).toBe("light");
+    expect(parseSimulatorTheme("dark")).toBe("dark");
+  });
+
+  test("rejects unsupported themes", () => {
+    expect(() => parseSimulatorTheme("system")).toThrow("Expected simulator theme");
   });
 });

--- a/packages/serve-sim/src/client/client.tsx
+++ b/packages/serve-sim/src/client/client.tsx
@@ -93,6 +93,7 @@ function previewConfigKey(config: PreviewConfig | null): string {
 }
 
 function App() {
+  const initialState = window.__SIM_PREVIEW__?.initialState;
   const [config, setConfig] = useState<PreviewConfig | null>(() =>
     proxyPreviewConfigForBrowser(streamConfigFrom(window.__SIM_PREVIEW__), window.location)
   );
@@ -106,10 +107,11 @@ function App() {
     return new URLSearchParams(window.location.search).get("device");
   });
   const [axOverlayEnabled, setAxOverlayEnabled] = useState(false);
-  const [devtoolsOpen, setDevtoolsOpen] = useState(false);
+  const [devtoolsOpen, setDevtoolsOpen] = useState(() => initialState?.panes?.includes("devtools") ?? false);
   // Open the sidebar by default when the viewport has room for it beside the
   // simulator; narrow windows keep it collapsed so the device isn't squeezed.
   const [gridOpen, setGridOpen] = useState(() => {
+    if (initialState?.panes) return initialState.panes.includes("devices");
     if (typeof window === "undefined") return false;
     return window.innerWidth >= DEVICE_SIDEBAR_WIDTH + 520;
   });
@@ -412,6 +414,7 @@ function AppWithConfig({
   streaming,
   setStreaming,
 }: AppWithConfigProps) {
+  const initialState = config.initialState;
   useEffect(() => {
     document.title = deviceName ? `Simulator - ${deviceName}` : "Simulator Preview";
   }, [deviceName]);
@@ -669,6 +672,7 @@ function AppWithConfig({
   // the simulator (typical device frame ≈ 420px plus page/panel gutters);
   // smaller windows keep it closed so the device isn't squeezed on load.
   const [panelOpen, setPanelOpen] = useState(() => {
+    if (initialState?.panes) return initialState.panes.includes("tools");
     if (typeof window === "undefined") return false;
     const stored = Number(window.localStorage.getItem("serve-sim:tools-panel-width"));
     const panelWidth = Number.isFinite(stored) && stored > 0 ? stored : PANEL_WIDTH;
@@ -835,6 +839,7 @@ function AppWithConfig({
     viewportWidth,
     viewportHeight,
     aspectRatio: containerAspectRatioValue,
+    initialFit: initialState?.fit === true,
     onStart: () => setSimFocused(false),
   });
 

--- a/packages/serve-sim/src/client/client.tsx
+++ b/packages/serve-sim/src/client/client.tsx
@@ -70,6 +70,7 @@ import {
   PANEL_WIDTH,
 } from "./utils/panel-widths";
 import { proxyPreviewConfigForBrowser } from "./utils/preview-config";
+import { selectInitialRightPane } from "../preview-initial-state";
 import { simEndpoint, streamConfigFrom } from "./utils/sim-endpoint";
 import {
   SIMULATOR_RESIZE_DRAG_TRANSITION,
@@ -94,6 +95,7 @@ function previewConfigKey(config: PreviewConfig | null): string {
 
 function App() {
   const initialState = window.__SIM_PREVIEW__?.initialState;
+  const initialRightPane = selectInitialRightPane(initialState?.panes);
   const [config, setConfig] = useState<PreviewConfig | null>(() =>
     proxyPreviewConfigForBrowser(streamConfigFrom(window.__SIM_PREVIEW__), window.location)
   );
@@ -107,7 +109,7 @@ function App() {
     return new URLSearchParams(window.location.search).get("device");
   });
   const [axOverlayEnabled, setAxOverlayEnabled] = useState(false);
-  const [devtoolsOpen, setDevtoolsOpen] = useState(() => initialState?.panes?.includes("devtools") ?? false);
+  const [devtoolsOpen, setDevtoolsOpen] = useState(initialRightPane === "devtools");
   // Open the sidebar by default when the viewport has room for it beside the
   // simulator; narrow windows keep it collapsed so the device isn't squeezed.
   const [gridOpen, setGridOpen] = useState(() => {
@@ -415,6 +417,7 @@ function AppWithConfig({
   setStreaming,
 }: AppWithConfigProps) {
   const initialState = config.initialState;
+  const initialRightPane = selectInitialRightPane(initialState?.panes);
   useEffect(() => {
     document.title = deviceName ? `Simulator - ${deviceName}` : "Simulator Preview";
   }, [deviceName]);
@@ -672,7 +675,7 @@ function AppWithConfig({
   // the simulator (typical device frame ≈ 420px plus page/panel gutters);
   // smaller windows keep it closed so the device isn't squeezed on load.
   const [panelOpen, setPanelOpen] = useState(() => {
-    if (initialState?.panes) return initialState.panes.includes("tools");
+    if (initialState?.panes) return initialRightPane === "tools";
     if (typeof window === "undefined") return false;
     const stored = Number(window.localStorage.getItem("serve-sim:tools-panel-width"));
     const panelWidth = Number.isFinite(stored) && stored > 0 ? stored : PANEL_WIDTH;

--- a/packages/serve-sim/src/client/hooks/use-simulator-resize.ts
+++ b/packages/serve-sim/src/client/hooks/use-simulator-resize.ts
@@ -41,12 +41,15 @@ export function useSimulatorResize({
   viewportWidth,
   viewportHeight,
   aspectRatio,
+  initialFit = false,
   onStart,
 }: {
   defaultWidth: number;
   viewportWidth: number;
   viewportHeight: number;
   aspectRatio: number;
+  /** Ignore saved sizing and start at the largest frame that fits the viewport. */
+  initialFit?: boolean;
   onStart: () => void;
 }) {
   const reducedMotion = usePrefersReducedMotion();
@@ -62,6 +65,9 @@ export function useSimulatorResize({
 
   const readRestoredWidth = useCallback(() => {
     if (typeof window === "undefined") return defaultWidth;
+    if (initialFit) {
+      return getSimulatorFrameMaxWidth(defaultWidth, viewportWidth, viewportHeight, aspectRatio);
+    }
     // A non-finite scale (storage threw / empty / NaN) falls back to defaultWidth
     // inside restoredSimulatorFrameWidth, so both paths share one call.
     let scale = NaN;
@@ -76,7 +82,7 @@ export function useSimulatorResize({
       aspectRatio,
       scale,
     );
-  }, [aspectRatio, defaultWidth, viewportHeight, viewportWidth]);
+  }, [aspectRatio, defaultWidth, initialFit, viewportHeight, viewportWidth]);
   const initialWidth = useMemo(() => readRestoredWidth(), [readRestoredWidth]);
   const [frameWidth, setFrameWidth] = useState<number | null>(initialWidth);
   const lastWidthRef = useRef<number | null>(initialWidth);

--- a/packages/serve-sim/src/client/hooks/use-simulator-resize.ts
+++ b/packages/serve-sim/src/client/hooks/use-simulator-resize.ts
@@ -65,10 +65,16 @@ export function useSimulatorResize({
   const initialFitRef = useRef(initialFit);
   const initialFitConsumedRef = useRef(false);
 
+  // Mark the startup override consumed only after the initial render commits.
+  // Mutating this ref while calculating initial state would make an abandoned
+  // concurrent render suppress the fit on the first visible render.
+  useEffect(() => {
+    initialFitConsumedRef.current = true;
+  }, []);
+
   const readRestoredWidth = useCallback(() => {
     if (typeof window === "undefined") return defaultWidth;
     if (initialFitRef.current && !initialFitConsumedRef.current) {
-      initialFitConsumedRef.current = true;
       return getSimulatorFrameMaxWidth(defaultWidth, viewportWidth, viewportHeight, aspectRatio);
     }
     // A non-finite scale (storage threw / empty / NaN) falls back to defaultWidth

--- a/packages/serve-sim/src/client/hooks/use-simulator-resize.ts
+++ b/packages/serve-sim/src/client/hooks/use-simulator-resize.ts
@@ -62,10 +62,13 @@ export function useSimulatorResize({
   const tweenCancelRef = useRef<(() => void) | null>(null);
   const persistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const handleRef = useRef<HTMLDivElement | null>(null);
+  const initialFitRef = useRef(initialFit);
+  const initialFitConsumedRef = useRef(false);
 
   const readRestoredWidth = useCallback(() => {
     if (typeof window === "undefined") return defaultWidth;
-    if (initialFit) {
+    if (initialFitRef.current && !initialFitConsumedRef.current) {
+      initialFitConsumedRef.current = true;
       return getSimulatorFrameMaxWidth(defaultWidth, viewportWidth, viewportHeight, aspectRatio);
     }
     // A non-finite scale (storage threw / empty / NaN) falls back to defaultWidth
@@ -82,7 +85,7 @@ export function useSimulatorResize({
       aspectRatio,
       scale,
     );
-  }, [aspectRatio, defaultWidth, initialFit, viewportHeight, viewportWidth]);
+  }, [aspectRatio, defaultWidth, viewportHeight, viewportWidth]);
   const initialWidth = useMemo(() => readRestoredWidth(), [readRestoredWidth]);
   const [frameWidth, setFrameWidth] = useState<number | null>(initialWidth);
   const lastWidthRef = useRef<number | null>(initialWidth);

--- a/packages/serve-sim/src/client/utils/sim-endpoint.ts
+++ b/packages/serve-sim/src/client/utils/sim-endpoint.ts
@@ -31,6 +31,11 @@ declare global {
        * future values like `"hevc"`/`"av1"`.
        */
       codec?: string;
+      /** UI choices applied once when this preview page loads. */
+      initialState?: {
+        panes?: Array<"devices" | "tools" | "devtools">;
+        fit?: boolean;
+      };
       /**
        * Set when the server routes helper stream/control + DevTools sockets
        * through its same-origin `/helper` and `/devtools` proxies. The browser

--- a/packages/serve-sim/src/index.ts
+++ b/packages/serve-sim/src/index.ts
@@ -11,11 +11,16 @@ import { dirnameOf, sleepSync, isPortFree, servePreview } from "./runtime";
 import { killPortHolder } from "./ports";
 import { findBootedDevice, resolveDevice } from "./device";
 import { permissions } from "./permissions";
-import { uiSettings } from "./ui-settings";
+import { setUiOption, uiSettings } from "./ui-settings";
 import { debugCli, debugHelper, debugState } from "./debug";
 import type { EventLogEntry } from "./event-log";
 import { formatEventLogLine } from "./event-log-format";
-import { parsePreviewPanes, type PreviewInitialState } from "./preview-initial-state";
+import {
+  parsePreviewPanes,
+  parseSimulatorTheme,
+  type PreviewInitialState,
+  type SimulatorTheme,
+} from "./preview-initial-state";
 
 // `import.meta.dir` is Bun-only; resolve once via fileURLToPath so the bundled
 // CLI works under plain `node` too.
@@ -1672,6 +1677,7 @@ async function serve(
   host: string,
   codec: string | undefined,
   initialState: PreviewInitialState | undefined,
+  theme: SimulatorTheme | undefined,
 ) {
   // Boot the target simulators; the preview server streams them in-process
   // (no spawned helper). Sessions are created lazily on the first stream request.
@@ -1680,6 +1686,9 @@ async function serve(
     console.log("Starting simulator stream...");
   }
   for (const udid of targetDevices) await ensureBooted(udid);
+  if (theme) {
+    for (const udid of targetDevices) await setUiOption(udid, "appearance", theme);
+  }
   const targetDevice = targetDevices[0];
 
   const { simMiddleware } = await import("./middleware");
@@ -1793,6 +1802,17 @@ program
   )
   .option("--fit", "Initially size the simulator to fit the preview viewport")
   .option(
+    "--theme <theme>",
+    "Set simulator appearance before opening the preview: light or dark",
+    (value) => {
+      try {
+        return parseSimulatorTheme(value);
+      } catch (error) {
+        throw new InvalidArgumentError(error instanceof Error ? error.message : String(error));
+      }
+    },
+  )
+  .option(
     "--codec <codec>",
     "Stream codec for the preview UI: 'auto' (H.264 when the browser can decode " +
       "it) or 'mjpeg' (force software JPEG — e.g. on VMs without H.264 encode).",
@@ -1815,6 +1835,7 @@ Examples:
   serve-sim -p 8080                      Preview on a custom port
   serve-sim --codec mjpeg                Force MJPEG (e.g. on VMs without H.264 encode)
   serve-sim --panes devices,tools --fit  Open panes and fit the simulator to the viewport
+  serve-sim --theme dark                 Start the simulator in Dark Mode
   serve-sim --no-preview                 Auto-detect booted sim, stream in foreground
   serve-sim --no-preview "iPhone 16 Pro" Stream a specific device (no preview)
   serve-sim --detach                     Start streaming in background (daemon)
@@ -1842,7 +1863,15 @@ Examples:
           ...(opts.panes !== undefined ? { panes: opts.panes } : {}),
           ...(opts.fit ? { fit: true } : {}),
         } : undefined;
-      await serve(startPort ?? 3200, devices, startPort !== undefined, opts.host, opts.codec, initialState);
+      await serve(
+        startPort ?? 3200,
+        devices,
+        startPort !== undefined,
+        opts.host,
+        opts.codec,
+        initialState,
+        opts.theme,
+      );
     }
   });
 

--- a/packages/serve-sim/src/index.ts
+++ b/packages/serve-sim/src/index.ts
@@ -15,6 +15,7 @@ import { uiSettings } from "./ui-settings";
 import { debugCli, debugHelper, debugState } from "./debug";
 import type { EventLogEntry } from "./event-log";
 import { formatEventLogLine } from "./event-log-format";
+import { parsePreviewPanes, type PreviewInitialState } from "./preview-initial-state";
 
 // `import.meta.dir` is Bun-only; resolve once via fileURLToPath so the bundled
 // CLI works under plain `node` too.
@@ -1670,6 +1671,7 @@ async function serve(
   portExplicit: boolean,
   host: string,
   codec: string | undefined,
+  initialState: PreviewInitialState | undefined,
 ) {
   // Boot the target simulators; the preview server streams them in-process
   // (no spawned helper). Sessions are created lazily on the first stream request.
@@ -1683,7 +1685,13 @@ async function serve(
   const { simMiddleware } = await import("./middleware");
   // Standalone serve-sim owns its HTTP server and wires WebSocket upgrades, so
   // it can route helper/DevTools sockets through the single preview port.
-  const middleware = simMiddleware({ basePath: "/", device: targetDevice, codec, proxyHelpers: true });
+  const middleware = simMiddleware({
+    basePath: "/",
+    device: targetDevice,
+    codec,
+    initialState,
+    proxyHelpers: true,
+  });
 
   // Try requested port; if busy and the user didn't pin it, scan forward.
   const maxScan = portExplicit ? 1 : 50;
@@ -1773,6 +1781,18 @@ program
   .option("-q, --quiet", "Suppress human-readable output, JSON only")
   .option("--no-preview", "Skip the web preview server; stream in foreground only")
   .option(
+    "--panes <panes>",
+    "Initially open preview panes: devices, tools, devtools, or none",
+    (value) => {
+      try {
+        return parsePreviewPanes(value);
+      } catch (error) {
+        throw new InvalidArgumentError(error instanceof Error ? error.message : String(error));
+      }
+    },
+  )
+  .option("--fit", "Initially size the simulator to fit the preview viewport")
+  .option(
     "--codec <codec>",
     "Stream codec for the preview UI: 'auto' (H.264 when the browser can decode " +
       "it) or 'mjpeg' (force software JPEG — e.g. on VMs without H.264 encode).",
@@ -1794,6 +1814,7 @@ Examples:
   serve-sim                              Open simulator preview at localhost:3200
   serve-sim -p 8080                      Preview on a custom port
   serve-sim --codec mjpeg                Force MJPEG (e.g. on VMs without H.264 encode)
+  serve-sim --panes devices,tools --fit  Open panes and fit the simulator to the viewport
   serve-sim --no-preview                 Auto-detect booted sim, stream in foreground
   serve-sim --no-preview "iPhone 16 Pro" Stream a specific device (no preview)
   serve-sim --detach                     Start streaming in background (daemon)
@@ -1816,7 +1837,12 @@ Examples:
     } else if (opts.preview === false) {
       await follow(devices, startPort ?? 3100, !!opts.quiet);
     } else {
-      await serve(startPort ?? 3200, devices, startPort !== undefined, opts.host, opts.codec);
+      const initialState: PreviewInitialState | undefined =
+        opts.panes !== undefined || opts.fit ? {
+          ...(opts.panes !== undefined ? { panes: opts.panes } : {}),
+          ...(opts.fit ? { fit: true } : {}),
+        } : undefined;
+      await serve(startPort ?? 3200, devices, startPort !== undefined, opts.host, opts.codec, initialState);
     }
   });
 

--- a/packages/serve-sim/src/middleware.ts
+++ b/packages/serve-sim/src/middleware.ts
@@ -30,6 +30,7 @@ import {
 } from "./devicekit-chrome";
 import { createExecUpgradeHandler, type UiRequestHandler } from "./exec-ws";
 import { UI_OPTIONS, getUiStatus, normalizeUiValue, setUiOption } from "./ui-settings";
+import type { PreviewInitialState } from "./preview-initial-state";
 
 type SimReq = IncomingMessage;
 type SimRes = ServerResponse;
@@ -822,6 +823,7 @@ export function previewConfigForState(
   execToken: string,
   codec?: string,
   proxyHelpers = false,
+  initialState?: PreviewInitialState,
 ): ServeSimState & {
   basePath: string;
   appStateEndpoint: string;
@@ -837,6 +839,7 @@ export function previewConfigForState(
   previewEndpoint: string;
   execToken: string;
   codec?: string;
+  initialState?: PreviewInitialState;
   proxyHelpers?: boolean;
 } {
   const gridApiBase = (base === "" ? "" : base) + "/grid/api";
@@ -856,6 +859,7 @@ export function previewConfigForState(
     previewEndpoint: base === "" ? "/" : base,
     execToken,
     ...(codec ? { codec } : {}),
+    ...(initialState ? { initialState } : {}),
     ...(proxyHelpers ? { proxyHelpers: true } : {}),
   };
 }
@@ -1195,6 +1199,8 @@ export interface SimMiddlewareOptions {
    * Reserved for future values such as `"hevc"`/`"av1"`.
    */
   codec?: string;
+  /** UI choices applied when a preview page initially loads. */
+  initialState?: PreviewInitialState;
   /**
    * Route the browser's helper stream/control and DevTools sockets through the
    * preview's same-origin `/helper` and `/devtools` proxies instead of the
@@ -1335,7 +1341,11 @@ export function simMiddleware(options?: SimMiddlewareOptions): SimMiddleware {
         // Empty-state UI still polls /exec (boot/list helpers), so the page
         // needs the bearer token even before a helper attaches. Inject a
         // minimal config with just the basePath + token.
-        const minimal = JSON.stringify({ basePath: base, execToken });
+        const minimal = JSON.stringify({
+          basePath: base,
+          execToken,
+          ...(options?.initialState ? { initialState: options.initialState } : {}),
+        });
         html = html.replace(
           "<!--__SIM_PREVIEW_CONFIG__-->",
           `<script>window.__SIM_PREVIEW__=${minimal}</script>`,
@@ -1344,7 +1354,15 @@ export function simMiddleware(options?: SimMiddlewareOptions): SimMiddleware {
 
       if (state) {
         const remoteState = rewriteStateForRequestHost(state, hostForRequest(req), base, httpProtocolForRequest(req), proxyHelpers);
-        const config = JSON.stringify(previewConfigForState(remoteState, base, serveSimBinPath(), execToken, options?.codec, proxyHelpers));
+        const config = JSON.stringify(previewConfigForState(
+          remoteState,
+          base,
+          serveSimBinPath(),
+          execToken,
+          options?.codec,
+          proxyHelpers,
+          options?.initialState,
+        ));
         const configScript = `<script>window.__SIM_PREVIEW__=${config}</script>`;
         html = html.replace("<!--__SIM_PREVIEW_CONFIG__-->", configScript);
       }
@@ -1655,7 +1673,15 @@ export function simMiddleware(options?: SimMiddlewareOptions): SimMiddleware {
         "Cache-Control": "no-store",
       });
       const remoteState = state ? rewriteStateForRequestHost(state, hostForRequest(req), base, httpProtocolForRequest(req), proxyHelpers) : null;
-      res.end(JSON.stringify(remoteState ? previewConfigForState(remoteState, base, serveSimBinPath(), execToken, options?.codec, proxyHelpers) : null));
+      res.end(JSON.stringify(remoteState ? previewConfigForState(
+        remoteState,
+        base,
+        serveSimBinPath(),
+        execToken,
+        options?.codec,
+        proxyHelpers,
+        options?.initialState,
+      ) : null));
       return;
     }
 
@@ -1719,7 +1745,15 @@ export function simMiddleware(options?: SimMiddlewareOptions): SimMiddleware {
         const state = selectServeSimState(states, selectedDevice);
         const remoteState = state ? rewriteStateForRequestHost(state, hostForRequest(req), base, httpProtocolForRequest(req), proxyHelpers) : null;
         return JSON.stringify(
-          remoteState ? previewConfigForState(remoteState, base, serveSimBinPath(), execToken, options?.codec, proxyHelpers) : null,
+          remoteState ? previewConfigForState(
+            remoteState,
+            base,
+            serveSimBinPath(),
+            execToken,
+            options?.codec,
+            proxyHelpers,
+            options?.initialState,
+          ) : null,
         );
       };
 

--- a/packages/serve-sim/src/preview-initial-state.ts
+++ b/packages/serve-sim/src/preview-initial-state.ts
@@ -1,0 +1,33 @@
+export const PREVIEW_PANES = ["devices", "tools", "devtools"] as const;
+
+export type PreviewPane = (typeof PREVIEW_PANES)[number];
+
+/** UI choices applied once when a preview page first loads. */
+export type PreviewInitialState = {
+  panes?: PreviewPane[];
+  fit?: boolean;
+};
+
+/**
+ * Parse the comma-separated value accepted by `serve-sim --panes`.
+ * `none` is deliberately exclusive so a typo such as `none,tools` cannot
+ * quietly produce an unexpected layout.
+ */
+export function parsePreviewPanes(value: string): PreviewPane[] {
+  const panes = value
+    .split(",")
+    .map((pane) => pane.trim().toLowerCase())
+    .filter(Boolean);
+
+  if (panes.length === 1 && panes[0] === "none") return [];
+  if (panes.length === 0 || panes.includes("none")) {
+    throw new Error("Expected 'none' or a comma-separated list of: devices, tools, devtools.");
+  }
+
+  const invalid = panes.filter((pane) => !PREVIEW_PANES.includes(pane as PreviewPane));
+  if (invalid.length > 0) {
+    throw new Error(`Unknown pane${invalid.length === 1 ? "" : "s"}: ${invalid.join(", ")}. Expected: ${PREVIEW_PANES.join(", ")}.`);
+  }
+
+  return [...new Set(panes)] as PreviewPane[];
+}

--- a/packages/serve-sim/src/preview-initial-state.ts
+++ b/packages/serve-sim/src/preview-initial-state.ts
@@ -1,6 +1,7 @@
 export const PREVIEW_PANES = ["devices", "tools", "devtools"] as const;
 
 export type PreviewPane = (typeof PREVIEW_PANES)[number];
+export type SimulatorTheme = "light" | "dark";
 
 /** UI choices applied once when a preview page first loads. */
 export type PreviewInitialState = {
@@ -30,4 +31,11 @@ export function parsePreviewPanes(value: string): PreviewPane[] {
   }
 
   return [...new Set(panes)] as PreviewPane[];
+}
+
+/** Parse the simulator appearance accepted by `serve-sim --theme`. */
+export function parseSimulatorTheme(value: string): SimulatorTheme {
+  const theme = value.trim().toLowerCase();
+  if (theme === "light" || theme === "dark") return theme;
+  throw new Error("Expected simulator theme: light or dark.");
 }

--- a/packages/serve-sim/src/preview-initial-state.ts
+++ b/packages/serve-sim/src/preview-initial-state.ts
@@ -2,6 +2,7 @@ export const PREVIEW_PANES = ["devices", "tools", "devtools"] as const;
 
 export type PreviewPane = (typeof PREVIEW_PANES)[number];
 export type SimulatorTheme = "light" | "dark";
+export type PreviewRightPane = "tools" | "devtools";
 
 /** UI choices applied once when a preview page first loads. */
 export type PreviewInitialState = {
@@ -38,4 +39,13 @@ export function parseSimulatorTheme(value: string): SimulatorTheme {
   const theme = value.trim().toLowerCase();
   if (theme === "light" || theme === "dark") return theme;
   throw new Error("Expected simulator theme: light or dark.");
+}
+
+/** Select the right-side pane to open when a startup state names both. */
+export function selectInitialRightPane(
+  panes: readonly PreviewPane[] | undefined,
+): PreviewRightPane | null {
+  if (panes?.includes("devtools")) return "devtools";
+  if (panes?.includes("tools")) return "tools";
+  return null;
 }


### PR DESCRIPTION
Adds launch-time controls for the serve-sim preview: `--panes`, `--fit`, and `--theme light|dark`. Startup state flows through middleware to the browser, including the empty-device view; the theme is applied to the simulator after boot. Tools and DevTools are mutually exclusive at launch, and fit is applied only on the first size restore. Includes validation, documentation, and test coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `serve-sim` CLI options to seed the preview UI: `--panes <panes>` (devices/tools/devtools or `none`), `--fit`, and `--theme <light|dark>`.
  * The preview now initializes with the requested right-side pane and applies initial fit sizing; theme is applied to the simulator UI when provided.
* **Tests**
  * Added Bun test coverage for pane parsing/validation, theme parsing, initial pane selection precedence, and initial-state propagation.
* **Documentation**
  * Updated the `serve-sim` README/examples to include `--panes`, `--fit`, and `--theme dark`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->