### PR TITLE
Avoid subprocess polling for camera status

### DIFF
--- a/packages/serve-sim/package.json
+++ b/packages/serve-sim/package.json
@@ -32,7 +32,7 @@
     "dist/simax/serve-sim-ax-settings",
     "src/ax-shared.ts",
     "src/ax.ts",
-    "src/camera-status.ts",
+    "src/camera-helper.ts",
     "src/middleware.ts",
     "src/native.ts",
     "src/state.ts",

--- a/packages/serve-sim/package.json
+++ b/packages/serve-sim/package.json
@@ -32,6 +32,7 @@
     "dist/simax/serve-sim-ax-settings",
     "src/ax-shared.ts",
     "src/ax.ts",
+    "src/camera-status.ts",
     "src/middleware.ts",
     "src/native.ts",
     "src/state.ts",

--- a/packages/serve-sim/src/__tests__/camera-status.test.ts
+++ b/packages/serve-sim/src/__tests__/camera-status.test.ts
@@ -1,0 +1,122 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { randomUUID } from "crypto";
+import { mkdirSync, unlinkSync, writeFileSync } from "fs";
+import { createServer as createHttpServer } from "http";
+import { createServer as createNetServer, type AddressInfo } from "net";
+import { dirname } from "path";
+import {
+  cameraHelperBundlesFile,
+  cameraHelperPidFile,
+  cameraHelperSocketFile,
+  isCameraHelperAlive,
+  readCameraStatus,
+} from "../camera-status";
+import { simMiddleware } from "../middleware";
+
+const udid = randomUUID().toUpperCase();
+const stateFiles = [
+  cameraHelperPidFile(udid),
+  cameraHelperBundlesFile(udid),
+  cameraHelperSocketFile(udid),
+];
+
+afterAll(() => {
+  for (const path of stateFiles) {
+    try { unlinkSync(path); } catch {}
+  }
+});
+
+async function withMiddlewareServer<T>(fn: (origin: string) => Promise<T>): Promise<T> {
+  const middleware = simMiddleware({ basePath: "/", proxyHelpers: true });
+  const server = createHttpServer((req, res) => {
+    void middleware(req, res, async () => {
+      res.writeHead(404);
+      res.end("Not found");
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as AddressInfo).port;
+  try {
+    return await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+describe("camera status", () => {
+  test("treats a malformed pid file as a stopped helper", async () => {
+    mkdirSync(dirname(cameraHelperPidFile(udid)), { recursive: true });
+    writeFileSync(cameraHelperPidFile(udid), "not-a-pid");
+
+    expect(isCameraHelperAlive(udid)).toBe(false);
+    expect(await readCameraStatus(udid)).toEqual({ udid, alive: false });
+  });
+
+  test("decodes split UTF-8 replies and validates persisted bundle IDs", async () => {
+    const socketPath = cameraHelperSocketFile(udid);
+    try { unlinkSync(socketPath); } catch {}
+    const reply = Buffer.from(JSON.stringify({
+      ok: true,
+      source: "video",
+      arg: "/tmp/zażółć.mov",
+      alive: false,
+      udid: "wrong-device",
+      helperPid: 0,
+      bundleIds: ["wrong.bundle"],
+    }) + "\n");
+    const split = reply.indexOf(Buffer.from("ż")) + 1;
+    const server = createNetServer((socket) => {
+      socket.once("data", () => {
+        socket.write(reply.subarray(0, split));
+        socket.end(reply.subarray(split));
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(socketPath, resolve);
+    });
+    writeFileSync(cameraHelperPidFile(udid), String(process.pid));
+    writeFileSync(cameraHelperBundlesFile(udid), JSON.stringify({
+      helperPid: process.pid,
+      bundleIds: ["com.example.app", 42],
+    }));
+
+    try {
+      expect(await readCameraStatus(udid)).toEqual({
+        udid,
+        alive: true,
+        helperPid: process.pid,
+        bundleIds: ["com.example.app"],
+        ok: true,
+        source: "video",
+        arg: "/tmp/zażółć.mov",
+      });
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  test("serves status without opening a simulator session", async () => {
+    try { unlinkSync(cameraHelperPidFile(udid)); } catch {}
+    await withMiddlewareServer(async (origin) => {
+      const response = await fetch(`${origin}/helper/${udid}/camera/status`);
+      expect(response.status).toBe(200);
+      expect(response.headers.get("cache-control")).toBe("no-store");
+      expect(await response.json()).toEqual({ udid, alive: false });
+    });
+  });
+
+  test("rejects writes and malformed device IDs", async () => {
+    await withMiddlewareServer(async (origin) => {
+      const writeResponse = await fetch(`${origin}/helper/${udid}/camera/status`, {
+        method: "POST",
+      });
+      expect(writeResponse.status).toBe(405);
+      expect(writeResponse.headers.get("allow")).toBe("GET");
+
+      const invalidResponse = await fetch(`${origin}/helper/not-a-udid/camera/status`);
+      expect(invalidResponse.status).toBe(400);
+      expect(await invalidResponse.json()).toEqual({ error: "invalid_device" });
+    });
+  });
+});

--- a/packages/serve-sim/src/__tests__/camera-status.test.ts
+++ b/packages/serve-sim/src/__tests__/camera-status.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { randomUUID } from "crypto";
 import { mkdirSync, unlinkSync, writeFileSync } from "fs";
 import { createServer as createHttpServer } from "http";
@@ -10,7 +10,7 @@ import {
   cameraHelperSocketFile,
   isCameraHelperAlive,
   readCameraStatus,
-} from "../camera-status";
+} from "../camera-helper";
 import { simMiddleware } from "../middleware";
 
 const udid = randomUUID().toUpperCase();
@@ -19,6 +19,10 @@ const stateFiles = [
   cameraHelperBundlesFile(udid),
   cameraHelperSocketFile(udid),
 ];
+
+beforeAll(() => {
+  mkdirSync(dirname(cameraHelperPidFile(udid)), { recursive: true });
+});
 
 afterAll(() => {
   for (const path of stateFiles) {
@@ -45,14 +49,13 @@ async function withMiddlewareServer<T>(fn: (origin: string) => Promise<T>): Prom
 
 describe("camera status", () => {
   test("treats a malformed pid file as a stopped helper", async () => {
-    mkdirSync(dirname(cameraHelperPidFile(udid)), { recursive: true });
     writeFileSync(cameraHelperPidFile(udid), "not-a-pid");
 
     expect(isCameraHelperAlive(udid)).toBe(false);
     expect(await readCameraStatus(udid)).toEqual({ udid, alive: false });
   });
 
-  test("decodes split UTF-8 replies and validates persisted bundle IDs", async () => {
+  test("decodes split UTF-8, validates bundles, and keeps helper extensions", async () => {
     const socketPath = cameraHelperSocketFile(udid);
     try { unlinkSync(socketPath); } catch {}
     const reply = Buffer.from(JSON.stringify({
@@ -63,6 +66,7 @@ describe("camera status", () => {
       udid: "wrong-device",
       helperPid: 0,
       bundleIds: ["wrong.bundle"],
+      frameCount: 12,
     }) + "\n");
     const split = reply.indexOf(Buffer.from("ż")) + 1;
     const server = createNetServer((socket) => {
@@ -90,6 +94,7 @@ describe("camera status", () => {
         ok: true,
         source: "video",
         arg: "/tmp/zażółć.mov",
+        frameCount: 12,
       });
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()));

--- a/packages/serve-sim/src/__tests__/camera-tool.test.tsx
+++ b/packages/serve-sim/src/__tests__/camera-tool.test.tsx
@@ -22,7 +22,7 @@ describe("requestCameraStatus", () => {
   test("reads structured status directly from the configured endpoint", async () => {
     const request = async (input: string, init: RequestInit) => {
       expect(input).toBe("/helper/DEVICE-A/camera/status");
-      expect(init?.cache).toBe("no-store");
+      expect(init.cache).toBe("no-store");
       return new Response(JSON.stringify({ alive: true, helperPid: 42 }), {
         headers: { "Content-Type": "application/json" },
       });

--- a/packages/serve-sim/src/__tests__/camera-tool.test.tsx
+++ b/packages/serve-sim/src/__tests__/camera-tool.test.tsx
@@ -14,8 +14,34 @@ import {
   isOversizedCameraVideo,
   nextCameraPillState,
   parseWebcamListOutput,
+  requestCameraStatus,
   selectCameraPrimaryKind,
 } from "../client/components/camera-tool";
+
+describe("requestCameraStatus", () => {
+  test("reads structured status directly from the configured endpoint", async () => {
+    const request = async (input: string, init: RequestInit) => {
+      expect(input).toBe("/helper/DEVICE-A/camera/status");
+      expect(init?.cache).toBe("no-store");
+      return new Response(JSON.stringify({ alive: true, helperPid: 42 }), {
+        headers: { "Content-Type": "application/json" },
+      });
+    };
+
+    expect(await requestCameraStatus("/helper/DEVICE-A/camera/status", request)).toEqual({
+      alive: true,
+      helperPid: 42,
+    });
+  });
+
+  test("returns null for failed or malformed responses", async () => {
+    const failedRequest = async () => new Response("no", { status: 503 });
+    const malformedRequest = async () => Response.json(["not", "an", "object"]);
+
+    expect(await requestCameraStatus("/status", failedRequest)).toBeNull();
+    expect(await requestCameraStatus("/status", malformedRequest)).toBeNull();
+  });
+});
 
 describe("nextCameraPillState", () => {
   test("ready stays ready on dead poll", () => {

--- a/packages/serve-sim/src/__tests__/middleware-selection.test.ts
+++ b/packages/serve-sim/src/__tests__/middleware-selection.test.ts
@@ -74,6 +74,12 @@ describe("previewConfigForState", () => {
       previewConfigForState(states[0]!, "/preview", "/bin/serve-sim", "token-xyz", "mjpeg").codec,
     ).toBe("mjpeg");
   });
+
+  test("builds the camera status endpoint correctly at the root mount", () => {
+    expect(
+      previewConfigForState(states[0]!, "", "/bin/serve-sim", "token-xyz").cameraStatusEndpoint,
+    ).toBe("/helper/DEVICE-A/camera/status");
+  });
 });
 
 describe("rewriteStateForRequestHost", () => {

--- a/packages/serve-sim/src/__tests__/middleware-selection.test.ts
+++ b/packages/serve-sim/src/__tests__/middleware-selection.test.ts
@@ -51,6 +51,7 @@ describe("previewConfigForState", () => {
       eventLogEndpoint: "/preview/api/event-log?device=DEVICE-B",
       eventLogEventsEndpoint: "/preview/api/event-log/events?device=DEVICE-B",
       axEndpoint: "/preview/ax?device=DEVICE-B",
+      cameraStatusEndpoint: "/preview/helper/DEVICE-B/camera/status",
       devtoolsEndpoint: "/preview/devtools?device=DEVICE-B",
       serveSimBin: "/bin/serve-sim",
       gridApiEndpoint: "/preview/grid/api",

--- a/packages/serve-sim/src/camera-helper.ts
+++ b/packages/serve-sim/src/camera-helper.ts
@@ -3,8 +3,7 @@ import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { STATE_DIR } from "./state";
 
-const CAMERA_STATE_DIR = join(STATE_DIR, "simcam");
-const MAX_HELPER_REPLY_BYTES = 64 * 1024;
+export const CAMERA_STATE_DIR = join(STATE_DIR, "simcam");
 const HELPER_TIMEOUT_MS = 3000;
 
 interface InjectedBundlesState {
@@ -13,6 +12,7 @@ interface InjectedBundlesState {
 }
 
 export interface CameraHelperReply {
+  [key: string]: unknown;
   ok?: boolean;
   source?: string;
   arg?: string;
@@ -63,14 +63,7 @@ function parseCameraHelperReply(value: unknown): CameraHelperReply {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new Error("invalid camera helper reply");
   }
-  const reply = value as Record<string, unknown>;
-  return {
-    ...(typeof reply.ok === "boolean" ? { ok: reply.ok } : {}),
-    ...(typeof reply.source === "string" ? { source: reply.source } : {}),
-    ...(typeof reply.arg === "string" ? { arg: reply.arg } : {}),
-    ...(typeof reply.mirror === "string" ? { mirror: reply.mirror } : {}),
-    ...(typeof reply.error === "string" ? { error: reply.error } : {}),
-  };
+  return value as CameraHelperReply;
 }
 
 export async function sendCameraHelperCommand(
@@ -80,7 +73,7 @@ export async function sendCameraHelperCommand(
   const socketPath = cameraHelperSocketFile(udid);
   if (!existsSync(socketPath)) throw new Error("camera helper socket not found");
   const net = await import("net");
-  return await new Promise((resolve, reject) => {
+  return new Promise((resolve, reject) => {
     const socket = net.createConnection(socketPath);
     socket.setEncoding("utf8");
     let buffer = "";
@@ -97,11 +90,6 @@ export async function sendCameraHelperCommand(
 
     socket.on("data", (chunk) => {
       buffer += chunk;
-      if (Buffer.byteLength(buffer) > MAX_HELPER_REPLY_BYTES) {
-        socket.destroy();
-        settle(new Error("camera helper reply is too large"));
-        return;
-      }
       const newline = buffer.indexOf("\n");
       if (newline < 0) return;
       try {
@@ -112,10 +100,10 @@ export async function sendCameraHelperCommand(
       socket.end();
     });
     socket.on("error", settle);
-    socket.on("close", () => settle(new Error("camera helper socket closed")));
+    socket.on("close", () => settle(new Error("socket closed")));
     timeout = setTimeout(() => {
       socket.destroy();
-      settle(new Error("camera helper timed out"));
+      settle(new Error("helper timeout"));
     }, HELPER_TIMEOUT_MS);
     socket.write(JSON.stringify(command) + "\n");
   });

--- a/packages/serve-sim/src/camera-status.ts
+++ b/packages/serve-sim/src/camera-status.ts
@@ -1,0 +1,162 @@
+import { createHash } from "crypto";
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { STATE_DIR } from "./state";
+
+const CAMERA_STATE_DIR = join(STATE_DIR, "simcam");
+const MAX_HELPER_REPLY_BYTES = 64 * 1024;
+const HELPER_TIMEOUT_MS = 3000;
+
+interface InjectedBundlesState {
+  helperPid: number;
+  bundleIds: string[];
+}
+
+export interface CameraHelperReply {
+  ok?: boolean;
+  source?: string;
+  arg?: string;
+  mirror?: string;
+  error?: string;
+}
+
+export interface CameraStatusReply extends CameraHelperReply {
+  udid: string;
+  alive: boolean;
+  helperPid?: number | null;
+  bundleIds?: string[];
+}
+
+export function cameraHelperPidFile(udid: string): string {
+  return join(CAMERA_STATE_DIR, `${udid}.pid`);
+}
+
+export function cameraHelperBundlesFile(udid: string): string {
+  return join(CAMERA_STATE_DIR, `${udid}.bundles.json`);
+}
+
+export function cameraHelperSocketFile(udid: string): string {
+  // POSIX sun_path is 104 chars on macOS, so keep this short.
+  const short = createHash("sha1").update(udid).digest("hex").slice(0, 12);
+  return `/tmp/serve-sim-cam-${short}.sock`;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function readCameraHelperPid(udid: string): number | null {
+  try {
+    const pid = Number(readFileSync(cameraHelperPidFile(udid), "utf-8").trim());
+    return Number.isInteger(pid) && pid > 0 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+function parseCameraHelperReply(value: unknown): CameraHelperReply {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("invalid camera helper reply");
+  }
+  const reply = value as Record<string, unknown>;
+  return {
+    ...(typeof reply.ok === "boolean" ? { ok: reply.ok } : {}),
+    ...(typeof reply.source === "string" ? { source: reply.source } : {}),
+    ...(typeof reply.arg === "string" ? { arg: reply.arg } : {}),
+    ...(typeof reply.mirror === "string" ? { mirror: reply.mirror } : {}),
+    ...(typeof reply.error === "string" ? { error: reply.error } : {}),
+  };
+}
+
+export async function sendCameraHelperCommand(
+  udid: string,
+  command: object,
+): Promise<CameraHelperReply> {
+  const socketPath = cameraHelperSocketFile(udid);
+  if (!existsSync(socketPath)) throw new Error("camera helper socket not found");
+  const net = await import("net");
+  return await new Promise((resolve, reject) => {
+    const socket = net.createConnection(socketPath);
+    socket.setEncoding("utf8");
+    let buffer = "";
+    let settled = false;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    const settle = (error?: unknown, reply?: CameraHelperReply) => {
+      if (settled) return;
+      settled = true;
+      if (timeout) clearTimeout(timeout);
+      if (error) reject(error);
+      else resolve(reply ?? {});
+    };
+
+    socket.on("data", (chunk) => {
+      buffer += chunk;
+      if (Buffer.byteLength(buffer) > MAX_HELPER_REPLY_BYTES) {
+        socket.destroy();
+        settle(new Error("camera helper reply is too large"));
+        return;
+      }
+      const newline = buffer.indexOf("\n");
+      if (newline < 0) return;
+      try {
+        settle(undefined, parseCameraHelperReply(JSON.parse(buffer.slice(0, newline)) as unknown));
+      } catch (error) {
+        settle(error);
+      }
+      socket.end();
+    });
+    socket.on("error", settle);
+    socket.on("close", () => settle(new Error("camera helper socket closed")));
+    timeout = setTimeout(() => {
+      socket.destroy();
+      settle(new Error("camera helper timed out"));
+    }, HELPER_TIMEOUT_MS);
+    socket.write(JSON.stringify(command) + "\n");
+  });
+}
+
+export function isCameraHelperAlive(udid: string): boolean {
+  const pid = readCameraHelperPid(udid);
+  return pid !== null && isProcessAlive(pid) && existsSync(cameraHelperSocketFile(udid));
+}
+
+export function readInjectedCameraBundles(udid: string): string[] {
+  let state: InjectedBundlesState;
+  try {
+    const value = JSON.parse(readFileSync(cameraHelperBundlesFile(udid), "utf-8")) as unknown;
+    if (!value || typeof value !== "object" || Array.isArray(value)) return [];
+    const candidate = value as Partial<InjectedBundlesState>;
+    if (typeof candidate.helperPid !== "number" || !Array.isArray(candidate.bundleIds)) return [];
+    state = { helperPid: candidate.helperPid, bundleIds: candidate.bundleIds };
+  } catch {
+    return [];
+  }
+  const currentHelperPid = readCameraHelperPid(udid);
+  if (currentHelperPid === null || state.helperPid !== currentHelperPid) return [];
+  return state.bundleIds.filter((bundleId): bundleId is string => typeof bundleId === "string");
+}
+
+export async function readCameraStatus(udid: string): Promise<CameraStatusReply> {
+  if (!isCameraHelperAlive(udid)) return { udid, alive: false };
+
+  const helperPid = readCameraHelperPid(udid);
+  const bundleIds = readInjectedCameraBundles(udid);
+  try {
+    const reply = await sendCameraHelperCommand(udid, { action: "status" });
+    return { ...reply, udid, alive: true, helperPid, bundleIds };
+  } catch (error) {
+    return {
+      udid,
+      alive: true,
+      helperPid,
+      bundleIds,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/packages/serve-sim/src/client/components/camera-tool.tsx
+++ b/packages/serve-sim/src/client/components/camera-tool.tsx
@@ -13,6 +13,36 @@ export type CameraPillState = "ready" | "active" | "disconnected";
 
 export const CAMERA_POLL_INTERVAL_MS = 3000;
 
+interface CameraStatusResponse {
+  alive?: boolean;
+  source?: string;
+  arg?: string;
+  mirror?: string;
+  helperPid?: number;
+  bundleIds?: string[];
+}
+
+type CameraStatusRequest = (
+  endpoint: string,
+  init: RequestInit,
+) => Promise<Pick<Response, "ok" | "json">>;
+
+export async function requestCameraStatus(
+  endpoint: string,
+  request: CameraStatusRequest = fetch,
+): Promise<CameraStatusResponse | null> {
+  try {
+    const response = await request(endpoint, { cache: "no-store" });
+    if (!response.ok) return null;
+    const value = await response.json() as unknown;
+    return value && typeof value === "object" && !Array.isArray(value)
+      ? value as CameraStatusResponse
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 export const CAMERA_LARGE_VIDEO_BYTES = 200 * 1024 * 1024;
 export const CAMERA_LARGE_VIDEO_WARNING =
   "Large video (>200 MB) — may stutter on shared memory";
@@ -239,21 +269,9 @@ export function CameraTool({
   }, []);
 
   const fetchCameraStatus = useCallback(async () => {
-    const res = await execOnHost(`${cliPrefix} camera status -d ${udid}`);
-    if (res.exitCode !== 0) return null;
-    try {
-      return JSON.parse(res.stdout.trim()) as {
-        alive?: boolean;
-        source?: string;
-        arg?: string;
-        mirror?: string;
-        helperPid?: number;
-        bundleIds?: string[];
-      };
-    } catch {
-      return null;
-    }
-  }, [cliPrefix, udid]);
+    const endpoint = window.__SIM_PREVIEW__?.cameraStatusEndpoint;
+    return endpoint ? requestCameraStatus(endpoint) : null;
+  }, []);
 
   const refreshWebcamsRef = useRef<() => Promise<void>>(async () => {});
   const bundleIdRef = useRef<string | null>(bundleId);

--- a/packages/serve-sim/src/client/utils/sim-endpoint.ts
+++ b/packages/serve-sim/src/client/utils/sim-endpoint.ts
@@ -9,6 +9,7 @@ declare global {
       device: string;
       basePath: string;
       axEndpoint?: string;
+      cameraStatusEndpoint?: string;
       appStateEndpoint?: string;
       eventLogEndpoint?: string;
       eventLogEventsEndpoint?: string;

--- a/packages/serve-sim/src/index.ts
+++ b/packages/serve-sim/src/index.ts
@@ -15,6 +15,15 @@ import { uiSettings } from "./ui-settings";
 import { debugCli, debugHelper, debugState } from "./debug";
 import type { EventLogEntry } from "./event-log";
 import { formatEventLogLine } from "./event-log-format";
+import {
+  cameraHelperBundlesFile as helperBundlesFile,
+  cameraHelperPidFile as helperPidFile,
+  cameraHelperSocketFile as helperSocketFile,
+  isCameraHelperAlive as isHelperAlive,
+  readCameraStatus,
+  readInjectedCameraBundles as readInjectedBundles,
+  sendCameraHelperCommand as sendHelperCommand,
+} from "./camera-status";
 
 // `import.meta.dir` is Bun-only; resolve once via fileURLToPath so the bundled
 // CLI works under plain `node` too.
@@ -1047,79 +1056,10 @@ function shmNameForUdid(udid: string): string {
   return `/serve-sim-cam-${short}`;
 }
 
-function helperPidFile(udid: string): string {
-  return join(SIMCAM_STATE_DIR, `${udid}.pid`);
-}
-
-function helperBundlesFile(udid: string): string {
-  return join(SIMCAM_STATE_DIR, `${udid}.bundles.json`);
-}
-
-interface InjectedBundlesState {
-  helperPid: number;
-  bundleIds: string[];
-}
-
-function helperSocketFile(udid: string): string {
-  // POSIX sun_path is 104 chars on macOS — keep this short.
-  const short = createHash("sha1").update(udid).digest("hex").slice(0, 12);
-  return `/tmp/serve-sim-cam-${short}.sock`;
-}
-
-interface HelperReply { ok?: boolean; source?: string; arg?: string; error?: string }
-
-async function sendHelperCommand(udid: string, cmd: object): Promise<HelperReply> {
-  const sockPath = helperSocketFile(udid);
-  if (!existsSync(sockPath)) throw new Error("camera helper socket not found");
-  const net = await import("net");
-  return await new Promise((resolve, reject) => {
-    const c = net.createConnection(sockPath);
-    let buf = "";
-    let settled = false;
-    c.on("data", (d) => {
-      buf += d.toString();
-      const nl = buf.indexOf("\n");
-      if (nl >= 0 && !settled) {
-        settled = true;
-        try { resolve(JSON.parse(buf.slice(0, nl))); } catch (e) { reject(e); }
-        c.end();
-      }
-    });
-    c.on("error", (e) => { if (!settled) { settled = true; reject(e); } });
-    c.on("close", () => { if (!settled) { settled = true; reject(new Error("socket closed")); } });
-    c.write(JSON.stringify(cmd) + "\n");
-    setTimeout(() => { if (!settled) { settled = true; c.destroy(); reject(new Error("helper timeout")); } }, 3000);
-  });
-}
-
-function isHelperAlive(udid: string): boolean {
-  const pf = helperPidFile(udid);
-  if (!existsSync(pf)) return false;
-  const pid = Number(readFileSync(pf, "utf-8").trim());
-  return Number.isFinite(pid) && isProcessAlive(pid) && existsSync(helperSocketFile(udid));
-}
-
-function readInjectedBundles(udid: string): string[] {
-  const path = helperBundlesFile(udid);
-  if (!existsSync(path)) return [];
-  let state: InjectedBundlesState;
-  try {
-    state = JSON.parse(readFileSync(path, "utf-8")) as InjectedBundlesState;
-  } catch {
-    return [];
-  }
-  let currentHelperPid: number | null = null;
-  try {
-    currentHelperPid = Number(readFileSync(helperPidFile(udid), "utf-8").trim()) || null;
-  } catch {}
-  if (currentHelperPid == null || state.helperPid !== currentHelperPid) return [];
-  return Array.isArray(state.bundleIds) ? state.bundleIds : [];
-}
-
 function recordInjectedBundle(udid: string, bundleId: string, helperPid: number): void {
   const existing = readInjectedBundles(udid);
   const bundleIds = existing.includes(bundleId) ? existing : [...existing, bundleId];
-  const next: InjectedBundlesState = { helperPid, bundleIds };
+  const next = { helperPid, bundleIds };
   if (!existsSync(SIMCAM_STATE_DIR)) mkdirSync(SIMCAM_STATE_DIR, { recursive: true });
   writeFileSync(helperBundlesFile(udid), JSON.stringify(next));
 }
@@ -1510,22 +1450,7 @@ Examples:
       console.log(JSON.stringify({ alive: false, error: "no booted simulator" }));
       return;
     }
-    if (!isHelperAlive(udid)) {
-      console.log(JSON.stringify({ udid, alive: false }));
-      return;
-    }
-    let helperPid: number | null = null;
-    try { helperPid = Number(readFileSync(helperPidFile(udid), "utf-8").trim()) || null; } catch {}
-    const bundleIds = readInjectedBundles(udid);
-    try {
-      const reply = await sendHelperCommand(udid, { action: "status" });
-      console.log(JSON.stringify({ udid, alive: true, helperPid, bundleIds, ...reply }));
-    } catch (e: any) {
-      // pid file + socket exist but the helper didn't reply — surface
-      // alive:true so the UI can still skip "Inject + relaunch", and
-      // include the error for diagnosis.
-      console.log(JSON.stringify({ udid, alive: true, helperPid, bundleIds, error: e?.message ?? String(e) }));
-    }
+    console.log(JSON.stringify(await readCameraStatus(udid)));
     return;
   }
 

--- a/packages/serve-sim/src/index.ts
+++ b/packages/serve-sim/src/index.ts
@@ -16,6 +16,7 @@ import { debugCli, debugHelper, debugState } from "./debug";
 import type { EventLogEntry } from "./event-log";
 import { formatEventLogLine } from "./event-log-format";
 import {
+  CAMERA_STATE_DIR as SIMCAM_STATE_DIR,
   cameraHelperBundlesFile as helperBundlesFile,
   cameraHelperPidFile as helperPidFile,
   cameraHelperSocketFile as helperSocketFile,
@@ -23,7 +24,7 @@ import {
   readCameraStatus,
   readInjectedCameraBundles as readInjectedBundles,
   sendCameraHelperCommand as sendHelperCommand,
-} from "./camera-status";
+} from "./camera-helper";
 
 // `import.meta.dir` is Bun-only; resolve once via fileURLToPath so the bundled
 // CLI works under plain `node` too.
@@ -1048,8 +1049,6 @@ function buildCameraHelper(): string {
   return out;
 }
 
-const SIMCAM_STATE_DIR = join(STATE_DIR, "simcam");
-
 function shmNameForUdid(udid: string): string {
   // POSIX shm names on macOS have a 31-char limit. Hash the UDID short.
   const short = createHash("sha1").update(udid).digest("hex").slice(0, 8);
@@ -1440,10 +1439,8 @@ Examples:
     return;
   }
 
-  // `serve-sim camera status [-d udid]` — JSON-only probe used by the
-  // preview UI (and humans) to see whether the helper is still alive after
-  // a page reload, so we don't have to "Inject + relaunch" the app just to
-  // re-establish UI state.
+  // `serve-sim camera status [-d udid]` — JSON probe for scripts and humans.
+  // The preview UI reads the same shared implementation through middleware.
   if (filtered[0] === "status") {
     const udid = deviceArg ? resolveDevice(deviceArg) : findBootedDevice();
     if (!udid) {

--- a/packages/serve-sim/src/middleware.ts
+++ b/packages/serve-sim/src/middleware.ts
@@ -12,7 +12,7 @@ import type { Socket } from "net";
 // importing the dependency keeps the proxy working regardless of runtime.
 import { WebSocket } from "ws";
 import { createAxStreamerCache } from "./ax";
-import { readCameraStatus } from "./camera-status";
+import { readCameraStatus } from "./camera-helper";
 import { getDeviceSession, closeDeviceSession, type HidSocket } from "./device-session";
 import {
   eventLogEventForCommand,
@@ -729,9 +729,10 @@ async function handleCameraStatus(req: SimReq, res: SimRes, device: string): Pro
 }
 
 /**
- * Serve a helper endpoint from an in-process DeviceSession (NativeCapture +
- * NativeHid). Returns false when no session can serve it (device not booted, or
- * an endpoint this path doesn't own) so the caller can respond 404.
+ * Serve a device-scoped helper endpoint in-process. Camera status reads the
+ * camera helper's persisted state; stream and input routes lazily create a
+ * DeviceSession. Returns false for paths this function doesn't own or when a
+ * session-backed route cannot open the requested simulator.
  */
 function serveHelperInProcess(req: SimReq, res: SimRes, device: string | null, upstreamPath: string): boolean {
   if (!device) return false;

--- a/packages/serve-sim/src/middleware.ts
+++ b/packages/serve-sim/src/middleware.ts
@@ -12,6 +12,7 @@ import type { Socket } from "net";
 // importing the dependency keeps the proxy working regardless of runtime.
 import { WebSocket } from "ws";
 import { createAxStreamerCache } from "./ax";
+import { readCameraStatus } from "./camera-status";
 import { getDeviceSession, closeDeviceSession, type HidSocket } from "./device-session";
 import {
   eventLogEventForCommand,
@@ -688,6 +689,45 @@ function bridgeWebSocketFrames(req: SimReq, socket: Socket, head: Buffer, upstre
   drainFrames();
 }
 
+/** Read camera-helper state without opening the simulator capture session. */
+async function handleCameraStatus(req: SimReq, res: SimRes, device: string): Promise<void> {
+  if (!isSimulatorUdid(device)) {
+    res.writeHead(400, {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+    });
+    res.end(JSON.stringify({ error: "invalid_device" }));
+    return;
+  }
+  if (req.method !== "GET") {
+    res.writeHead(405, {
+      Allow: "GET",
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+    });
+    res.end(JSON.stringify({ error: "method_not_allowed" }));
+    return;
+  }
+  try {
+    const status = await readCameraStatus(device);
+    res.writeHead(200, {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+    });
+    res.end(JSON.stringify(status));
+  } catch (error) {
+    res.writeHead(500, {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+    });
+    res.end(JSON.stringify({
+      udid: device,
+      alive: false,
+      error: error instanceof Error ? error.message : String(error),
+    }));
+  }
+}
+
 /**
  * Serve a helper endpoint from an in-process DeviceSession (NativeCapture +
  * NativeHid). Returns false when no session can serve it (device not booted, or
@@ -695,13 +735,18 @@ function bridgeWebSocketFrames(req: SimReq, socket: Socket, head: Buffer, upstre
  */
 function serveHelperInProcess(req: SimReq, res: SimRes, device: string | null, upstreamPath: string): boolean {
   if (!device) return false;
+  const endpoint = upstreamPath.split("?")[0];
+  if (endpoint === "/camera/status") {
+    void handleCameraStatus(req, res, device);
+    return true;
+  }
   let session;
   try {
     session = getDeviceSession(device);
   } catch {
     return false; // not booted / capture unavailable → 404
   }
-  switch (upstreamPath.split("?")[0]) {
+  switch (endpoint) {
     case "/stream.mjpeg": session.handleMjpeg(req, res); return true;
     case "/stream.avcc": session.handleAvcc(req, res); return true;
     case "/config": session.handleConfig(req, res); return true;
@@ -828,6 +873,7 @@ export function previewConfigForState(
   eventLogEndpoint: string;
   eventLogEventsEndpoint: string;
   axEndpoint: string;
+  cameraStatusEndpoint: string;
   devtoolsEndpoint: string;
   serveSimBin: string;
   gridApiEndpoint: string;
@@ -847,6 +893,7 @@ export function previewConfigForState(
     eventLogEndpoint: endpoint(base, "/api/event-log", state.device),
     eventLogEventsEndpoint: endpoint(base, "/api/event-log/events", state.device),
     axEndpoint: endpoint(base, "/ax", state.device),
+    cameraStatusEndpoint: `${base === "/" ? "" : base}/helper/${encodeURIComponent(state.device)}/camera/status`,
     devtoolsEndpoint: endpoint(base, "/devtools", state.device),
     serveSimBin,
     gridApiEndpoint: gridApiBase,


### PR DESCRIPTION
## Summary

- move the existing camera-helper state and socket protocol into a shared module
- add a read-only, device-scoped camera status endpoint served without opening a simulator capture session
- have the Camera panel poll structured JSON directly instead of invoking the `serve-sim camera status` CLI through `/exec`

## Why

The Camera panel currently starts a complete CLI subprocess every three seconds to read state that the running server can access directly. This adds repeated process startup and output parsing, and scales poorly when multiple simulators or browser sessions are open.

Camera injection, source switching, mirroring, and shutdown commands are unchanged. The CLI's `camera status` command keeps its existing JSON contract and uses the same shared status reader as the middleware.

## Validation

- `bun run packages/serve-sim/build.ts`
- `bun run typecheck`
- `bun run lint`
- `bun test packages/serve-sim/src/__tests__` (341 pass, 3 skip, 0 fail)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added camera status monitoring through a device-specific HTTP endpoint.
  * Camera tools now poll status without invoking the simulator command line.
  * Camera status includes helper availability, process details, injected bundles, and video metadata.
  * Camera helper functionality is included in published packages.

* **Bug Fixes**
  * Improved handling of malformed responses, invalid device IDs, unavailable helpers, and split response data.
  * Added appropriate caching, method, and error responses for camera status requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->