### PR TITLE
feat: add per-app CPU/memory metrics (sampler, /metrics SSE, tools-panel readout)

### DIFF
--- a/packages/serve-sim/src/__tests__/cpu-mem-sampler.test.ts
+++ b/packages/serve-sim/src/__tests__/cpu-mem-sampler.test.ts
@@ -11,9 +11,11 @@ import {
 
 const UDID = "ABCD1234-0000-0000-0000-0000000000EF";
 
-// `ps -axo pid= cputime= rss= args=` — the user app and its extension run from the sim's
-// Containers/Bundle/Application path; launchd_sim and a RuntimeRoot daemon do not,
-// and an unrelated host process is off-device. Only the first two count. cputime is cumulative.
+// `ps -axo pid= cputime= rss= comm=` — the executable path of each process. The user app and its
+// extension run from the sim's Containers/Bundle/Application path; launchd_sim and a RuntimeRoot
+// daemon do not, and an unrelated host process is off-device. Matching on comm= (not args=) means a
+// host tool that merely passes a sim bundle path as an argument never reports one here. Only the
+// first two count. cputime is cumulative.
 function psFixture(): string {
   return [
     `  101   0:00.10  15000 launchd_sim /x/Devices/${UDID}/data/var/run/launchd_bootstrap.plist`,
@@ -125,7 +127,7 @@ describe("sampleUserApp", () => {
     };
     const usage = await sampleUserApp(UDID, { exec, frontmostApp: frontmost(103, "dev.expo.MyApp") });
     // cumulative cpu seconds of MyApp (12) + its extension (3); the sampler turns this into a %
-    expect(usage).toEqual({ bundleId: "dev.expo.MyApp", cpuSeconds: 15, memBytes: 2_000_000 });
+    expect(usage).toEqual({ bundleId: "dev.expo.MyApp", processKey: "103,104", cpuSeconds: 15, memBytes: 2_000_000 });
     expect(seen.sort()).toEqual(["footprint", "ps"]);
   });
 
@@ -135,7 +137,7 @@ describe("sampleUserApp", () => {
       throw new Error("footprint exited non-zero");
     };
     const usage = await sampleUserApp(UDID, { exec, frontmostApp: frontmost(103) });
-    expect(usage).toEqual({ bundleId: "dev.expo.MyApp", cpuSeconds: 15, memBytes: (80000 + 20000) * 1024 });
+    expect(usage).toEqual({ bundleId: "dev.expo.MyApp", processKey: "103,104", cpuSeconds: 15, memBytes: (80000 + 20000) * 1024 });
   });
 
   it("tags bundleId null and covers all user apps when nothing user-facing is foreground", async () => {
@@ -144,12 +146,14 @@ describe("sampleUserApp", () => {
     // AX unavailable -> no frontmost app: sum all user apps (103 + 104 + 106), bundleId null
     expect(await sampleUserApp(UDID, { exec, frontmostApp: async () => null })).toEqual({
       bundleId: null,
+      processKey: "103,104,106",
       cpuSeconds: 17,
       memBytes: 3_000_000,
     });
     // a system app is frontmost (pid not among the user-app processes) -> same
     expect(await sampleUserApp(UDID, { exec, frontmostApp: frontmost(999999) })).toEqual({
       bundleId: null,
+      processKey: "103,104,106",
       cpuSeconds: 17,
       memBytes: 3_000_000,
     });
@@ -192,11 +196,11 @@ describe("MetricsSampler", () => {
     //   t1 no baseline -> 0; t2 +0.5s/1s -> 50; t3 drop (churn) -> clamped 0;
     //   t4 app switch (B) -> 0; t5 +0.6s/1s -> 60.
     const readings = [
-      { bundleId: "dev.expo.A", cpuSeconds: 10.0, memBytes: 100 },
-      { bundleId: "dev.expo.A", cpuSeconds: 10.5, memBytes: 400 },
-      { bundleId: "dev.expo.A", cpuSeconds: 10.4, memBytes: 250 },
-      { bundleId: "dev.expo.B", cpuSeconds: 99.0, memBytes: 260 },
-      { bundleId: "dev.expo.B", cpuSeconds: 99.6, memBytes: 270 },
+      { bundleId: "dev.expo.A", processKey: "1", cpuSeconds: 10.0, memBytes: 100 },
+      { bundleId: "dev.expo.A", processKey: "1", cpuSeconds: 10.5, memBytes: 400 },
+      { bundleId: "dev.expo.A", processKey: "1", cpuSeconds: 10.4, memBytes: 250 },
+      { bundleId: "dev.expo.B", processKey: "2", cpuSeconds: 99.0, memBytes: 260 },
+      { bundleId: "dev.expo.B", processKey: "2", cpuSeconds: 99.6, memBytes: 270 },
     ];
     let i = 0;
     const sampler = new MetricsSampler({
@@ -220,12 +224,31 @@ describe("MetricsSampler", () => {
     sampler.stop();
   });
 
+  it("resets the cpu baseline when the process set changes within the same app", async () => {
+    // Same bundle, but the pid set changes (relaunch / extension swap) at t3. Cumulative CPU isn't
+    // comparable across process sets, so the delta must reset rather than report a false spike.
+    const readings = [
+      { bundleId: "dev.expo.A", processKey: "1", cpuSeconds: 10, memBytes: 100 },
+      { bundleId: "dev.expo.A", processKey: "1", cpuSeconds: 10.5, memBytes: 100 },
+      { bundleId: "dev.expo.A", processKey: "2", cpuSeconds: 99, memBytes: 100 },
+    ];
+    let i = 0;
+    const sampler = new MetricsSampler({ udid: UDID, sample: async () => readings[i++]!, now: fakeClock(), hostCores: 8 });
+    const got: MetricSample[] = [];
+    sampler.onSample((s) => got.push(s));
+
+    for (let n = 0; n < readings.length; n++) await sampler.tickOnce();
+
+    expect(got.map((s) => s.cpuPct)).toEqual([0, 50, 0]); // t3 resets despite the unchanged bundleId
+    sampler.stop();
+  });
+
   it("anchors the CPU delta to the observation time, not after the slow memory probe", async () => {
     let clockMs = 0;
     const now = () => clockMs;
     const readings = [
-      { bundleId: "dev.expo.A", cpuSeconds: 10, memBytes: 100 },
-      { bundleId: "dev.expo.A", cpuSeconds: 10.5, memBytes: 100 },
+      { bundleId: "dev.expo.A", processKey: "1", cpuSeconds: 10, memBytes: 100 },
+      { bundleId: "dev.expo.A", processKey: "1", cpuSeconds: 10.5, memBytes: 100 },
     ];
     let i = 0;
     let footprintMs = 0;
@@ -267,7 +290,7 @@ describe("MetricsSampler", () => {
   it("keeps notifying later listeners when an earlier one throws", async () => {
     const sampler = new MetricsSampler({
       udid: UDID,
-      sample: async () => ({ bundleId: "dev.expo.A", cpuSeconds: 1, memBytes: 2 }),
+      sample: async () => ({ bundleId: "dev.expo.A", processKey: "1", cpuSeconds: 1, memBytes: 2 }),
       now: fakeClock(),
       hostCores: 8,
     });
@@ -308,7 +331,7 @@ describe("createMetricsSamplerCache", () => {
   it("fans one sample out to every subscriber", async () => {
     let sampler!: MetricsSampler;
     const cache = createMetricsSamplerCache((udid) => {
-      sampler = new MetricsSampler({ udid, sample: async () => ({ bundleId: "dev.expo.A", cpuSeconds: 5, memBytes: 9 }), now: (() => { let t = 0; return () => (t += 1000); })(), hostCores: 8 });
+      sampler = new MetricsSampler({ udid, sample: async () => ({ bundleId: "dev.expo.A", processKey: "1", cpuSeconds: 5, memBytes: 9 }), now: (() => { let t = 0; return () => (t += 1000); })(), hostCores: 8 });
       return sampler;
     });
     const seen: number[] = [];

--- a/packages/serve-sim/src/__tests__/cpu-mem-sampler.test.ts
+++ b/packages/serve-sim/src/__tests__/cpu-mem-sampler.test.ts
@@ -302,6 +302,36 @@ describe("MetricsSampler", () => {
     await sampler.tickOnce();
     expect(received).toHaveLength(1);
   });
+
+  it("does not spawn overlapping poll loops on a stop/start during a tick", async () => {
+    const intervalMs = 30;
+    let ticks = 0;
+    let releaseFirstTick!: () => void;
+    const firstTickGate = new Promise<void>((resolve) => (releaseFirstTick = resolve));
+    const sample = async () => {
+      ticks++;
+      if (ticks === 1) await firstTickGate; // hold the first tick open across the stop/start
+      return null;
+    };
+    const sampler = new MetricsSampler({ udid: UDID, sample, intervalMs, hostCores: 8 });
+
+    sampler.start();
+    for (let waited = 0; ticks < 1 && waited < 500; waited += 5) {
+      await new Promise((r) => setTimeout(r, 5)); // wait until the first tick is in flight
+    }
+    expect(ticks).toBe(1);
+
+    // Restart while the tick is still awaiting; the superseded loop must not reschedule.
+    sampler.stop();
+    sampler.start();
+    releaseFirstTick();
+    await new Promise((r) => setTimeout(r, 5)); // flush the old loop's continuation
+    sampler.stop();
+
+    const ticksAtStop = ticks;
+    await new Promise((r) => setTimeout(r, intervalMs * 3)); // an orphaned loop would fire here
+    expect(ticks).toBe(ticksAtStop);
+  });
 });
 
 describe("createMetricsSamplerCache", () => {

--- a/packages/serve-sim/src/__tests__/cpu-mem-sampler.test.ts
+++ b/packages/serve-sim/src/__tests__/cpu-mem-sampler.test.ts
@@ -1,0 +1,324 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  createMetricsSamplerCache,
+  findUserAppProcesses,
+  MetricsSampler,
+  sampleUserApp,
+  sumPhysFootprintBytes,
+  type MetricSample,
+} from "../cpu-mem-sampler";
+
+const UDID = "ABCD1234-0000-0000-0000-0000000000EF";
+
+// `ps -axo pid= cputime= rss= args=` — the user app and its extension run from the sim's
+// Containers/Bundle/Application path; launchd_sim and a RuntimeRoot daemon do not,
+// and an unrelated host process is off-device. Only the first two count. cputime is cumulative.
+function psFixture(): string {
+  return [
+    `  101   0:00.10  15000 launchd_sim /x/Devices/${UDID}/data/var/run/launchd_bootstrap.plist`,
+    `  102   0:40.00  32000 /Runtime/RuntimeRoot/System/Library/PrivateFrameworks/ApplePushService.framework/apsd`,
+    `  103   0:12.00  80000 /x/Devices/${UDID}/data/Containers/Bundle/Application/AAA/MyApp.app/MyApp`,
+    `  104   0:03.00  20000 /x/Devices/${UDID}/data/Containers/Bundle/Application/AAA/MyApp.app/PlugIns/Share.appex/Share`,
+    `  105   0:09.90 999999 /some/host/process --unrelated`,
+  ].join("\n");
+}
+
+// A second user app ("Two Words.app", a space in its path like real "Expo Go.app") on the same sim.
+function psFixtureTwoApps(): string {
+  return [
+    psFixture(),
+    `  106   0:02.00  50000 /x/Devices/${UDID}/data/Containers/Bundle/Application/BBB/Two Words.app/Two Words`,
+  ].join("\n");
+}
+
+describe("findUserAppProcesses", () => {
+  it("scopes to the frontmost app's bundle (host + extensions), ignoring other user/system apps", () => {
+    // frontmost pid 103 -> MyApp.app; sums MyApp (12s) + its Share extension (3s), not the other app
+    expect(findUserAppProcesses(psFixtureTwoApps(), UDID, 103)).toEqual({
+      pids: [103, 104],
+      cpuSeconds: 15,
+      rssKb: 80000 + 20000,
+    });
+    // frontmost is the space-named app -> just that bundle
+    expect(findUserAppProcesses(psFixtureTwoApps(), UDID, 106)).toEqual({
+      pids: [106],
+      cpuSeconds: 2,
+      rssKb: 50000,
+    });
+  });
+
+  it("matches the device path case-insensitively", () => {
+    const ps = `7 0:02.00 1000 /x/Devices/${UDID.toLowerCase()}/data/Containers/Bundle/Application/AAA/App.app/App`;
+    expect(findUserAppProcesses(ps, UDID, 7)).toEqual({ pids: [7], cpuSeconds: 2, rssKb: 1000 });
+  });
+
+  it("sums every user app when the frontmost pid is unknown or not a user app", () => {
+    // no frontmost pid, or one that isn't a user process -> aggregate all user apps
+    for (const pid of [undefined, 999999]) {
+      expect(findUserAppProcesses(psFixtureTwoApps(), UDID, pid)).toEqual({
+        pids: [103, 104, 106],
+        cpuSeconds: 15 + 2,
+        rssKb: 80000 + 20000 + 50000,
+      });
+    }
+  });
+
+  it("returns null when no user app is running on this sim", () => {
+    // right sim, but only a system process (no Containers/Bundle path)
+    expect(
+      findUserAppProcesses(`1 0.1 15000 launchd_sim /x/Devices/${UDID}/data/var/run/x.plist\n`, UDID),
+    ).toBeNull();
+    expect(findUserAppProcesses("", UDID)).toBeNull();
+  });
+});
+
+describe("sumPhysFootprintBytes", () => {
+  // `footprint --noCategories --format bytes <pid> <pid>` output shape
+  const footprintFixture = [
+    "======================================================================",
+    "MyApp [103]: 64-bit    Footprint: 253904480 B (16384 bytes per page)",
+    "======================================================================",
+    "",
+    "Auxiliary data:",
+    "    phys_footprint: 253937248 B",
+    "    phys_footprint_peak: 333989448 B",
+    "",
+    "======================================================================",
+    "Share [104]: 64-bit    Footprint: 2244968 B (16384 bytes per page)",
+    "======================================================================",
+    "",
+    "Auxiliary data:",
+    "    phys_footprint: 2261352 B",
+    "    phys_footprint_peak: 2310504 B",
+    "",
+    "======================================================================",
+    "Summary Footprint: 256100296 B",
+    "======================================================================",
+  ].join("\n");
+
+  it("sums per-process phys_footprint, ignoring peaks and the summary", () => {
+    expect(sumPhysFootprintBytes(footprintFixture)).toBe(253937248 + 2261352);
+  });
+
+  it("returns null when no process was reported", () => {
+    expect(sumPhysFootprintBytes("")).toBeNull();
+    expect(sumPhysFootprintBytes("footprint: Unable to find pid for process matching '9'")).toBeNull();
+  });
+});
+
+describe("sampleUserApp", () => {
+  const footprintFor = (pids: string[]): string =>
+    pids.map((pid) => `App [${pid}]:\nAuxiliary data:\n    phys_footprint: 1000000 B\n`).join("\n");
+
+  const frontmost = (pid: number, bundleId = "dev.expo.MyApp") => async () => ({ pid, bundleId });
+
+  it("tags the sample with the frontmost bundleId and combines ps (cpu) with footprint (mem)", async () => {
+    const seen: string[] = [];
+    const exec = async (file: string, args: string[]): Promise<string> => {
+      seen.push(file);
+      if (file === "ps") return psFixtureTwoApps();
+      // footprint receives only the frontmost app's pids (MyApp 103 + its extension 104)
+      const pids = args.filter((a) => /^\d+$/.test(a));
+      expect(pids).toEqual(["103", "104"]);
+      return footprintFor(pids);
+    };
+    const usage = await sampleUserApp(UDID, { exec, frontmostApp: frontmost(103, "dev.expo.MyApp") });
+    // cumulative cpu seconds of MyApp (12) + its extension (3); the sampler turns this into a %
+    expect(usage).toEqual({ bundleId: "dev.expo.MyApp", cpuSeconds: 15, memBytes: 2_000_000 });
+    expect(seen.sort()).toEqual(["footprint", "ps"]);
+  });
+
+  it("falls back to RSS bytes when footprint fails", async () => {
+    const exec = async (file: string): Promise<string> => {
+      if (file === "ps") return psFixture();
+      throw new Error("footprint exited non-zero");
+    };
+    const usage = await sampleUserApp(UDID, { exec, frontmostApp: frontmost(103) });
+    expect(usage).toEqual({ bundleId: "dev.expo.MyApp", cpuSeconds: 15, memBytes: (80000 + 20000) * 1024 });
+  });
+
+  it("tags bundleId null and covers all user apps when nothing user-facing is foreground", async () => {
+    const exec = async (file: string, args: string[]): Promise<string> =>
+      file === "ps" ? psFixtureTwoApps() : footprintFor(args.filter((a) => /^\d+$/.test(a)));
+    // AX unavailable -> no frontmost app: sum all user apps (103 + 104 + 106), bundleId null
+    expect(await sampleUserApp(UDID, { exec, frontmostApp: async () => null })).toEqual({
+      bundleId: null,
+      cpuSeconds: 17,
+      memBytes: 3_000_000,
+    });
+    // a system app is frontmost (pid not among the user-app processes) -> same
+    expect(await sampleUserApp(UDID, { exec, frontmostApp: frontmost(999999) })).toEqual({
+      bundleId: null,
+      cpuSeconds: 17,
+      memBytes: 3_000_000,
+    });
+  });
+
+  it("returns null when no user app is running or ps fails", async () => {
+    const psFails = async (): Promise<string> => {
+      throw new Error("ps exited non-zero");
+    };
+    expect(await sampleUserApp(UDID, { exec: psFails, frontmostApp: frontmost(103) })).toBeNull();
+    // ps succeeds but only system processes are present
+    const systemOnly = async (file: string): Promise<string> =>
+      file === "ps" ? `1 0.1 15000 launchd_sim /x/Devices/${UDID}/data/var/run/x.plist` : "";
+    expect(await sampleUserApp(UDID, { exec: systemOnly, frontmostApp: async () => null })).toBeNull();
+  });
+});
+
+describe("MetricsSampler", () => {
+  function fakeClock(step = 1000): () => number {
+    let t = 0;
+    return () => {
+      const v = t;
+      t += step;
+      return v;
+    };
+  }
+
+  it("exposes meta (schema, udid, hostCores, interval)", () => {
+    const sampler = new MetricsSampler({ udid: UDID, intervalMs: 500, hostCores: 8 });
+    expect(sampler.meta).toEqual({
+      schemaVersion: 1,
+      udid: UDID,
+      hostCores: 8,
+      sampleIntervalMs: 500,
+    });
+  });
+
+  it("derives cpuPct from the cpu-time delta over each 1s interval", async () => {
+    // Cumulative cpu seconds per tick, at 1s spacing (fakeClock). Expected cpuPct:
+    //   t1 no baseline -> 0; t2 +0.5s/1s -> 50; t3 drop (churn) -> clamped 0;
+    //   t4 app switch (B) -> 0; t5 +0.6s/1s -> 60.
+    const readings = [
+      { bundleId: "dev.expo.A", cpuSeconds: 10.0, memBytes: 100 },
+      { bundleId: "dev.expo.A", cpuSeconds: 10.5, memBytes: 400 },
+      { bundleId: "dev.expo.A", cpuSeconds: 10.4, memBytes: 250 },
+      { bundleId: "dev.expo.B", cpuSeconds: 99.0, memBytes: 260 },
+      { bundleId: "dev.expo.B", cpuSeconds: 99.6, memBytes: 270 },
+    ];
+    let i = 0;
+    const sampler = new MetricsSampler({
+      udid: UDID,
+      sample: async () => readings[i++]!,
+      now: fakeClock(),
+      hostCores: 8,
+    });
+    const got: MetricSample[] = [];
+    sampler.onSample((s) => got.push(s));
+
+    for (let n = 0; n < readings.length; n++) await sampler.tickOnce();
+
+    expect(got).toEqual([
+      { t: 1000, bundleId: "dev.expo.A", cpuPct: 0, memBytes: 100 },
+      { t: 2000, bundleId: "dev.expo.A", cpuPct: 50, memBytes: 400 },
+      { t: 3000, bundleId: "dev.expo.A", cpuPct: 0, memBytes: 250 },
+      { t: 4000, bundleId: "dev.expo.B", cpuPct: 0, memBytes: 260 },
+      { t: 5000, bundleId: "dev.expo.B", cpuPct: 60, memBytes: 270 },
+    ]);
+    sampler.stop();
+  });
+
+  it("anchors the CPU delta to the observation time, not after the slow memory probe", async () => {
+    let clockMs = 0;
+    const now = () => clockMs;
+    const readings = [
+      { bundleId: "dev.expo.A", cpuSeconds: 10, memBytes: 100 },
+      { bundleId: "dev.expo.A", cpuSeconds: 10.5, memBytes: 100 },
+    ];
+    let i = 0;
+    let footprintMs = 0;
+    // sample() reads cpu up front, then the footprint probe takes `footprintMs` before returning.
+    const sample = async (): Promise<(typeof readings)[number]> => {
+      const reading = readings[i++]!;
+      clockMs += footprintMs;
+      return reading;
+    };
+    const sampler = new MetricsSampler({ udid: UDID, sample, now, hostCores: 8 });
+    const got: MetricSample[] = [];
+    sampler.onSample((s) => got.push(s));
+
+    footprintMs = 0;
+    await sampler.tickOnce(); // baseline
+    clockMs += 1000; // 1s until the next observation
+    footprintMs = 1000; // this tick's footprint probe is slow
+    await sampler.tickOnce();
+
+    // 0.5 cpu-seconds over the 1s observation interval = 50%, unaffected by the 1s footprint latency
+    // (which used to inflate the denominator and would report 25% here).
+    expect(got.at(-1)!.cpuPct).toBe(50);
+    sampler.stop();
+  });
+
+  it("skips a tick when the sim isn't up (null reading)", async () => {
+    const sampler = new MetricsSampler({
+      udid: UDID,
+      sample: async () => null,
+      now: fakeClock(),
+      hostCores: 8,
+    });
+    const got: MetricSample[] = [];
+    sampler.onSample((s) => got.push(s));
+    expect(await sampler.tickOnce()).toBeNull();
+    expect(got).toHaveLength(0);
+  });
+});
+
+describe("createMetricsSamplerCache", () => {
+  it("shares one sampler across subscribers for the same udid and stops it on last unsubscribe", () => {
+    const built: MetricsSampler[] = [];
+    const cache = createMetricsSamplerCache((udid) => {
+      const s = new MetricsSampler({ udid, sample: async () => null, hostCores: 8 });
+      built.push(s);
+      return s;
+    });
+
+    const a = cache.subscribe(UDID, () => {});
+    const b = cache.subscribe(UDID, () => {});
+    expect(built).toHaveLength(1); // one shared sampler
+    expect(a.meta.udid).toBe(UDID);
+
+    a.unsubscribe();
+    expect(built[0]!.listenerCount).toBe(1); // still alive for b
+    b.unsubscribe();
+
+    // A fresh subscribe after the last leaves builds a new sampler.
+    cache.subscribe(UDID, () => {});
+    expect(built).toHaveLength(2);
+  });
+
+  it("fans one sample out to every subscriber", async () => {
+    let sampler!: MetricsSampler;
+    const cache = createMetricsSamplerCache((udid) => {
+      sampler = new MetricsSampler({ udid, sample: async () => ({ bundleId: "dev.expo.A", cpuSeconds: 5, memBytes: 9 }), now: (() => { let t = 0; return () => (t += 1000); })(), hostCores: 8 });
+      return sampler;
+    });
+    const seen: number[] = [];
+    cache.subscribe(UDID, () => seen.push(1));
+    cache.subscribe(UDID, () => seen.push(2));
+    await sampler.tickOnce();
+    expect(seen.sort()).toEqual([1, 2]);
+  });
+
+  it("a stale double-unsubscribe does not evict a replacement sampler", () => {
+    const built: MetricsSampler[] = [];
+    const cache = createMetricsSamplerCache((udid) => {
+      const s = new MetricsSampler({ udid, sample: async () => null, hostCores: 8 });
+      built.push(s);
+      return s;
+    });
+
+    const first = cache.subscribe(UDID, () => {}); // builds sampler #1
+    first.unsubscribe(); // last listener -> stops + evicts #1
+    const second = cache.subscribe(UDID, () => {}); // builds sampler #2 for the same udid
+    expect(built).toHaveLength(2);
+
+    first.unsubscribe(); // stale, replayed: must NOT evict #2
+
+    // #2 is still the active sampler, so a new subscriber reuses it (no #3 built).
+    cache.subscribe(UDID, () => {});
+    expect(built).toHaveLength(2);
+    expect(second.meta.udid).toBe(UDID);
+  });
+});

--- a/packages/serve-sim/src/__tests__/cpu-mem-sampler.test.ts
+++ b/packages/serve-sim/src/__tests__/cpu-mem-sampler.test.ts
@@ -263,6 +263,22 @@ describe("MetricsSampler", () => {
     expect(await sampler.tickOnce()).toBeNull();
     expect(got).toHaveLength(0);
   });
+
+  it("keeps notifying later listeners when an earlier one throws", async () => {
+    const sampler = new MetricsSampler({
+      udid: UDID,
+      sample: async () => ({ bundleId: "dev.expo.A", cpuSeconds: 1, memBytes: 2 }),
+      now: fakeClock(),
+      hostCores: 8,
+    });
+    const received: MetricSample[] = [];
+    sampler.onSample(() => {
+      throw new Error("subscriber blew up");
+    });
+    sampler.onSample((s) => received.push(s));
+    await sampler.tickOnce();
+    expect(received).toHaveLength(1);
+  });
 });
 
 describe("createMetricsSamplerCache", () => {
@@ -284,8 +300,9 @@ describe("createMetricsSamplerCache", () => {
     b.unsubscribe();
 
     // A fresh subscribe after the last leaves builds a new sampler.
-    cache.subscribe(UDID, () => {});
+    const c = cache.subscribe(UDID, () => {});
     expect(built).toHaveLength(2);
+    c.unsubscribe();
   });
 
   it("fans one sample out to every subscriber", async () => {
@@ -295,10 +312,12 @@ describe("createMetricsSamplerCache", () => {
       return sampler;
     });
     const seen: number[] = [];
-    cache.subscribe(UDID, () => seen.push(1));
-    cache.subscribe(UDID, () => seen.push(2));
+    const a = cache.subscribe(UDID, () => seen.push(1));
+    const b = cache.subscribe(UDID, () => seen.push(2));
     await sampler.tickOnce();
     expect(seen.sort()).toEqual([1, 2]);
+    a.unsubscribe();
+    b.unsubscribe();
   });
 
   it("a stale double-unsubscribe does not evict a replacement sampler", () => {
@@ -317,8 +336,11 @@ describe("createMetricsSamplerCache", () => {
     first.unsubscribe(); // stale, replayed: must NOT evict #2
 
     // #2 is still the active sampler, so a new subscriber reuses it (no #3 built).
-    cache.subscribe(UDID, () => {});
+    const third = cache.subscribe(UDID, () => {});
     expect(built).toHaveLength(2);
+
+    second.unsubscribe();
+    third.unsubscribe();
     expect(second.meta.udid).toBe(UDID);
   });
 });

--- a/packages/serve-sim/src/__tests__/foreground-tracker.test.ts
+++ b/packages/serve-sim/src/__tests__/foreground-tracker.test.ts
@@ -63,6 +63,10 @@ describe("isUserFacingBundle", () => {
     expect(isUserFacingBundle("dev.expo.MyApp")).toBe(true);
     expect(isUserFacingBundle("com.apple.WidgetRenderer")).toBe(false);
     expect(isUserFacingBundle("dev.expo.MyApp.extension")).toBe(false);
+    // Generic names only match as whole components, so real apps that merely contain them stay in.
+    expect(isUserFacingBundle("com.example.CustomerService")).toBe(true);
+    expect(isUserFacingBundle("com.acme.InCallUITest")).toBe(true);
+    expect(isUserFacingBundle("com.apple.foo.Service")).toBe(false);
   });
 });
 
@@ -118,6 +122,19 @@ describe("createForegroundTrackerCache", () => {
     children[0]!.emit("exit");
     await tick();
     expect(children).toHaveLength(1); // no respawn once stopped
+  });
+
+  test("ref-counts duplicate callbacks independently", () => {
+    const { cache, children } = trackerWithFakeStream();
+    const callback = () => {};
+    const a = cache.subscribe("UDID", callback);
+    const b = cache.subscribe("UDID", callback); // same reference
+    expect(children).toHaveLength(1);
+
+    a.unsubscribe();
+    expect(children[0]!.killed).toBe(false); // b still active despite the shared callback
+    b.unsubscribe();
+    expect(children[0]!.killed).toBe(true);
   });
 
   test("shares one log stream per udid and stops it on last unsubscribe", () => {

--- a/packages/serve-sim/src/__tests__/foreground-tracker.test.ts
+++ b/packages/serve-sim/src/__tests__/foreground-tracker.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "events";
+import type { ChildProcess } from "child_process";
+import {
+  createForegroundTrackerCache,
+  isUserFacingBundle,
+  parseForegroundAppLogMessage,
+  type ForegroundApp,
+} from "../foreground-tracker";
+
+// A fake `log stream` child: an EventEmitter with a writable-looking stdout, driven by emitting
+// `data` chunks. Lets the tracker run without a booted simulator.
+function fakeChild() {
+  const stdout = Object.assign(new EventEmitter(), { destroy() {} });
+  return Object.assign(new EventEmitter(), {
+    stdout,
+    killed: false,
+    kill() {
+      this.killed = true;
+      return true;
+    },
+  });
+}
+
+function logChunk(bundleId: string, pid: number): Buffer {
+  const eventMessage = `[app<${bundleId}>:${pid}] Setting process visibility to: Foreground`;
+  return Buffer.from(JSON.stringify({ eventMessage }) + "\n");
+}
+
+function trackerWithFakeStream(restartDelayMs = 1000) {
+  const children: ReturnType<typeof fakeChild>[] = [];
+  const cache = createForegroundTrackerCache({
+    spawnLogStream: () => {
+      const child = fakeChild();
+      children.push(child);
+      return child as unknown as ChildProcess;
+    },
+    frontmostApp: async () => null, // no AX seed in tests; drive foreground purely from the feed
+    restartDelayMs,
+  });
+  return { cache, children };
+}
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 5));
+
+describe("parseForegroundAppLogMessage", () => {
+  test("extracts the bundle id and pid from a foreground line", () => {
+    expect(
+      parseForegroundAppLogMessage(
+        "[app<com.apple.mobilesafari>:43117] Setting process visibility to: Foreground",
+      ),
+    ).toEqual({ bundleId: "com.apple.mobilesafari", pid: 43117 });
+  });
+
+  test("returns null for non-foreground lines", () => {
+    expect(parseForegroundAppLogMessage("Setting process visibility to: Background")).toBeNull();
+  });
+});
+
+describe("isUserFacingBundle", () => {
+  test("keeps regular apps, drops widgets/extensions/services", () => {
+    expect(isUserFacingBundle("com.apple.mobilesafari")).toBe(true);
+    expect(isUserFacingBundle("dev.expo.MyApp")).toBe(true);
+    expect(isUserFacingBundle("com.apple.WidgetRenderer")).toBe(false);
+    expect(isUserFacingBundle("dev.expo.MyApp.extension")).toBe(false);
+  });
+});
+
+describe("createForegroundTrackerCache", () => {
+  test("tracks the latest user-facing app from the log feed", () => {
+    const { cache, children } = trackerWithFakeStream();
+    const seen: ForegroundApp[] = [];
+    const sub = cache.subscribe("UDID", (app) => seen.push(app));
+
+    children[0]!.stdout.emit("data", logChunk("dev.expo.A", 11));
+
+    expect(cache.peek("UDID")).toEqual({ bundleId: "dev.expo.A", pid: 11 });
+    expect(seen).toEqual([{ bundleId: "dev.expo.A", pid: 11 }]);
+    sub.unsubscribe();
+  });
+
+  test("ignores non-user-facing bundles and exact repeats, but tracks a same-bundle relaunch", () => {
+    const { cache, children } = trackerWithFakeStream();
+    const seen: ForegroundApp[] = [];
+    const sub = cache.subscribe("UDID", (app) => seen.push(app));
+    const child = children[0]!;
+
+    child.stdout.emit("data", logChunk("dev.expo.A", 11));
+    child.stdout.emit("data", logChunk("dev.expo.A", 11)); // exact repeat -> ignored
+    child.stdout.emit("data", logChunk("com.apple.WidgetRenderer", 99)); // non-UI -> ignored
+    child.stdout.emit("data", logChunk("dev.expo.A", 12)); // same bundle, new pid (relaunch) -> tracked
+    child.stdout.emit("data", logChunk("dev.expo.B", 22));
+
+    expect(seen).toEqual([
+      { bundleId: "dev.expo.A", pid: 11 },
+      { bundleId: "dev.expo.A", pid: 12 },
+      { bundleId: "dev.expo.B", pid: 22 },
+    ]);
+    sub.unsubscribe();
+  });
+
+  test("respawns the log stream when it exits while subscribers remain", async () => {
+    const { cache, children } = trackerWithFakeStream(0);
+    const sub = cache.subscribe("UDID");
+    expect(children).toHaveLength(1);
+
+    children[0]!.emit("exit"); // the stream died unexpectedly
+    await tick();
+    expect(children).toHaveLength(2); // respawned so tracking recovers
+    sub.unsubscribe();
+  });
+
+  test("does not respawn after an intentional stop", async () => {
+    const { cache, children } = trackerWithFakeStream(0);
+    const sub = cache.subscribe("UDID");
+    sub.unsubscribe(); // last listener -> stop()
+
+    children[0]!.emit("exit");
+    await tick();
+    expect(children).toHaveLength(1); // no respawn once stopped
+  });
+
+  test("shares one log stream per udid and stops it on last unsubscribe", () => {
+    const { cache, children } = trackerWithFakeStream();
+    const a = cache.subscribe("UDID");
+    const b = cache.subscribe("UDID");
+    expect(children).toHaveLength(1); // one shared tail
+
+    a.unsubscribe();
+    expect(children[0]!.killed).toBe(false); // still alive for b
+    b.unsubscribe();
+    expect(children[0]!.killed).toBe(true); // stopped with the last subscriber
+    expect(cache.peek("UDID")).toBeNull(); // evicted
+  });
+});

--- a/packages/serve-sim/src/__tests__/metrics-route.test.ts
+++ b/packages/serve-sim/src/__tests__/metrics-route.test.ts
@@ -89,7 +89,7 @@ describe("handleMetricsRequest", () => {
 
   test("writes the meta frame before any sample", async () => {
     const { cache, created } = createTrackingCache();
-    const { req } = createFakeReq();
+    const { req, close } = createFakeReq();
     const { res, writes } = createFakeRes();
 
     handleMetricsRequest(req, res, inProcessServeSimState("UDID-1", 4000), cache);
@@ -103,6 +103,7 @@ describe("handleMetricsRequest", () => {
     await firstSampler(created).tickOnce();
     expect(sampleFrames(writes)).toHaveLength(1);
 
+    close();
     created.forEach((s) => s.stop());
   });
 
@@ -123,6 +124,8 @@ describe("handleMetricsRequest", () => {
     expect(sampleFrames(resA.writes)).toEqual(sampleFrames(resB.writes));
     expect(sampleFrames(resA.writes)).toHaveLength(1);
 
+    a.close();
+    b.close();
     created.forEach((s) => s.stop());
   });
 
@@ -143,9 +146,11 @@ describe("handleMetricsRequest", () => {
     expect(firstSampler(created).listenerCount).toBe(0);
 
     // With the shared sampler evicted, a fresh subscriber builds a new one.
-    handleMetricsRequest(createFakeReq().req, createFakeRes().res, state, cache);
+    const c = createFakeReq();
+    handleMetricsRequest(c.req, createFakeRes().res, state, cache);
     expect(created).toHaveLength(2);
 
+    c.close();
     created.forEach((s) => s.stop());
   });
 });

--- a/packages/serve-sim/src/__tests__/metrics-route.test.ts
+++ b/packages/serve-sim/src/__tests__/metrics-route.test.ts
@@ -2,8 +2,16 @@ import { describe, expect, test } from "bun:test";
 import { EventEmitter } from "events";
 import type { IncomingMessage, ServerResponse } from "http";
 import { MetricsSampler, createMetricsSamplerCache } from "../cpu-mem-sampler";
+import type { ForegroundTrackerCache } from "../foreground-tracker";
 import { handleMetricsRequest } from "../middleware";
 import { inProcessServeSimState } from "../state";
+
+// The route keeps the foreground tail warm; these unit tests don't exercise it, so a no-op
+// tracker keeps them off a real `log stream`.
+const noopTracker: ForegroundTrackerCache = {
+  subscribe: () => ({ unsubscribe: () => {} }),
+  peek: () => null,
+};
 
 /**
  * Unit tests for the `/metrics` route handler. These exercise the route's own
@@ -57,7 +65,7 @@ function createTrackingCache() {
       intervalMs: 1_000_000,
       now: () => 0,
       hostCores: 8,
-      sample: async () => ({ bundleId: "com.example.app", cpuSeconds: 1, memBytes: 2048 }),
+      sample: async () => ({ bundleId: "com.example.app", processKey: "1", cpuSeconds: 1, memBytes: 2048 }),
     });
     created.push(sampler);
     return sampler;
@@ -81,7 +89,7 @@ describe("handleMetricsRequest", () => {
     const { req } = createFakeReq();
     const { res, status } = createFakeRes();
 
-    handleMetricsRequest(req, res, null, cache);
+    handleMetricsRequest(req, res, null, cache, noopTracker);
 
     expect(status()).toBe(404);
     expect(created).toHaveLength(0);
@@ -92,7 +100,7 @@ describe("handleMetricsRequest", () => {
     const { req, close } = createFakeReq();
     const { res, writes } = createFakeRes();
 
-    handleMetricsRequest(req, res, inProcessServeSimState("UDID-1", 4000), cache);
+    handleMetricsRequest(req, res, inProcessServeSimState("UDID-1", 4000), cache, noopTracker);
 
     const metaFrame = writes[1] ?? "";
     expect(metaFrame).toStartWith("event: meta\ndata:");
@@ -115,8 +123,8 @@ describe("handleMetricsRequest", () => {
     const resA = createFakeRes();
     const resB = createFakeRes();
 
-    handleMetricsRequest(a.req, resA.res, state, cache);
-    handleMetricsRequest(b.req, resB.res, state, cache);
+    handleMetricsRequest(a.req, resA.res, state, cache, noopTracker);
+    handleMetricsRequest(b.req, resB.res, state, cache, noopTracker);
 
     expect(created).toHaveLength(1);
 
@@ -135,8 +143,8 @@ describe("handleMetricsRequest", () => {
     const a = createFakeReq();
     const b = createFakeReq();
 
-    handleMetricsRequest(a.req, createFakeRes().res, state, cache);
-    handleMetricsRequest(b.req, createFakeRes().res, state, cache);
+    handleMetricsRequest(a.req, createFakeRes().res, state, cache, noopTracker);
+    handleMetricsRequest(b.req, createFakeRes().res, state, cache, noopTracker);
     expect(created).toHaveLength(1);
 
     a.close();
@@ -147,7 +155,7 @@ describe("handleMetricsRequest", () => {
 
     // With the shared sampler evicted, a fresh subscriber builds a new one.
     const c = createFakeReq();
-    handleMetricsRequest(c.req, createFakeRes().res, state, cache);
+    handleMetricsRequest(c.req, createFakeRes().res, state, cache, noopTracker);
     expect(created).toHaveLength(2);
 
     c.close();

--- a/packages/serve-sim/src/__tests__/metrics-route.test.ts
+++ b/packages/serve-sim/src/__tests__/metrics-route.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "events";
+import type { IncomingMessage, ServerResponse } from "http";
+import { MetricsSampler, createMetricsSamplerCache } from "../cpu-mem-sampler";
+import { handleMetricsRequest } from "../middleware";
+import { inProcessServeSimState } from "../state";
+
+/**
+ * Unit tests for the `/metrics` route handler. These exercise the route's own
+ * contract with a fake req/res and a sampler cache backed by a controllable
+ * sampler, so they run without a booted simulator or shelling out to `ps`.
+ * The end-to-end wiring against a real device lives in metrics-endpoint.test.ts.
+ */
+
+function createFakeReq(): { req: IncomingMessage; close: () => void } {
+  const req = Object.assign(new EventEmitter(), { headers: {} });
+  return { req: req as unknown as IncomingMessage, close: () => req.emit("close") };
+}
+
+function createFakeRes(): {
+  res: ServerResponse;
+  writes: string[];
+  status: () => number;
+  ended: () => boolean;
+} {
+  const writes: string[] = [];
+  let statusCode = 0;
+  let ended = false;
+  const res = {
+    writeHead(status: number) {
+      statusCode = status;
+      return res;
+    },
+    write(chunk: string) {
+      writes.push(chunk);
+      return true;
+    },
+    end(chunk?: string) {
+      if (chunk !== undefined) writes.push(chunk);
+      ended = true;
+      return res;
+    },
+    get writableEnded() {
+      return ended;
+    },
+  };
+  return { res: res as unknown as ServerResponse, writes, status: () => statusCode, ended: () => ended };
+}
+
+// A cache whose samplers never fire on their own timer (huge interval); the
+// test drives emission explicitly via `created[i].tickOnce()`.
+function createTrackingCache() {
+  const created: MetricsSampler[] = [];
+  const cache = createMetricsSamplerCache((udid) => {
+    const sampler = new MetricsSampler({
+      udid,
+      intervalMs: 1_000_000,
+      now: () => 0,
+      hostCores: 8,
+      sample: async () => ({ bundleId: "com.example.app", cpuSeconds: 1, memBytes: 2048 }),
+    });
+    created.push(sampler);
+    return sampler;
+  });
+  return { cache, created };
+}
+
+function sampleFrames(writes: string[]): string[] {
+  return writes.filter((w) => w.startsWith("data:"));
+}
+
+function firstSampler(created: MetricsSampler[]): MetricsSampler {
+  const sampler = created[0];
+  if (!sampler) throw new Error("expected a sampler to have been created");
+  return sampler;
+}
+
+describe("handleMetricsRequest", () => {
+  test("responds 404 for an unknown device without opening a sampler", () => {
+    const { cache, created } = createTrackingCache();
+    const { req } = createFakeReq();
+    const { res, status } = createFakeRes();
+
+    handleMetricsRequest(req, res, null, cache);
+
+    expect(status()).toBe(404);
+    expect(created).toHaveLength(0);
+  });
+
+  test("writes the meta frame before any sample", async () => {
+    const { cache, created } = createTrackingCache();
+    const { req } = createFakeReq();
+    const { res, writes } = createFakeRes();
+
+    handleMetricsRequest(req, res, inProcessServeSimState("UDID-1", 4000), cache);
+
+    const metaFrame = writes[1] ?? "";
+    expect(metaFrame).toStartWith("event: meta\ndata:");
+    const meta = JSON.parse(metaFrame.slice("event: meta\ndata:".length).trim());
+    expect("t" in meta).toBe(false);
+    expect(sampleFrames(writes)).toHaveLength(0);
+
+    await firstSampler(created).tickOnce();
+    expect(sampleFrames(writes)).toHaveLength(1);
+
+    created.forEach((s) => s.stop());
+  });
+
+  test("shares one sampler across concurrent subscribers to the same device", async () => {
+    const { cache, created } = createTrackingCache();
+    const state = inProcessServeSimState("UDID-1", 4000);
+    const a = createFakeReq();
+    const b = createFakeReq();
+    const resA = createFakeRes();
+    const resB = createFakeRes();
+
+    handleMetricsRequest(a.req, resA.res, state, cache);
+    handleMetricsRequest(b.req, resB.res, state, cache);
+
+    expect(created).toHaveLength(1);
+
+    await firstSampler(created).tickOnce();
+    expect(sampleFrames(resA.writes)).toEqual(sampleFrames(resB.writes));
+    expect(sampleFrames(resA.writes)).toHaveLength(1);
+
+    created.forEach((s) => s.stop());
+  });
+
+  test("stops the sampler only after the last client disconnects", async () => {
+    const { cache, created } = createTrackingCache();
+    const state = inProcessServeSimState("UDID-1", 4000);
+    const a = createFakeReq();
+    const b = createFakeReq();
+
+    handleMetricsRequest(a.req, createFakeRes().res, state, cache);
+    handleMetricsRequest(b.req, createFakeRes().res, state, cache);
+    expect(created).toHaveLength(1);
+
+    a.close();
+    expect(firstSampler(created).listenerCount).toBe(1);
+
+    b.close();
+    expect(firstSampler(created).listenerCount).toBe(0);
+
+    // With the shared sampler evicted, a fresh subscriber builds a new one.
+    handleMetricsRequest(createFakeReq().req, createFakeRes().res, state, cache);
+    expect(created).toHaveLength(2);
+
+    created.forEach((s) => s.stop());
+  });
+});

--- a/packages/serve-sim/src/__tests__/middleware-selection.test.ts
+++ b/packages/serve-sim/src/__tests__/middleware-selection.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import {
   matchInstalledAppByDisplayName,
-  parseForegroundAppLogMessage,
   previewConfigForState,
   rewriteStateForRequestHost,
   selectServeSimState,
   type ServeSimState,
 } from "../middleware";
+import { parseForegroundAppLogMessage } from "../foreground-tracker";
 
 const states: ServeSimState[] = [
   {

--- a/packages/serve-sim/src/__tests__/middleware-selection.test.ts
+++ b/packages/serve-sim/src/__tests__/middleware-selection.test.ts
@@ -51,6 +51,7 @@ describe("previewConfigForState", () => {
       eventLogEndpoint: "/preview/api/event-log?device=DEVICE-B",
       eventLogEventsEndpoint: "/preview/api/event-log/events?device=DEVICE-B",
       axEndpoint: "/preview/ax?device=DEVICE-B",
+      metricsEndpoint: "/preview/metrics?device=DEVICE-B",
       cameraStatusEndpoint: "/preview/helper/DEVICE-B/camera/status",
       devtoolsEndpoint: "/preview/devtools?device=DEVICE-B",
       serveSimBin: "/bin/serve-sim",

--- a/packages/serve-sim/src/client/client.tsx
+++ b/packages/serve-sim/src/client/client.tsx
@@ -1147,6 +1147,7 @@ function AppWithConfig({
         deviceRuntime={deviceRuntime}
         currentApp={currentApp}
         eventLogEventsEndpoint={config.eventLogEventsEndpoint}
+        metricsEndpoint={config.metricsEndpoint}
         axOverlayEnabled={axOverlayEnabled}
         onToggleAxOverlay={() => setAxOverlayEnabled((enabled) => !enabled)}
         codecPreference={codecPreference}

--- a/packages/serve-sim/src/client/components/metrics-tool.tsx
+++ b/packages/serve-sim/src/client/components/metrics-tool.tsx
@@ -24,16 +24,13 @@ export function MetricsTool({
   );
   const { meta, latest, history, errored, stale } = useMetricsStream(path);
   const [open, setOpen] = useState(true);
-  // We only measure user-installed apps. When a system app is in the foreground the readout would
-  // be a backgrounded user app's numbers, so surface that it isn't supported rather than showing a
-  // stale graph. Only idle when the foreground signal (currentApp, from /appstate) positively
-  // reports a system app, so a fresh load — signal not yet known — still shows the running app.
-  // Intentionally keyed off /appstate, not the sample's bundleId: that comes from axFrontmost, which
-  // only resolves when the Simulator window is macOS-focused, so it's null in the normal
-  // browser-driven case while the aggregate numbers stay valid — gating on it would idle constantly.
+  // Live only while the backend actually scoped to a user app: each sample carries that app's
+  // bundleId, and null when a system app is in front (those run outside the sampler's reach) or
+  // nothing is running. Keying on the sampler's own output keeps this from drifting from what it can
+  // measure; currentAppBundleId (from /appstate) only words the idle reason.
+  const live = latest !== null && latest.bundleId !== null && !errored && !stale;
   const foregroundIsSystemApp =
     currentAppBundleId != null && currentAppBundleId.startsWith("com.apple.");
-  const live = latest !== null && !errored && !stale && !foregroundIsSystemApp;
   // When there's nothing to show, a header glyph carries the reason on hover instead of a body line.
   const idleReason = errored
     ? "The metrics stream disconnected"
@@ -64,7 +61,7 @@ export function MetricsTool({
                   role="status"
                   className="group relative justify-self-end inline-flex items-center"
                 >
-                  <TriangleAlert aria-hidden="true" className="w-3.5 h-3.5 text-amber-400/80" />
+                  <TriangleAlert aria-hidden="true" className="w-3.5 h-3.5 text-amber-400" />
                   <span className="sr-only">{idleReason}</span>
                   <span className="pointer-events-none absolute right-0 top-full z-10 mt-1 hidden w-max max-w-[220px] rounded-md bg-black/90 px-2 py-1 text-[11px] leading-snug text-white/90 shadow-lg group-hover:block">
                     {idleReason}

--- a/packages/serve-sim/src/client/components/metrics-tool.tsx
+++ b/packages/serve-sim/src/client/components/metrics-tool.tsx
@@ -8,7 +8,7 @@ import { CollapsibleSection } from "./collapsible-section";
 const SPARK_W = 96;
 const SPARK_H = 24;
 
-// Live CPU/memory readout for the sim's user app, with a sparkline for each.
+/** Live CPU/memory readout for the sim's user app, with a sparkline for each. */
 export function MetricsTool({
   udid,
   currentAppBundleId,
@@ -90,6 +90,7 @@ export function MetricsTool({
   );
 }
 
+/** One labeled metric: its current value with a sparkline of recent history. */
 function MetricRow({
   label,
   value,
@@ -117,6 +118,7 @@ function MetricRow({
   );
 }
 
+/** Minimal filled-area sparkline for a series of values. */
 function Sparkline({ values, className }: { values: number[]; className: string }) {
   const line = sparklinePath(values, SPARK_W, SPARK_H);
   // Close the line down to the baseline and back to fill the area under it.

--- a/packages/serve-sim/src/client/components/metrics-tool.tsx
+++ b/packages/serve-sim/src/client/components/metrics-tool.tsx
@@ -28,6 +28,9 @@ export function MetricsTool({
   // be a backgrounded user app's numbers, so surface that it isn't supported rather than showing a
   // stale graph. Only idle when the foreground signal (currentApp, from /appstate) positively
   // reports a system app, so a fresh load — signal not yet known — still shows the running app.
+  // Intentionally keyed off /appstate, not the sample's bundleId: that comes from axFrontmost, which
+  // only resolves when the Simulator window is macOS-focused, so it's null in the normal
+  // browser-driven case while the aggregate numbers stay valid — gating on it would idle constantly.
   const foregroundIsSystemApp =
     currentAppBundleId != null && currentAppBundleId.startsWith("com.apple.");
   const live = latest !== null && !errored && !stale && !foregroundIsSystemApp;
@@ -58,9 +61,11 @@ export function MetricsTool({
             : (
                 <span
                   data-metrics-warning
+                  role="status"
                   className="group relative justify-self-end inline-flex items-center"
                 >
-                  <TriangleAlert className="w-3.5 h-3.5 text-amber-400/80" />
+                  <TriangleAlert aria-hidden="true" className="w-3.5 h-3.5 text-amber-400/80" />
+                  <span className="sr-only">{idleReason}</span>
                   <span className="pointer-events-none absolute right-0 top-full z-10 mt-1 hidden w-max max-w-[220px] rounded-md bg-black/90 px-2 py-1 text-[11px] leading-snug text-white/90 shadow-lg group-hover:block">
                     {idleReason}
                   </span>

--- a/packages/serve-sim/src/client/components/metrics-tool.tsx
+++ b/packages/serve-sim/src/client/components/metrics-tool.tsx
@@ -1,0 +1,140 @@
+import { TriangleAlert } from "lucide-react";
+import { useMemo, useState } from "react";
+import { useMetricsStream } from "../hooks/use-metrics-stream";
+import { formatCpu, formatMem, sparklinePath } from "../utils/format-metrics";
+import { simEndpoint } from "../utils/sim-endpoint";
+import { CollapsibleSection } from "./collapsible-section";
+
+const SPARK_W = 96;
+const SPARK_H = 24;
+
+// Live CPU/memory readout for the sim's user app, with a sparkline for each.
+export function MetricsTool({
+  udid,
+  currentAppBundleId,
+  metricsEndpoint,
+}: {
+  udid: string;
+  currentAppBundleId: string | null;
+  metricsEndpoint?: string;
+}) {
+  const path = useMemo(
+    () => metricsEndpoint ?? `${simEndpoint("metrics")}?device=${encodeURIComponent(udid)}`,
+    [metricsEndpoint, udid],
+  );
+  const { meta, latest, history, errored, stale } = useMetricsStream(path);
+  const [open, setOpen] = useState(true);
+  // We only measure user-installed apps. When a system app is in the foreground the readout would
+  // be a backgrounded user app's numbers, so surface that it isn't supported rather than showing a
+  // stale graph. Only idle when the foreground signal (currentApp, from /appstate) positively
+  // reports a system app, so a fresh load — signal not yet known — still shows the running app.
+  const foregroundIsSystemApp =
+    currentAppBundleId != null && currentAppBundleId.startsWith("com.apple.");
+  const live = latest !== null && !errored && !stale && !foregroundIsSystemApp;
+  // When there's nothing to show, a header glyph carries the reason on hover instead of a body line.
+  const idleReason = errored
+    ? "The metrics stream disconnected"
+    : foregroundIsSystemApp
+      ? "Only your app is measured; a system app is in the foreground"
+      : "Waiting for CPU / memory data";
+
+  return (
+    <CollapsibleSection
+      open={open}
+      onOpenChange={setOpen}
+      summaryClassName="grid [grid-template-columns:auto_1fr_auto] items-center gap-2 text-left"
+      bodyClassName={live ? undefined : "hidden"}
+      summary={
+        <>
+          <span className="text-[11px] font-semibold text-white/50 uppercase tracking-[0.08em] leading-none inline-flex items-center">
+            Activity
+          </span>
+          {live
+            ? !open && (
+                <span className="text-[11px] text-white/40 tabular-nums text-right">
+                  {formatCpu(latest.cpuPct)} · {formatMem(latest.memBytes)}
+                </span>
+              )
+            : (
+                <span
+                  data-metrics-warning
+                  className="group relative justify-self-end inline-flex items-center"
+                >
+                  <TriangleAlert className="w-3.5 h-3.5 text-amber-400/80" />
+                  <span className="pointer-events-none absolute right-0 top-full z-10 mt-1 hidden w-max max-w-[220px] rounded-md bg-black/90 px-2 py-1 text-[11px] leading-snug text-white/90 shadow-lg group-hover:block">
+                    {idleReason}
+                  </span>
+                </span>
+              )}
+        </>
+      }
+    >
+      {live ? (
+        <>
+          <MetricRow
+            label="CPU"
+            value={formatCpu(latest.cpuPct)}
+            hint={meta ? `${meta.hostCores} cores` : undefined}
+            values={history.map((s) => s.cpuPct)}
+            className="text-emerald-400"
+          />
+          <MetricRow
+            label="Memory"
+            value={formatMem(latest.memBytes)}
+            values={history.map((s) => s.memBytes)}
+            className="text-sky-400"
+          />
+        </>
+      ) : null}
+    </CollapsibleSection>
+  );
+}
+
+function MetricRow({
+  label,
+  value,
+  hint,
+  values,
+  className,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+  values: number[];
+  className: string;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-baseline justify-between">
+        <span className="text-white/50 text-[11px]">{label}</span>
+        <span className="tabular-nums text-[11px]">
+          {value}
+          {hint && <span className="text-white/30 text-[11px] ml-1.5">{hint}</span>}
+        </span>
+      </div>
+      <Sparkline values={values} className={className} />
+    </div>
+  );
+}
+
+function Sparkline({ values, className }: { values: number[]; className: string }) {
+  const line = sparklinePath(values, SPARK_W, SPARK_H);
+  // Close the line down to the baseline and back to fill the area under it.
+  const area = line ? `${line} L${SPARK_W},${SPARK_H} L0,${SPARK_H} Z` : "";
+  return (
+    <svg
+      viewBox={`0 0 ${SPARK_W} ${SPARK_H}`}
+      preserveAspectRatio="none"
+      className={`w-full h-8 ${className}`}
+    >
+      <path d={area} fill="currentColor" opacity={0.12} stroke="none" />
+      <path
+        d={line}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        vectorEffect="non-scaling-stroke"
+      />
+    </svg>
+  );
+}

--- a/packages/serve-sim/src/client/components/tools-panel.tsx
+++ b/packages/serve-sim/src/client/components/tools-panel.tsx
@@ -6,6 +6,7 @@ import { AppPermissionsTool } from "./app-permissions-tool";
 import { AxTreeTool } from "./ax-tree-tool";
 import { CameraTool } from "./camera-tool";
 import { EventLogTool } from "./event-log-tool";
+import { MetricsTool } from "./metrics-tool";
 import { PANEL_BACKGROUND } from "./panel-colors";
 import { SimulatorSettingsTool } from "./simulator-settings-tool";
 import { StreamSettingsTool, type CodecPreference } from "./stream-settings-tool";
@@ -49,6 +50,7 @@ export function ToolsPanel({
       {open && (
         <div className="p-3.5 overflow-y-auto flex-1 flex flex-col gap-3">
           <AppDetectionTool udid={udid} currentApp={currentApp} />
+          <MetricsTool udid={udid} currentAppBundleId={currentApp?.bundleId ?? null} />
           <EventLogTool udid={udid} eventsEndpoint={eventLogEventsEndpoint} />
           <SimulatorSettingsTool udid={udid} runtime={deviceRuntime} />
           <AxTreeTool

--- a/packages/serve-sim/src/client/components/tools-panel.tsx
+++ b/packages/serve-sim/src/client/components/tools-panel.tsx
@@ -19,6 +19,7 @@ export function ToolsPanel({
   deviceRuntime,
   currentApp,
   eventLogEventsEndpoint,
+  metricsEndpoint,
   axOverlayEnabled,
   onToggleAxOverlay,
   codecPreference,
@@ -33,6 +34,7 @@ export function ToolsPanel({
   deviceRuntime: string | null;
   currentApp: { bundleId: string; isReactNative: boolean; pid?: number } | null;
   eventLogEventsEndpoint?: string;
+  metricsEndpoint?: string;
   axOverlayEnabled: boolean;
   onToggleAxOverlay: () => void;
   codecPreference: CodecPreference;
@@ -51,7 +53,7 @@ export function ToolsPanel({
       {open && (
         <div className="p-3.5 overflow-y-auto flex-1 flex flex-col gap-3">
           <AppDetectionTool udid={udid} currentApp={currentApp} />
-          <MetricsTool udid={udid} currentAppBundleId={currentApp?.bundleId ?? null} />
+          <MetricsTool udid={udid} currentAppBundleId={currentApp?.bundleId ?? null} metricsEndpoint={metricsEndpoint} />
           <EventLogTool udid={udid} eventsEndpoint={eventLogEventsEndpoint} />
           <SimulatorSettingsTool udid={udid} runtime={deviceRuntime} />
           <AxTreeTool

--- a/packages/serve-sim/src/client/components/tools-panel.tsx
+++ b/packages/serve-sim/src/client/components/tools-panel.tsx
@@ -11,6 +11,7 @@ import { PANEL_BACKGROUND } from "./panel-colors";
 import { SimulatorSettingsTool } from "./simulator-settings-tool";
 import { StreamSettingsTool, type CodecPreference } from "./stream-settings-tool";
 
+/** The preview's collapsible tools panel: app detection, metrics, camera, permissions, and settings. */
 export function ToolsPanel({
   open,
   onClose,

--- a/packages/serve-sim/src/client/hooks/use-metrics-stream.ts
+++ b/packages/serve-sim/src/client/hooks/use-metrics-stream.ts
@@ -45,15 +45,16 @@ export function useMetricsStream(path: string): {
           lastSampleAt.current = Date.now();
           setStale(false);
           setHistory((prev) => {
-            const previous = prev.at(-1);
-            // Reset only on a real foreground app switch. Ignore flips to/from the
-            // sampler's null aggregate (a brief loss of the frontmost signal) so the
-            // series isn't wiped every time the app is opened or closed.
+            // Reset only on a real foreground app switch. Compare against the last
+            // *known* app, ignoring the sampler's intermediate null aggregate when it
+            // briefly loses the frontmost signal (e.g. app A -> home -> app B), so the
+            // series isn't wiped on every open/close but still resets between two apps.
+            const lastBundleId =
+              [...prev].reverse().find((s) => s.bundleId !== null)?.bundleId ?? null;
             const appSwitched =
-              previous != null &&
-              previous.bundleId !== null &&
+              lastBundleId !== null &&
               sample.bundleId !== null &&
-              previous.bundleId !== sample.bundleId;
+              lastBundleId !== sample.bundleId;
             return [...(appSwitched ? [] : prev), sample].slice(-MAX_POINTS);
           });
         }

--- a/packages/serve-sim/src/client/hooks/use-metrics-stream.ts
+++ b/packages/serve-sim/src/client/hooks/use-metrics-stream.ts
@@ -8,9 +8,10 @@ export type { MetricSample, MetricsMeta };
 
 // ~1 minute of history at 1s cadence.
 const MAX_POINTS = 60;
-// The sampler emits ~1/s; treat the readout as stale after a few missed samples. The backend
-// goes quiet when no user app is foreground (or the app exits), so silence is expected, not rare.
-const STALE_AFTER_MS = 3_000;
+// The sampler emits ~1/s, but a single healthy tick can take up to ~7s (the poll interval plus the
+// ps and footprint timeouts), so only flag the readout stale well past that worst case. The backend
+// also goes quiet when no user app is foreground (or the app exits), so silence is expected, not rare.
+const STALE_AFTER_MS = 8_000;
 
 /**
  * The transport strips SSE `event:` lines, so meta and sample frames both

--- a/packages/serve-sim/src/client/hooks/use-metrics-stream.ts
+++ b/packages/serve-sim/src/client/hooks/use-metrics-stream.ts
@@ -12,8 +12,10 @@ const MAX_POINTS = 60;
 // goes quiet when no user app is foreground (or the app exits), so silence is expected, not rare.
 const STALE_AFTER_MS = 3_000;
 
-// The transport strips SSE `event:` lines, so meta and sample frames both
-// arrive as messages — discriminated by shape.
+/**
+ * The transport strips SSE `event:` lines, so meta and sample frames both
+ * arrive as messages, discriminated by shape.
+ */
 export function useMetricsStream(path: string): {
   meta: MetricsMeta | null;
   latest: MetricSample | null;

--- a/packages/serve-sim/src/client/hooks/use-metrics-stream.ts
+++ b/packages/serve-sim/src/client/hooks/use-metrics-stream.ts
@@ -1,0 +1,78 @@
+import { useEffect, useRef, useState } from "react";
+
+// Type-only — the sampler's node: imports must not reach the client bundle.
+import type { MetricSample, MetricsMeta } from "../../cpu-mem-sampler";
+import { openHostEventStream } from "../utils/exec";
+
+export type { MetricSample, MetricsMeta };
+
+// ~1 minute of history at 1s cadence.
+const MAX_POINTS = 60;
+// The sampler emits ~1/s; treat the readout as stale after a few missed samples. The backend
+// goes quiet when no user app is foreground (or the app exits), so silence is expected, not rare.
+const STALE_AFTER_MS = 3_000;
+
+// The transport strips SSE `event:` lines, so meta and sample frames both
+// arrive as messages — discriminated by shape.
+export function useMetricsStream(path: string): {
+  meta: MetricsMeta | null;
+  latest: MetricSample | null;
+  history: MetricSample[];
+  errored: boolean;
+  stale: boolean;
+} {
+  const [meta, setMeta] = useState<MetricsMeta | null>(null);
+  const [history, setHistory] = useState<MetricSample[]>([]);
+  const [errored, setErrored] = useState(false);
+  const [stale, setStale] = useState(false);
+  const lastSampleAt = useRef(0);
+
+  useEffect(() => {
+    // Reset so a device switch drops the previous device's samples.
+    setMeta(null);
+    setHistory([]);
+    setErrored(false);
+    setStale(false);
+    lastSampleAt.current = 0;
+    const stream = openHostEventStream(path);
+    stream.onmessage = ({ data }) => {
+      try {
+        const parsed = JSON.parse(data) as Record<string, unknown>;
+        setErrored(false);
+        if ("schemaVersion" in parsed) setMeta(parsed as unknown as MetricsMeta);
+        else if ("t" in parsed) {
+          const sample = parsed as unknown as MetricSample;
+          lastSampleAt.current = Date.now();
+          setStale(false);
+          setHistory((prev) => {
+            const previous = prev.at(-1);
+            // Reset only on a real foreground app switch. Ignore flips to/from the
+            // sampler's null aggregate (a brief loss of the frontmost signal) so the
+            // series isn't wiped every time the app is opened or closed.
+            const appSwitched =
+              previous != null &&
+              previous.bundleId !== null &&
+              sample.bundleId !== null &&
+              previous.bundleId !== sample.bundleId;
+            return [...(appSwitched ? [] : prev), sample].slice(-MAX_POINTS);
+          });
+        }
+      } catch {
+        // ignore a malformed frame
+      }
+    };
+    stream.onerror = () => setErrored(true);
+    // Flag the readout stale once samples stop arriving, so the last value isn't shown as live.
+    const watchdog = setInterval(() => {
+      if (lastSampleAt.current > 0 && Date.now() - lastSampleAt.current > STALE_AFTER_MS) {
+        setStale(true);
+      }
+    }, 1_000);
+    return () => {
+      stream.close();
+      clearInterval(watchdog);
+    };
+  }, [path]);
+
+  return { meta, latest: history.at(-1) ?? null, history, errored, stale };
+}

--- a/packages/serve-sim/src/client/utils/format-metrics.ts
+++ b/packages/serve-sim/src/client/utils/format-metrics.ts
@@ -1,0 +1,34 @@
+export function formatCpu(cpuPct: number): string {
+  return `${Math.round(cpuPct)}%`;
+}
+
+export function formatMem(memBytes: number): string {
+  const mb = memBytes / (1024 * 1024);
+  return mb >= 1024 ? `${(mb / 1024).toFixed(1)} GB` : `${Math.round(mb)} MB`;
+}
+
+// Smooth sparkline path, auto-scaled to the window peak. Catmull-Rom spline with
+// control points clamped per segment so the curve never overshoots the data.
+export function sparklinePath(values: number[], width: number, height: number): string {
+  if (values.length < 2) return "";
+  const max = Math.max(...values, 1);
+  const stepX = width / (values.length - 1);
+  const pts = values.map((v, i) => ({ x: i * stepX, y: height - (v / max) * height }));
+
+  let d = `M${pts[0]!.x.toFixed(1)},${pts[0]!.y.toFixed(1)}`;
+  for (let i = 0; i < pts.length - 1; i++) {
+    const p0 = pts[i - 1] ?? pts[i]!;
+    const p1 = pts[i]!;
+    const p2 = pts[i + 1]!;
+    const p3 = pts[i + 2] ?? p2;
+    const lo = Math.min(p1.y, p2.y);
+    const hi = Math.max(p1.y, p2.y);
+    const clampY = (y: number) => Math.min(hi, Math.max(lo, y));
+    const c1x = p1.x + (p2.x - p0.x) / 6;
+    const c1y = clampY(p1.y + (p2.y - p0.y) / 6);
+    const c2x = p2.x - (p3.x - p1.x) / 6;
+    const c2y = clampY(p2.y - (p3.y - p1.y) / 6);
+    d += ` C${c1x.toFixed(1)},${c1y.toFixed(1)} ${c2x.toFixed(1)},${c2y.toFixed(1)} ${p2.x.toFixed(1)},${p2.y.toFixed(1)}`;
+  }
+  return d;
+}

--- a/packages/serve-sim/src/client/utils/format-metrics.ts
+++ b/packages/serve-sim/src/client/utils/format-metrics.ts
@@ -1,14 +1,18 @@
+/** Format a CPU percentage as a rounded whole-number string (e.g. "42%"). */
 export function formatCpu(cpuPct: number): string {
   return `${Math.round(cpuPct)}%`;
 }
 
+/** Format a byte count as MB, switching to GB past 1024 MB. */
 export function formatMem(memBytes: number): string {
   const mb = memBytes / (1024 * 1024);
   return mb >= 1024 ? `${(mb / 1024).toFixed(1)} GB` : `${Math.round(mb)} MB`;
 }
 
-// Smooth sparkline path, auto-scaled to the window peak. Catmull-Rom spline with
-// control points clamped per segment so the curve never overshoots the data.
+/**
+ * Smooth sparkline path, auto-scaled to the window peak. Catmull-Rom spline with
+ * control points clamped per segment so the curve never overshoots the data.
+ */
 export function sparklinePath(values: number[], width: number, height: number): string {
   if (values.length < 2) return "";
   const max = Math.max(...values, 1);

--- a/packages/serve-sim/src/client/utils/sim-endpoint.ts
+++ b/packages/serve-sim/src/client/utils/sim-endpoint.ts
@@ -9,6 +9,7 @@ declare global {
       device: string;
       basePath: string;
       axEndpoint?: string;
+      metricsEndpoint?: string;
       cameraStatusEndpoint?: string;
       appStateEndpoint?: string;
       eventLogEndpoint?: string;

--- a/packages/serve-sim/src/cpu-mem-sampler.ts
+++ b/packages/serve-sim/src/cpu-mem-sampler.ts
@@ -229,7 +229,14 @@ export class MetricsSampler {
     this.prev = { t, bundleId: reading.bundleId, cpuSeconds: reading.cpuSeconds };
 
     const sample: MetricSample = { t, bundleId: reading.bundleId, cpuPct, memBytes: reading.memBytes };
-    for (const listener of this.listeners) listener(sample);
+    for (const listener of this.listeners) {
+      try {
+        listener(sample);
+      } catch {
+        // A failing subscriber (e.g. a write to an already-closed SSE response)
+        // must not starve the other viewers of this sample.
+      }
+    }
     return sample;
   }
 

--- a/packages/serve-sim/src/cpu-mem-sampler.ts
+++ b/packages/serve-sim/src/cpu-mem-sampler.ts
@@ -115,6 +115,7 @@ export interface SampleDeps {
   frontmostApp?: (udid: string) => Promise<FrontmostApp | null>;
 }
 
+/** Run a host command with a bounded timeout and output buffer, resolving its stdout. */
 const runCommand = (file: string, args: string[]): Promise<string> =>
   execFileAsync(file, args, { timeout: 3000, maxBuffer: 8 * 1024 * 1024 }).then((r) => r.stdout);
 
@@ -203,6 +204,7 @@ export class MetricsSampler {
   // Previous reading, to turn cumulative CPU time into a per-interval %.
   private prev: { t: number; bundleId: string | null; cpuSeconds: number } | null = null;
 
+  /** Build a sampler for one udid, resolving the interval, clock, and host core count. */
   constructor(opts: MetricsSamplerOptions) {
     this.intervalMs = opts.intervalMs ?? 1000;
     this.sample = opts.sample ?? sampleUserApp;
@@ -215,6 +217,7 @@ export class MetricsSampler {
     };
   }
 
+  /** Number of active subscribers. */
   get listenerCount(): number {
     return this.listeners.size;
   }

--- a/packages/serve-sim/src/cpu-mem-sampler.ts
+++ b/packages/serve-sim/src/cpu-mem-sampler.ts
@@ -48,12 +48,12 @@ interface PsRow {
   appPath: string; // the `.app` bundle this process runs from (host app + its extensions share it)
 }
 
-// `ps` cputime is `[HH:]MM:SS.ss` cumulative CPU time; fold it down to seconds.
+/** `ps` cputime is `[HH:]MM:SS.ss` cumulative CPU time; fold it down to seconds. */
 function cputimeToSeconds(cputime: string): number {
   return cputime.split(":").reduce((acc, part) => acc * 60 + Number(part), 0);
 }
 
-// Processes running from the sim's Containers/Bundle path (the user apps), not the ~190 system daemons.
+/** Processes running from the sim's Containers/Bundle path (the user apps), not the ~190 system daemons. */
 function parseUserAppRows(output: string, udid: string): PsRow[] {
   const device = `/Devices/${udid}/`.toUpperCase();
   const rows: PsRow[] = [];
@@ -70,9 +70,11 @@ function parseUserAppRows(output: string, udid: string): PsRow[] {
   return rows;
 }
 
-// Aggregate the user app's processes. When the frontmost pid maps to a user app, narrow to just
-// that app's `.app` bundle (its host process + extensions). Otherwise sum every user app on the
-// sim (nothing user-facing is foreground). Null only when no user app is running at all.
+/**
+ * Aggregate the user app's processes. When the frontmost pid maps to a user app, narrow to just
+ * that app's `.app` bundle (its host process + extensions). Otherwise sum every user app on the
+ * sim (nothing user-facing is foreground). Null only when no user app is running at all.
+ */
 export function findUserAppProcesses(
   output: string,
   udid: string,
@@ -91,7 +93,7 @@ export function findUserAppProcesses(
   };
 }
 
-// Sum the per-process `phys_footprint: <n> B` lines (skips _peak and the Summary line).
+/** Sum the per-process `phys_footprint: <n> B` lines (skips _peak and the Summary line). */
 export function sumPhysFootprintBytes(output: string): number | null {
   let bytes = 0;
   let found = false;
@@ -116,6 +118,7 @@ export interface SampleDeps {
 const runCommand = (file: string, args: string[]): Promise<string> =>
   execFileAsync(file, args, { timeout: 3000, maxBuffer: 8 * 1024 * 1024 }).then((r) => r.stdout);
 
+/** Resolve the sim's frontmost app (pid + bundleId) via the AX bridge; null when it can't be read. */
 async function frontmostAppOf(udid: string): Promise<FrontmostApp | null> {
   try {
     const { pid, bundleId } = JSON.parse(await axFrontmostAsync(udid)) as {
@@ -129,10 +132,12 @@ async function frontmostAppOf(udid: string): Promise<FrontmostApp | null> {
   }
 }
 
-// CPU side: the app's processes + their %CPU, and which app they belong to. `ps` and the
-// frontmost probe don't depend on each other, so they run together. bundleId is the frontmost
-// app when it's a user app, else null (the numbers then cover every user app). Null only when
-// no user app is running.
+/**
+ * CPU side: the app's processes + their %CPU, and which app they belong to. `ps` and the
+ * frontmost probe don't depend on each other, so they run together. bundleId is the frontmost
+ * app when it's a user app, else null (the numbers then cover every user app). Null only when
+ * no user app is running.
+ */
 async function sampleForegroundApp(
   udid: string,
   deps: Required<SampleDeps>,
@@ -148,8 +153,10 @@ async function sampleForegroundApp(
   return { procs, bundleId };
 }
 
-// Memory side: phys_footprint of the app's processes. Depends on the pids the CPU
-// side found, so it can't start until those are known; RSS is the fallback.
+/**
+ * Memory side: phys_footprint of the app's processes. Depends on the pids the CPU
+ * side found, so it can't start until those are known; RSS is the fallback.
+ */
 async function sampleMemoryBytes(procs: AppProcesses, deps: Required<SampleDeps>): Promise<number> {
   try {
     const output = await deps.exec("footprint", ["--noCategories", "--format", "bytes", ...procs.pids.map(String)]);
@@ -160,6 +167,7 @@ async function sampleMemoryBytes(procs: AppProcesses, deps: Required<SampleDeps>
   }
 }
 
+/** One poll of the foreground user app: its cumulative CPU time, memory, and the bundleId they belong to. */
 export async function sampleUserApp(udid: string, deps: SampleDeps = {}): Promise<AppUsage | null> {
   const resolved: Required<SampleDeps> = {
     exec: deps.exec ?? runCommand,
@@ -182,7 +190,7 @@ export interface MetricsSamplerOptions {
   hostCores?: number;
 }
 
-// Polls the sim and fans samples out; reschedules only after each tick settles, so ticks never overlap.
+/** Polls the sim and fans samples out; reschedules only after each tick settles, so ticks never overlap. */
 export class MetricsSampler {
   readonly meta: MetricsMeta;
 
@@ -211,11 +219,13 @@ export class MetricsSampler {
     return this.listeners.size;
   }
 
+  /** Subscribe to samples; returns an unsubscribe function. */
   onSample(listener: (sample: MetricSample) => void): () => void {
     this.listeners.add(listener);
     return () => this.listeners.delete(listener);
   }
 
+  /** Poll once, derive the interval %CPU, and fan the sample out to every listener. */
   async tickOnce(): Promise<MetricSample | null> {
     this.startedAt ??= this.now();
     // Timestamp the observation up front: sample() reads cumulative CPU via `ps` before the slower
@@ -240,9 +250,11 @@ export class MetricsSampler {
     return sample;
   }
 
-  // %CPU over the interval since the previous reading, from the delta in cumulative CPU time.
-  // Zero on the first tick or right after an app switch (no comparable baseline); a drop in
-  // cumulative time (a process exited) clamps to zero rather than going negative.
+  /**
+   * %CPU over the interval since the previous reading, from the delta in cumulative CPU time.
+   * Zero on the first tick or right after an app switch (no comparable baseline); a drop in
+   * cumulative time (a process exited) clamps to zero rather than going negative.
+   */
   private cpuPctSince(reading: AppUsage, t: number): number {
     const prev = this.prev;
     if (!prev || prev.bundleId !== reading.bundleId || t <= prev.t) return 0;
@@ -250,6 +262,7 @@ export class MetricsSampler {
     return pct > 0 ? +pct.toFixed(1) : 0;
   }
 
+  /** Begin the poll loop; a no-op if it is already running. */
   start(): void {
     if (this.timer) return;
     this.startedAt ??= this.now();
@@ -260,6 +273,7 @@ export class MetricsSampler {
     this.timer = setTimeout(loop, this.intervalMs);
   }
 
+  /** Stop the poll loop. */
   stop(): void {
     if (this.timer) {
       clearTimeout(this.timer);
@@ -275,7 +289,7 @@ export interface MetricsSubscription {
 
 export type MetricsSamplerCache = ReturnType<typeof createMetricsSamplerCache>;
 
-// One shared sampler per udid (like the ax streamer cache); ref-counted by subscribers.
+/** One shared sampler per udid (like the ax streamer cache); ref-counted by subscribers. */
 export function createMetricsSamplerCache(
   makeSampler: (udid: string) => MetricsSampler = (udid) => new MetricsSampler({ udid }),
 ) {

--- a/packages/serve-sim/src/cpu-mem-sampler.ts
+++ b/packages/serve-sim/src/cpu-mem-sampler.ts
@@ -1,14 +1,14 @@
 // CPU/mem of the user's app on a booted sim, measured host-side. %CPU is per-core (can exceed 100)
 // and computed from the delta in the app's cumulative CPU time between ticks, so it reflects usage
 // during the interval rather than ps's decaying ~1-minute average. Scopes to the foreground app via
-// axFrontmost, tagging each sample with its bundleId (null when nothing user-facing is foreground,
-// in which case the numbers cover every user app). Memory is phys_footprint, with an RSS fallback.
+// the foreground tracker, tagging each sample with its bundleId (null when nothing user-facing is
+// foreground, in which case the numbers cover every user app). Memory is phys_footprint, RSS fallback.
 
 import { execFile } from "node:child_process";
 import { cpus } from "node:os";
 import { promisify } from "node:util";
 
-import { axFrontmostAsync } from "./native";
+import { foregroundTracker, frontmostAppViaAx, type ForegroundApp } from "./foreground-tracker";
 
 const execFileAsync = promisify(execFile);
 
@@ -17,6 +17,7 @@ export const METRICS_SCHEMA_VERSION = 1;
 // One poll's raw reading: cumulative CPU time (the sampler diffs it into a %) and current memory.
 export interface AppUsage {
   bundleId: string | null; // the foreground app these numbers belong to, or null for all user apps
+  processKey: string; // identity of the sampled pid set; the CPU baseline resets when it changes
   cpuSeconds: number;
   memBytes: number;
 }
@@ -53,19 +54,24 @@ function cputimeToSeconds(cputime: string): number {
   return cputime.split(":").reduce((acc, part) => acc * 60 + Number(part), 0);
 }
 
-/** Processes running from the sim's Containers/Bundle path (the user apps), not the ~190 system daemons. */
+/**
+ * Processes whose executable runs from the sim's Containers/Bundle path (the user apps), not the
+ * ~190 system daemons. Matches on `comm=` (the executable) rather than `args=`, so a host process
+ * that merely passes a sim bundle path as an argument isn't miscounted.
+ */
 function parseUserAppRows(output: string, udid: string): PsRow[] {
   const device = `/Devices/${udid}/`.toUpperCase();
   const rows: PsRow[] = [];
   for (const line of output.split("\n")) {
+    // pid, cputime, rss, then comm= (the executable path, which can contain spaces).
     const m = /^\s*(\d+)\s+([\d:.]+)\s+(\d+)\s+(.*)$/.exec(line);
     if (!m) continue;
-    const args = m[4]!;
-    const upper = args.toUpperCase();
+    const exe = m[4]!;
+    const upper = exe.toUpperCase();
     if (!upper.includes(device) || !upper.includes("/CONTAINERS/BUNDLE/APPLICATION/")) continue;
     // First `.app` in the exec path; extensions live under it (…/MyApp.app/PlugIns/X.appex/X).
-    const app = /^(.*?\.app)\//.exec(args);
-    rows.push({ pid: +m[1]!, cpuSeconds: cputimeToSeconds(m[2]!), rssKb: +m[3]!, appPath: app ? app[1]! : args });
+    const app = /^(.*?\.app)\//.exec(exe);
+    rows.push({ pid: +m[1]!, cpuSeconds: cputimeToSeconds(m[2]!), rssKb: +m[3]!, appPath: app ? app[1]! : exe });
   }
   return rows;
 }
@@ -104,33 +110,20 @@ export function sumPhysFootprintBytes(output: string): number | null {
   return found ? bytes : null;
 }
 
-export interface FrontmostApp {
-  pid: number;
-  bundleId: string;
-}
-
 // Injected so tests can drive sampleUserApp without spawning real processes.
 export interface SampleDeps {
   exec?: (file: string, args: string[]) => Promise<string>;
-  frontmostApp?: (udid: string) => Promise<FrontmostApp | null>;
+  frontmostApp?: (udid: string) => Promise<ForegroundApp | null>;
 }
 
 /** Run a host command with a bounded timeout and output buffer, resolving its stdout. */
 const runCommand = (file: string, args: string[]): Promise<string> =>
   execFileAsync(file, args, { timeout: 3000, maxBuffer: 8 * 1024 * 1024 }).then((r) => r.stdout);
 
-/** Resolve the sim's frontmost app (pid + bundleId) via the AX bridge; null when it can't be read. */
-async function frontmostAppOf(udid: string): Promise<FrontmostApp | null> {
-  try {
-    const { pid, bundleId } = JSON.parse(await axFrontmostAsync(udid)) as {
-      pid?: number;
-      bundleId?: string;
-    };
-    return pid != null && bundleId ? { pid, bundleId } : null;
-  } catch {
-    // AX bridge warming up or unreachable: skip this tick (caller returns null).
-    return null;
-  }
+/** The current foreground app: the tracker when it's warm, else the AX bridge; null when unknown. */
+function frontmostAppOf(udid: string): Promise<ForegroundApp | null> {
+  const tracked = foregroundTracker.peek(udid);
+  return tracked ? Promise.resolve(tracked) : frontmostAppViaAx(udid);
 }
 
 /**
@@ -144,7 +137,7 @@ async function sampleForegroundApp(
   deps: Required<SampleDeps>,
 ): Promise<{ procs: AppProcesses; bundleId: string | null } | null> {
   const [psOutput, frontmost] = await Promise.all([
-    deps.exec("ps", ["-axo", "pid=,cputime=,rss=,args="]).catch(() => null),
+    deps.exec("ps", ["-axo", "pid=,cputime=,rss=,comm="]).catch(() => null),
     deps.frontmostApp(udid),
   ]);
   if (psOutput == null) return null;
@@ -178,6 +171,7 @@ export async function sampleUserApp(udid: string, deps: SampleDeps = {}): Promis
   if (!foreground) return null;
   return {
     bundleId: foreground.bundleId,
+    processKey: [...foreground.procs.pids].sort((a, b) => a - b).join(","),
     cpuSeconds: foreground.procs.cpuSeconds,
     memBytes: await sampleMemoryBytes(foreground.procs, resolved),
   };
@@ -202,7 +196,7 @@ export class MetricsSampler {
   private timer: ReturnType<typeof setTimeout> | null = null;
   private startedAt: number | null = null;
   // Previous reading, to turn cumulative CPU time into a per-interval %.
-  private prev: { t: number; bundleId: string | null; cpuSeconds: number } | null = null;
+  private prev: { t: number; bundleId: string | null; processKey: string; cpuSeconds: number } | null = null;
 
   /** Build a sampler for one udid, resolving the interval, clock, and host core count. */
   constructor(opts: MetricsSamplerOptions) {
@@ -239,7 +233,7 @@ export class MetricsSampler {
     if (!reading) return null;
 
     const cpuPct = this.cpuPctSince(reading, t);
-    this.prev = { t, bundleId: reading.bundleId, cpuSeconds: reading.cpuSeconds };
+    this.prev = { t, bundleId: reading.bundleId, processKey: reading.processKey, cpuSeconds: reading.cpuSeconds };
 
     const sample: MetricSample = { t, bundleId: reading.bundleId, cpuPct, memBytes: reading.memBytes };
     for (const listener of this.listeners) {
@@ -255,12 +249,14 @@ export class MetricsSampler {
 
   /**
    * %CPU over the interval since the previous reading, from the delta in cumulative CPU time.
-   * Zero on the first tick or right after an app switch (no comparable baseline); a drop in
-   * cumulative time (a process exited) clamps to zero rather than going negative.
+   * Zero on the first tick, an app switch, or a changed process set (no comparable baseline, since
+   * cumulative CPU is per-process); a drop in cumulative time (a process exited) clamps to zero.
    */
   private cpuPctSince(reading: AppUsage, t: number): number {
     const prev = this.prev;
-    if (!prev || prev.bundleId !== reading.bundleId || t <= prev.t) return 0;
+    if (!prev || prev.bundleId !== reading.bundleId || prev.processKey !== reading.processKey || t <= prev.t) {
+      return 0;
+    }
     const pct = ((reading.cpuSeconds - prev.cpuSeconds) / ((t - prev.t) / 1000)) * 100;
     return pct > 0 ? +pct.toFixed(1) : 0;
   }

--- a/packages/serve-sim/src/cpu-mem-sampler.ts
+++ b/packages/serve-sim/src/cpu-mem-sampler.ts
@@ -202,7 +202,7 @@ export class MetricsSampler {
   constructor(opts: MetricsSamplerOptions) {
     this.intervalMs = opts.intervalMs ?? 1000;
     this.sample = opts.sample ?? sampleUserApp;
-    this.now = opts.now ?? Date.now;
+    this.now = opts.now ?? (() => performance.now()); // monotonic: immune to NTP clock jumps in the CPU delta
     this.meta = {
       schemaVersion: METRICS_SCHEMA_VERSION,
       udid: opts.udid,

--- a/packages/serve-sim/src/cpu-mem-sampler.ts
+++ b/packages/serve-sim/src/cpu-mem-sampler.ts
@@ -1,0 +1,299 @@
+// CPU/mem of the user's app on a booted sim, measured host-side. %CPU is per-core (can exceed 100)
+// and computed from the delta in the app's cumulative CPU time between ticks, so it reflects usage
+// during the interval rather than ps's decaying ~1-minute average. Scopes to the foreground app via
+// axFrontmost, tagging each sample with its bundleId (null when nothing user-facing is foreground,
+// in which case the numbers cover every user app). Memory is phys_footprint, with an RSS fallback.
+
+import { execFile } from "node:child_process";
+import { cpus } from "node:os";
+import { promisify } from "node:util";
+
+import { axFrontmostAsync } from "./native";
+
+const execFileAsync = promisify(execFile);
+
+export const METRICS_SCHEMA_VERSION = 1;
+
+// One poll's raw reading: cumulative CPU time (the sampler diffs it into a %) and current memory.
+export interface AppUsage {
+  bundleId: string | null; // the foreground app these numbers belong to, or null for all user apps
+  cpuSeconds: number;
+  memBytes: number;
+}
+
+export interface MetricSample {
+  t: number; // ms since the sampler started
+  bundleId: string | null;
+  cpuPct: number; // usage over the interval since the previous sample (per-core, can exceed 100)
+  memBytes: number;
+}
+
+export interface MetricsMeta {
+  schemaVersion: number;
+  udid: string;
+  hostCores: number;
+  sampleIntervalMs: number;
+}
+
+export interface AppProcesses {
+  pids: number[];
+  cpuSeconds: number;
+  rssKb: number;
+}
+
+interface PsRow {
+  pid: number;
+  cpuSeconds: number;
+  rssKb: number;
+  appPath: string; // the `.app` bundle this process runs from (host app + its extensions share it)
+}
+
+// `ps` cputime is `[HH:]MM:SS.ss` cumulative CPU time; fold it down to seconds.
+function cputimeToSeconds(cputime: string): number {
+  return cputime.split(":").reduce((acc, part) => acc * 60 + Number(part), 0);
+}
+
+// Processes running from the sim's Containers/Bundle path (the user apps), not the ~190 system daemons.
+function parseUserAppRows(output: string, udid: string): PsRow[] {
+  const device = `/Devices/${udid}/`.toUpperCase();
+  const rows: PsRow[] = [];
+  for (const line of output.split("\n")) {
+    const m = /^\s*(\d+)\s+([\d:.]+)\s+(\d+)\s+(.*)$/.exec(line);
+    if (!m) continue;
+    const args = m[4]!;
+    const upper = args.toUpperCase();
+    if (!upper.includes(device) || !upper.includes("/CONTAINERS/BUNDLE/APPLICATION/")) continue;
+    // First `.app` in the exec path; extensions live under it (…/MyApp.app/PlugIns/X.appex/X).
+    const app = /^(.*?\.app)\//.exec(args);
+    rows.push({ pid: +m[1]!, cpuSeconds: cputimeToSeconds(m[2]!), rssKb: +m[3]!, appPath: app ? app[1]! : args });
+  }
+  return rows;
+}
+
+// Aggregate the user app's processes. When the frontmost pid maps to a user app, narrow to just
+// that app's `.app` bundle (its host process + extensions). Otherwise sum every user app on the
+// sim (nothing user-facing is foreground). Null only when no user app is running at all.
+export function findUserAppProcesses(
+  output: string,
+  udid: string,
+  frontmostPid?: number,
+): AppProcesses | null {
+  const rows = parseUserAppRows(output, udid);
+  if (!rows.length) return null;
+
+  const front = frontmostPid != null ? rows.find((r) => r.pid === frontmostPid) : undefined;
+  const scoped = front ? rows.filter((r) => r.appPath === front.appPath) : rows;
+
+  return {
+    pids: scoped.map((r) => r.pid),
+    cpuSeconds: scoped.reduce((sum, r) => sum + r.cpuSeconds, 0),
+    rssKb: scoped.reduce((sum, r) => sum + r.rssKb, 0),
+  };
+}
+
+// Sum the per-process `phys_footprint: <n> B` lines (skips _peak and the Summary line).
+export function sumPhysFootprintBytes(output: string): number | null {
+  let bytes = 0;
+  let found = false;
+  for (const m of output.matchAll(/^\s*phys_footprint:\s+(\d+) B$/gm)) {
+    bytes += +m[1]!;
+    found = true;
+  }
+  return found ? bytes : null;
+}
+
+export interface FrontmostApp {
+  pid: number;
+  bundleId: string;
+}
+
+// Injected so tests can drive sampleUserApp without spawning real processes.
+export interface SampleDeps {
+  exec?: (file: string, args: string[]) => Promise<string>;
+  frontmostApp?: (udid: string) => Promise<FrontmostApp | null>;
+}
+
+const runCommand = (file: string, args: string[]): Promise<string> =>
+  execFileAsync(file, args, { timeout: 3000, maxBuffer: 8 * 1024 * 1024 }).then((r) => r.stdout);
+
+async function frontmostAppOf(udid: string): Promise<FrontmostApp | null> {
+  try {
+    const { pid, bundleId } = JSON.parse(await axFrontmostAsync(udid)) as {
+      pid?: number;
+      bundleId?: string;
+    };
+    return pid != null && bundleId ? { pid, bundleId } : null;
+  } catch {
+    // AX bridge warming up or unreachable: skip this tick (caller returns null).
+    return null;
+  }
+}
+
+// CPU side: the app's processes + their %CPU, and which app they belong to. `ps` and the
+// frontmost probe don't depend on each other, so they run together. bundleId is the frontmost
+// app when it's a user app, else null (the numbers then cover every user app). Null only when
+// no user app is running.
+async function sampleForegroundApp(
+  udid: string,
+  deps: Required<SampleDeps>,
+): Promise<{ procs: AppProcesses; bundleId: string | null } | null> {
+  const [psOutput, frontmost] = await Promise.all([
+    deps.exec("ps", ["-axo", "pid=,cputime=,rss=,args="]).catch(() => null),
+    deps.frontmostApp(udid),
+  ]);
+  if (psOutput == null) return null;
+  const procs = findUserAppProcesses(psOutput, udid, frontmost?.pid);
+  if (!procs) return null;
+  const bundleId = frontmost && procs.pids.includes(frontmost.pid) ? frontmost.bundleId : null;
+  return { procs, bundleId };
+}
+
+// Memory side: phys_footprint of the app's processes. Depends on the pids the CPU
+// side found, so it can't start until those are known; RSS is the fallback.
+async function sampleMemoryBytes(procs: AppProcesses, deps: Required<SampleDeps>): Promise<number> {
+  try {
+    const output = await deps.exec("footprint", ["--noCategories", "--format", "bytes", ...procs.pids.map(String)]);
+    return sumPhysFootprintBytes(output) ?? procs.rssKb * 1024;
+  } catch {
+    // footprint can exit non-zero (all pids gone mid-tick); keep the RSS fallback.
+    return procs.rssKb * 1024;
+  }
+}
+
+export async function sampleUserApp(udid: string, deps: SampleDeps = {}): Promise<AppUsage | null> {
+  const resolved: Required<SampleDeps> = {
+    exec: deps.exec ?? runCommand,
+    frontmostApp: deps.frontmostApp ?? frontmostAppOf,
+  };
+  const foreground = await sampleForegroundApp(udid, resolved);
+  if (!foreground) return null;
+  return {
+    bundleId: foreground.bundleId,
+    cpuSeconds: foreground.procs.cpuSeconds,
+    memBytes: await sampleMemoryBytes(foreground.procs, resolved),
+  };
+}
+
+export interface MetricsSamplerOptions {
+  udid: string;
+  intervalMs?: number;
+  sample?: (udid: string) => Promise<AppUsage | null>;
+  now?: () => number;
+  hostCores?: number;
+}
+
+// Polls the sim and fans samples out; reschedules only after each tick settles, so ticks never overlap.
+export class MetricsSampler {
+  readonly meta: MetricsMeta;
+
+  private readonly intervalMs: number;
+  private readonly sample: (udid: string) => Promise<AppUsage | null>;
+  private readonly now: () => number;
+  private readonly listeners = new Set<(sample: MetricSample) => void>();
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private startedAt: number | null = null;
+  // Previous reading, to turn cumulative CPU time into a per-interval %.
+  private prev: { t: number; bundleId: string | null; cpuSeconds: number } | null = null;
+
+  constructor(opts: MetricsSamplerOptions) {
+    this.intervalMs = opts.intervalMs ?? 1000;
+    this.sample = opts.sample ?? sampleUserApp;
+    this.now = opts.now ?? Date.now;
+    this.meta = {
+      schemaVersion: METRICS_SCHEMA_VERSION,
+      udid: opts.udid,
+      hostCores: opts.hostCores ?? cpus().length,
+      sampleIntervalMs: this.intervalMs,
+    };
+  }
+
+  get listenerCount(): number {
+    return this.listeners.size;
+  }
+
+  onSample(listener: (sample: MetricSample) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  async tickOnce(): Promise<MetricSample | null> {
+    this.startedAt ??= this.now();
+    // Timestamp the observation up front: sample() reads cumulative CPU via `ps` before the slower
+    // footprint probe, so anchoring the delta here (not after sample() returns) keeps variable
+    // footprint latency out of the elapsed-time denominator — otherwise it distorts CPU%.
+    const t = this.now() - this.startedAt;
+    const reading = await this.sample(this.meta.udid);
+    if (!reading) return null;
+
+    const cpuPct = this.cpuPctSince(reading, t);
+    this.prev = { t, bundleId: reading.bundleId, cpuSeconds: reading.cpuSeconds };
+
+    const sample: MetricSample = { t, bundleId: reading.bundleId, cpuPct, memBytes: reading.memBytes };
+    for (const listener of this.listeners) listener(sample);
+    return sample;
+  }
+
+  // %CPU over the interval since the previous reading, from the delta in cumulative CPU time.
+  // Zero on the first tick or right after an app switch (no comparable baseline); a drop in
+  // cumulative time (a process exited) clamps to zero rather than going negative.
+  private cpuPctSince(reading: AppUsage, t: number): number {
+    const prev = this.prev;
+    if (!prev || prev.bundleId !== reading.bundleId || t <= prev.t) return 0;
+    const pct = ((reading.cpuSeconds - prev.cpuSeconds) / ((t - prev.t) / 1000)) * 100;
+    return pct > 0 ? +pct.toFixed(1) : 0;
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.startedAt ??= this.now();
+    const loop = async (): Promise<void> => {
+      await this.tickOnce().catch(() => {});
+      if (this.timer) this.timer = setTimeout(loop, this.intervalMs);
+    };
+    this.timer = setTimeout(loop, this.intervalMs);
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+}
+
+export interface MetricsSubscription {
+  meta: MetricsMeta;
+  unsubscribe: () => void;
+}
+
+export type MetricsSamplerCache = ReturnType<typeof createMetricsSamplerCache>;
+
+// One shared sampler per udid (like the ax streamer cache); ref-counted by subscribers.
+export function createMetricsSamplerCache(
+  makeSampler: (udid: string) => MetricsSampler = (udid) => new MetricsSampler({ udid }),
+) {
+  const byUdid = new Map<string, MetricsSampler>();
+  return {
+    subscribe(udid: string, listener: (sample: MetricSample) => void): MetricsSubscription {
+      let sampler = byUdid.get(udid);
+      if (!sampler) {
+        sampler = makeSampler(udid);
+        byUdid.set(udid, sampler);
+        sampler.start();
+      }
+      const off = sampler.onSample(listener);
+      return {
+        meta: sampler.meta,
+        unsubscribe: () => {
+          off();
+          // Identity-guard the eviction: a double-called or stale unsubscribe must not
+          // delete a replacement sampler that a later subscriber created for this udid.
+          if (sampler.listenerCount === 0 && byUdid.get(udid) === sampler) {
+            sampler.stop();
+            byUdid.delete(udid);
+          }
+        },
+      };
+    },
+  };
+}

--- a/packages/serve-sim/src/cpu-mem-sampler.ts
+++ b/packages/serve-sim/src/cpu-mem-sampler.ts
@@ -265,11 +265,19 @@ export class MetricsSampler {
   start(): void {
     if (this.timer) return;
     this.startedAt ??= this.now();
+    // Track this loop's own timer identity: a stop()+start() during an in-flight tick would make
+    // this.timer truthy again, so a bare `if (this.timer)` check would schedule a second, overlapping
+    // loop. Reschedule only while this.timer still points at the timer this loop last set.
+    let currentTimer: ReturnType<typeof setTimeout>;
     const loop = async (): Promise<void> => {
       await this.tickOnce().catch(() => {});
-      if (this.timer) this.timer = setTimeout(loop, this.intervalMs);
+      if (this.timer === currentTimer) {
+        currentTimer = setTimeout(loop, this.intervalMs);
+        this.timer = currentTimer;
+      }
     };
-    this.timer = setTimeout(loop, this.intervalMs);
+    currentTimer = setTimeout(loop, this.intervalMs);
+    this.timer = currentTimer;
   }
 
   /** Stop the poll loop. */

--- a/packages/serve-sim/src/foreground-tracker.ts
+++ b/packages/serve-sim/src/foreground-tracker.ts
@@ -20,11 +20,12 @@ export interface ForegroundApp {
 const NON_UI_BUNDLE_RE =
   /(^|\.)(WidgetRenderer|ExtensionHost|Service|PlaceholderApp|InCallService|CallUI|InCallUI)(\.|$)|\.extension(\.|$)|com\.apple\.(Preferences\.Cellular|purplebuddy|chrono|shuttle|usernotificationsui)/i;
 
+/** True unless the bundle id is a non-UI helper (widget, extension, or background service). */
 export function isUserFacingBundle(bundleId: string): boolean {
   return !NON_UI_BUNDLE_RE.test(bundleId);
 }
 
-// e.g. "[app<com.apple.mobilesafari>:43117] Setting process visibility to: Foreground"
+/** Parse a SpringBoard visibility line, e.g. `[app<com.apple.mobilesafari>:43117] Setting process visibility to: Foreground`. */
 export function parseForegroundAppLogMessage(message: string): ForegroundApp | null {
   const match = /\[app<([^>]+)>:(\d+)\] Setting process visibility to: Foreground/.exec(message);
   if (!match) return null;
@@ -34,6 +35,7 @@ export function parseForegroundAppLogMessage(message: string): ForegroundApp | n
 const LINE_BUFFER_LIMIT = 1024 * 1024; // drop a pathological unbroken line rather than grow forever
 const RESTART_DELAY_MS = 1000; // bound the respawn rate when the log stream keeps dying (e.g. sim gone)
 
+/** Spawn the SpringBoard foreground-transition log stream for a device. */
 function spawnForegroundLogStream(udid: string): ChildProcess {
   return spawn(
     "xcrun",
@@ -48,8 +50,10 @@ function spawnForegroundLogStream(udid: string): ChildProcess {
   );
 }
 
-// The current frontmost app via the AX bridge; null when it can't be read (the common
-// browser-driven case). Used only to seed a fresh tail, since its feed is edge-triggered.
+/**
+ * The current frontmost app via the AX bridge; null when it can't be read (the common
+ * browser-driven case). Used only to seed a fresh tail, since its feed is edge-triggered.
+ */
 export async function frontmostAppViaAx(udid: string): Promise<ForegroundApp | null> {
   try {
     const { pid, bundleId } = JSON.parse(await axFrontmostAsync(udid)) as {
@@ -80,27 +84,33 @@ class ForegroundTracker {
   private restartTimer: ReturnType<typeof setTimeout> | null = null;
   private readonly listeners = new Set<(app: ForegroundApp) => void>();
 
+  /** Build a tracker for one udid, with injected spawn/frontmost/backoff deps. */
   constructor(
     private readonly udid: string,
     private readonly deps: Required<ForegroundTrackerDeps>,
   ) {}
 
+  /** Latest known foreground app, or null if none has been seen yet. */
   get current(): ForegroundApp | null {
     return this.latest;
   }
 
+  /** Number of active listeners (used for ref-counted eviction). */
   get listenerCount(): number {
     return this.listeners.size;
   }
 
+  /** Register a change listener. */
   add(listener: (app: ForegroundApp) => void): void {
     this.listeners.add(listener);
   }
 
+  /** Unregister a change listener. */
   remove(listener: (app: ForegroundApp) => void): void {
     this.listeners.delete(listener);
   }
 
+  /** Begin tailing: seed the current app from the AX bridge, then spawn the log stream. */
   start(): void {
     if (this.child) return;
     this.stopped = false;
@@ -115,6 +125,7 @@ class ForegroundTracker {
     this.spawn();
   }
 
+  /** Spawn the log stream and wire its output and exit handling. */
   private spawn(): void {
     const child = this.deps.spawnLogStream(this.udid);
     this.child = child;
@@ -123,8 +134,10 @@ class ForegroundTracker {
     child.on("exit", () => this.onChildGone());
   }
 
-  // The log-stream child died. Unless we asked it to, respawn at a bounded rate while subscribers
-  // remain, so a sim restart or a dropped stream doesn't leave the foreground signal permanently stale.
+  /**
+   * The log-stream child died. Unless we asked it to, respawn at a bounded rate while subscribers
+   * remain, so a sim restart or a dropped stream doesn't leave the foreground signal permanently stale.
+   */
   private onChildGone(): void {
     if (this.stopped || this.restartTimer) return;
     this.child = null;
@@ -135,6 +148,7 @@ class ForegroundTracker {
     }, this.deps.restartDelayMs);
   }
 
+  /** Stop tailing and cancel any pending respawn. */
   stop(): void {
     this.stopped = true;
     if (this.restartTimer) {
@@ -147,6 +161,7 @@ class ForegroundTracker {
     this.buf = "";
   }
 
+  /** Assemble log lines from a stdout chunk and adopt any foreground transitions. */
   private consume(text: string): void {
     this.buf += text;
     let nl: number;
@@ -166,8 +181,10 @@ class ForegroundTracker {
     if (this.buf.length > LINE_BUFFER_LIMIT) this.buf = "";
   }
 
-  // Adopt a new foreground app, ignoring non-UI bundles and exact repeats. Compares pid too, so a
-  // same-bundle relaunch refreshes the pid the sampler scopes by.
+  /**
+   * Adopt a new foreground app, ignoring non-UI bundles and exact repeats. Compares pid too, so a
+   * same-bundle relaunch refreshes the pid the sampler scopes by.
+   */
   private set(app: ForegroundApp): void {
     if (!isUserFacingBundle(app.bundleId)) return;
     if (app.bundleId === this.latest?.bundleId && app.pid === this.latest.pid) return;
@@ -188,8 +205,10 @@ export interface ForegroundSubscription {
 
 export type ForegroundTrackerCache = ReturnType<typeof createForegroundTrackerCache>;
 
-// One shared foreground tail per udid, ref-counted by subscribers (mirrors the metrics sampler
-// cache). The `log stream` child runs only while something is subscribed.
+/**
+ * One shared foreground tail per udid, ref-counted by subscribers (mirrors the metrics sampler
+ * cache). The `log stream` child runs only while something is subscribed.
+ */
 export function createForegroundTrackerCache(deps: ForegroundTrackerDeps = {}) {
   const resolved: Required<ForegroundTrackerDeps> = {
     spawnLogStream: deps.spawnLogStream ?? spawnForegroundLogStream,
@@ -198,12 +217,14 @@ export function createForegroundTrackerCache(deps: ForegroundTrackerDeps = {}) {
   };
   const byUdid = new Map<string, ForegroundTracker>();
   return {
-    // Latest known foreground app for a udid, or null when nothing is tracking it.
+    /** Latest known foreground app for a udid, or null when nothing is tracking it. */
     peek(udid: string): ForegroundApp | null {
       return byUdid.get(udid)?.current ?? null;
     },
-    // Subscribe to foreground changes (or just keep the tail warm with no listener). New listeners
-    // are notified on future changes only; read `peek` for the current value.
+    /**
+     * Subscribe to foreground changes (or just keep the tail warm with no listener). New listeners
+     * are notified on future changes only; read `peek` for the current value.
+     */
     subscribe(udid: string, onChange?: (app: ForegroundApp) => void): ForegroundSubscription {
       let tracker = byUdid.get(udid);
       if (!tracker) {

--- a/packages/serve-sim/src/foreground-tracker.ts
+++ b/packages/serve-sim/src/foreground-tracker.ts
@@ -1,0 +1,228 @@
+// Tracks the sim's foreground user app by tailing SpringBoard's visibility log. This is
+// focus-independent, unlike axFrontmost (which only resolves when the Simulator window is the
+// focused macOS app, so it's null when driving from a browser). One shared tail per udid feeds
+// both the /appstate stream and the CPU/mem sampler's per-app scoping.
+
+import { spawn, type ChildProcess } from "node:child_process";
+
+import { axFrontmostAsync } from "./native";
+
+// The foreground user app: `pid` is the frontmost process, `bundleId` its app.
+export interface ForegroundApp {
+  pid: number;
+  bundleId: string;
+}
+
+// SpringBoard logs these as "Foreground" but they aren't the visible user-facing app (widgets,
+// extensions, background services); tracking them would flicker the signal mid app-launch.
+const NON_UI_BUNDLE_RE =
+  /(WidgetRenderer|ExtensionHost|\.extension(\.|$)|Service|PlaceholderApp|InCallService|CallUI|InCallUI|com\.apple\.Preferences\.Cellular|com\.apple\.purplebuddy|com\.apple\.chrono|com\.apple\.shuttle|com\.apple\.usernotificationsui)/i;
+
+export function isUserFacingBundle(bundleId: string): boolean {
+  return !NON_UI_BUNDLE_RE.test(bundleId);
+}
+
+// e.g. "[app<com.apple.mobilesafari>:43117] Setting process visibility to: Foreground"
+export function parseForegroundAppLogMessage(message: string): ForegroundApp | null {
+  const match = /\[app<([^>]+)>:(\d+)\] Setting process visibility to: Foreground/.exec(message);
+  if (!match) return null;
+  return { bundleId: match[1]!, pid: parseInt(match[2]!, 10) };
+}
+
+const LINE_BUFFER_LIMIT = 1024 * 1024; // drop a pathological unbroken line rather than grow forever
+const RESTART_DELAY_MS = 1000; // bound the respawn rate when the log stream keeps dying (e.g. sim gone)
+
+function spawnForegroundLogStream(udid: string): ChildProcess {
+  return spawn(
+    "xcrun",
+    [
+      "simctl", "spawn", udid, "log", "stream",
+      "--style", "ndjson",
+      "--level", "info",
+      "--predicate",
+      'process == "SpringBoard" AND eventMessage CONTAINS "Setting process visibility to: Foreground"',
+    ],
+    { stdio: ["ignore", "pipe", "ignore"] },
+  );
+}
+
+// The current frontmost app via the AX bridge; null when it can't be read (the common
+// browser-driven case). Used only to seed a fresh tail, since its feed is edge-triggered.
+export async function frontmostAppViaAx(udid: string): Promise<ForegroundApp | null> {
+  try {
+    const { pid, bundleId } = JSON.parse(await axFrontmostAsync(udid)) as {
+      pid?: number;
+      bundleId?: string;
+    };
+    return pid != null && bundleId ? { pid, bundleId } : null;
+  } catch {
+    return null;
+  }
+}
+
+// Injected so tests can drive the tracker without a booted simulator.
+export interface ForegroundTrackerDeps {
+  spawnLogStream?: (udid: string) => ChildProcess;
+  frontmostApp?: (udid: string) => Promise<ForegroundApp | null>;
+  restartDelayMs?: number;
+}
+
+// Tails one SpringBoard foreground feed for a udid, holding the latest user-facing app and
+// notifying listeners on change. Seeds from the AX bridge on start (a no-op unless the sim window
+// is focused) because the log feed only emits on transitions.
+class ForegroundTracker {
+  private child: ChildProcess | null = null;
+  private buf = "";
+  private latest: ForegroundApp | null = null;
+  private stopped = false;
+  private restartTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly listeners = new Set<(app: ForegroundApp) => void>();
+
+  constructor(
+    private readonly udid: string,
+    private readonly deps: Required<ForegroundTrackerDeps>,
+  ) {}
+
+  get current(): ForegroundApp | null {
+    return this.latest;
+  }
+
+  get listenerCount(): number {
+    return this.listeners.size;
+  }
+
+  add(listener: (app: ForegroundApp) => void): void {
+    this.listeners.add(listener);
+  }
+
+  remove(listener: (app: ForegroundApp) => void): void {
+    this.listeners.delete(listener);
+  }
+
+  start(): void {
+    if (this.child) return;
+    this.stopped = false;
+    // Seed from the AX bridge (a no-op unless the sim window is focused). Only apply it while we
+    // still have nothing, so a log event that arrives first isn't overwritten by the slower seed.
+    this.deps
+      .frontmostApp(this.udid)
+      .then((app) => {
+        if (app && this.latest === null) this.set(app);
+      })
+      .catch(() => {});
+    this.spawn();
+  }
+
+  private spawn(): void {
+    const child = this.deps.spawnLogStream(this.udid);
+    this.child = child;
+    child.stdout?.on("data", (chunk: Buffer) => this.consume(chunk.toString()));
+    child.on("error", () => this.onChildGone());
+    child.on("exit", () => this.onChildGone());
+  }
+
+  // The log-stream child died. Unless we asked it to, respawn at a bounded rate while subscribers
+  // remain, so a sim restart or a dropped stream doesn't leave the foreground signal permanently stale.
+  private onChildGone(): void {
+    if (this.stopped || this.restartTimer) return;
+    this.child = null;
+    if (this.listeners.size === 0) return;
+    this.restartTimer = setTimeout(() => {
+      this.restartTimer = null;
+      if (!this.stopped && !this.child && this.listeners.size > 0) this.spawn();
+    }, this.deps.restartDelayMs);
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.restartTimer) {
+      clearTimeout(this.restartTimer);
+      this.restartTimer = null;
+    }
+    this.child?.stdout?.destroy();
+    this.child?.kill();
+    this.child = null;
+    this.buf = "";
+  }
+
+  private consume(text: string): void {
+    this.buf += text;
+    let nl: number;
+    while ((nl = this.buf.indexOf("\n")) !== -1) {
+      const line = this.buf.slice(0, nl).trim();
+      this.buf = this.buf.slice(nl + 1);
+      if (!line) continue;
+      let message: string;
+      try {
+        message = JSON.parse(line).eventMessage ?? "";
+      } catch {
+        continue;
+      }
+      const app = parseForegroundAppLogMessage(message);
+      if (app) this.set(app);
+    }
+    if (this.buf.length > LINE_BUFFER_LIMIT) this.buf = "";
+  }
+
+  // Adopt a new foreground app, ignoring non-UI bundles and exact repeats. Compares pid too, so a
+  // same-bundle relaunch refreshes the pid the sampler scopes by.
+  private set(app: ForegroundApp): void {
+    if (!isUserFacingBundle(app.bundleId)) return;
+    if (app.bundleId === this.latest?.bundleId && app.pid === this.latest.pid) return;
+    this.latest = app;
+    for (const listener of this.listeners) {
+      try {
+        listener(app);
+      } catch {
+        // A failing listener must not stop the others from seeing the change.
+      }
+    }
+  }
+}
+
+export interface ForegroundSubscription {
+  unsubscribe: () => void;
+}
+
+export type ForegroundTrackerCache = ReturnType<typeof createForegroundTrackerCache>;
+
+// One shared foreground tail per udid, ref-counted by subscribers (mirrors the metrics sampler
+// cache). The `log stream` child runs only while something is subscribed.
+export function createForegroundTrackerCache(deps: ForegroundTrackerDeps = {}) {
+  const resolved: Required<ForegroundTrackerDeps> = {
+    spawnLogStream: deps.spawnLogStream ?? spawnForegroundLogStream,
+    frontmostApp: deps.frontmostApp ?? frontmostAppViaAx,
+    restartDelayMs: deps.restartDelayMs ?? RESTART_DELAY_MS,
+  };
+  const byUdid = new Map<string, ForegroundTracker>();
+  return {
+    // Latest known foreground app for a udid, or null when nothing is tracking it.
+    peek(udid: string): ForegroundApp | null {
+      return byUdid.get(udid)?.current ?? null;
+    },
+    // Subscribe to foreground changes (or just keep the tail warm with no listener). New listeners
+    // are notified on future changes only; read `peek` for the current value.
+    subscribe(udid: string, onChange?: (app: ForegroundApp) => void): ForegroundSubscription {
+      let tracker = byUdid.get(udid);
+      if (!tracker) {
+        tracker = new ForegroundTracker(udid, resolved);
+        byUdid.set(udid, tracker);
+        tracker.start();
+      }
+      const listener = onChange ?? (() => {});
+      tracker.add(listener);
+      return {
+        unsubscribe: () => {
+          tracker.remove(listener);
+          // Identity-guard the eviction so a stale unsubscribe can't stop a replacement tail.
+          if (tracker.listenerCount === 0 && byUdid.get(udid) === tracker) {
+            tracker.stop();
+            byUdid.delete(udid);
+          }
+        },
+      };
+    },
+  };
+}
+
+export const foregroundTracker = createForegroundTrackerCache();

--- a/packages/serve-sim/src/foreground-tracker.ts
+++ b/packages/serve-sim/src/foreground-tracker.ts
@@ -14,9 +14,11 @@ export interface ForegroundApp {
 }
 
 // SpringBoard logs these as "Foreground" but they aren't the visible user-facing app (widgets,
-// extensions, background services); tracking them would flicker the signal mid app-launch.
+// extensions, background services); tracking them would flicker the signal mid app-launch. Generic
+// names match as whole bundle components (delimited by `.`), so a real app like
+// com.example.CustomerService isn't caught by the "Service" substring.
 const NON_UI_BUNDLE_RE =
-  /(WidgetRenderer|ExtensionHost|\.extension(\.|$)|Service|PlaceholderApp|InCallService|CallUI|InCallUI|com\.apple\.Preferences\.Cellular|com\.apple\.purplebuddy|com\.apple\.chrono|com\.apple\.shuttle|com\.apple\.usernotificationsui)/i;
+  /(^|\.)(WidgetRenderer|ExtensionHost|Service|PlaceholderApp|InCallService|CallUI|InCallUI)(\.|$)|\.extension(\.|$)|com\.apple\.(Preferences\.Cellular|purplebuddy|chrono|shuttle|usernotificationsui)/i;
 
 export function isUserFacingBundle(bundleId: string): boolean {
   return !NON_UI_BUNDLE_RE.test(bundleId);
@@ -209,7 +211,9 @@ export function createForegroundTrackerCache(deps: ForegroundTrackerDeps = {}) {
         byUdid.set(udid, tracker);
         tracker.start();
       }
-      const listener = onChange ?? (() => {});
+      // Wrap so each subscription is a distinct registration even when callers reuse a callback,
+      // otherwise a Set would collapse them and one unsubscribe could stop a still-watched tracker.
+      const listener = (app: ForegroundApp) => onChange?.(app);
       tracker.add(listener);
       return {
         unsubscribe: () => {

--- a/packages/serve-sim/src/middleware.ts
+++ b/packages/serve-sim/src/middleware.ts
@@ -12,6 +12,7 @@ import type { Socket } from "net";
 // importing the dependency keeps the proxy working regardless of runtime.
 import { WebSocket } from "ws";
 import { createAxStreamerCache } from "./ax";
+import { createMetricsSamplerCache, type MetricsSamplerCache } from "./cpu-mem-sampler";
 import { readCameraStatus } from "./camera-helper";
 import { getDeviceSession, closeDeviceSession, type HidSocket } from "./device-session";
 import {
@@ -109,6 +110,7 @@ type ExecRequestBody = { command?: string };
 export type ServeSimState = ServeSimDeviceState;
 
 const axStreamerCache = createAxStreamerCache();
+const metricsSamplerCache = createMetricsSamplerCache();
 
 // Hard cap on the SSE line-assembly buffer for child-process stdout.
 // A malformed log entry without a newline can't grow this beyond 1 MB;
@@ -876,6 +878,7 @@ export function previewConfigForState(
   eventLogEndpoint: string;
   eventLogEventsEndpoint: string;
   axEndpoint: string;
+  metricsEndpoint: string;
   cameraStatusEndpoint: string;
   devtoolsEndpoint: string;
   serveSimBin: string;
@@ -897,6 +900,7 @@ export function previewConfigForState(
     eventLogEndpoint: endpoint(base, "/api/event-log", state.device),
     eventLogEventsEndpoint: endpoint(base, "/api/event-log/events", state.device),
     axEndpoint: endpoint(base, "/ax", state.device),
+    metricsEndpoint: endpoint(base, "/metrics", state.device),
     cameraStatusEndpoint: `${base === "/" ? "" : base}/helper/${encodeURIComponent(state.device)}/camera/status`,
     devtoolsEndpoint: endpoint(base, "/devtools", state.device),
     serveSimBin,
@@ -1286,6 +1290,38 @@ function isJsonContentType(value: string | undefined): boolean {
  *   GET  {basePath}/api     — serve-sim state JSON
  *   GET  {basePath}/ax      — SSE stream of normalized accessibility snapshots
  */
+export function handleMetricsRequest(
+  req: SimReq,
+  res: SimRes,
+  state: ServeSimState | null,
+  samplerCache: MetricsSamplerCache = metricsSamplerCache,
+): void {
+  if (!state) {
+    res.writeHead(404);
+    res.end("No serve-sim device");
+    return;
+  }
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
+    "X-Accel-Buffering": "no",
+  });
+  res.write(":\n\n");
+  const { meta, unsubscribe } = samplerCache.subscribe(state.device, (sample) => {
+    if (!res.writableEnded) res.write("data: " + JSON.stringify(sample) + "\n\n");
+  });
+  res.write("event: meta\ndata: " + JSON.stringify(meta) + "\n\n");
+  // Heartbeat keeps an idle stream alive through buffering proxies.
+  const heartbeat = setInterval(() => {
+    if (!res.writableEnded) res.write(":\n\n");
+  }, 15000);
+  req.on("close", () => {
+    clearInterval(heartbeat);
+    unsubscribe();
+  });
+}
+
 export function simMiddleware(options?: SimMiddlewareOptions): SimMiddleware {
   const base = (options?.basePath ?? "/.sim").replace(/\/+$/, "");
   const helperPrefix = helperProxyPrefix(base);
@@ -1900,6 +1936,16 @@ export function simMiddleware(options?: SimMiddlewareOptions): SimMiddleware {
       return;
     }
 
+    // GET /metrics — SSE stream of the foreground app's CPU/memory. Mirrors /ax:
+    // an `event: meta` frame first (schema, udid, host cores, cadence), then one
+    // `data:` line per sample. One sampler per udid fans out to every viewer.
+    if (url === base + "/metrics") {
+      const states = await readServeSimStates();
+      const state = selectServeSimState(states, selectedDevice);
+      handleMetricsRequest(req, res, state, metricsSamplerCache);
+      return;
+    }
+
     // POST /exec — run a shell command on the host. Gated by a per-process
     // bearer token injected only into the same-origin preview HTML, with
     // Content-Type + Origin checks to block CORS-simple CSRF (a malicious
@@ -2114,6 +2160,7 @@ export function simMiddleware(options?: SimMiddlewareOptions): SimMiddleware {
       `${base}/api/event-log/events`,
       `${base}/appstate`,
       `${base}/ax`,
+      `${base}/metrics`,
     ],
     onUiRequest: handleUiRequest,
     onCommandResult: (command, result) => recordCommandEvent(command, result),

--- a/packages/serve-sim/src/middleware.ts
+++ b/packages/serve-sim/src/middleware.ts
@@ -2032,11 +2032,13 @@ export function simMiddleware(options?: SimMiddlewareOptions): SimMiddleware {
       // SpringBoard's foreground feed is edge-triggered, so a fresh subscriber sees nothing until
       // the next app switch. The shared tracker seeds itself from the AX bridge on start, so replay
       // its current app (once known) before streaming changes.
-      let lastBundle = "";
+      let lastApp: ForegroundApp | null = null;
       let generation = 0;
       const emit = async (app: ForegroundApp) => {
-        if (app.bundleId === lastBundle || res.writableEnded) return;
-        lastBundle = app.bundleId;
+        // Dedup on bundleId and pid: the tracker emits same-bundle relaunches with a fresh pid, and
+        // clients need the live pid.
+        if (res.writableEnded || (app.bundleId === lastApp?.bundleId && app.pid === lastApp.pid)) return;
+        lastApp = app;
         // detectReactNative is awaited, so a later switch can resolve first; only write if no newer
         // emit has started, otherwise a slow lookup could overwrite the client with a stale app.
         const generationAtStart = ++generation;

--- a/packages/serve-sim/src/middleware.ts
+++ b/packages/serve-sim/src/middleware.ts
@@ -1,5 +1,5 @@
 import { readdirSync, readFileSync, existsSync, unlinkSync, watch, type FSWatcher } from "fs";
-import { execSync, spawn, exec, execFile, type ChildProcess, type ExecException } from "child_process";
+import { execSync, exec, execFile, type ExecException } from "child_process";
 import { tmpdir } from "os";
 import { join } from "path";
 import { createServer as createNetServer } from "net";
@@ -13,6 +13,7 @@ import type { Socket } from "net";
 import { WebSocket } from "ws";
 import { createAxStreamerCache } from "./ax";
 import { createMetricsSamplerCache, type MetricsSamplerCache } from "./cpu-mem-sampler";
+import { foregroundTracker, type ForegroundApp, type ForegroundTrackerCache } from "./foreground-tracker";
 import { readCameraStatus } from "./camera-helper";
 import { getDeviceSession, closeDeviceSession, type HidSocket } from "./device-session";
 import {
@@ -21,7 +22,6 @@ import {
   recordEventLogEvent,
   subscribeEventLog,
 } from "./event-log";
-import { axFrontmostAsync } from "./native";
 import { inProcessServeSimState, writeServeSimState, type ServeSimDeviceState } from "./state";
 import { debugMw } from "./debug";
 import {
@@ -112,10 +112,6 @@ export type ServeSimState = ServeSimDeviceState;
 const axStreamerCache = createAxStreamerCache();
 const metricsSamplerCache = createMetricsSamplerCache();
 
-// Hard cap on the SSE line-assembly buffer for child-process stdout.
-// A malformed log entry without a newline can't grow this beyond 1 MB;
-// the partial line is dropped rather than retained indefinitely.
-const SSE_LINE_BUFFER_LIMIT = 1024 * 1024;
 let inspectWebKitBridge: Promise<WebKitBridge> | null = null;
 
 function eventLogLimit(rawUrl: string): number | undefined {
@@ -156,16 +152,6 @@ const RN_MARKERS = [
   "main.jsbundle",
 ];
 
-// Processes that SpringBoard logs as "Foreground" but are not the visible
-// user-facing app — widgets, extensions, background services. Emitting
-// these to the client causes the app indicator to flicker as the user
-// actually-foreground app switches mid-launch.
-const NON_UI_BUNDLE_RE = /(WidgetRenderer|ExtensionHost|\.extension(\.|$)|Service|PlaceholderApp|InCallService|CallUI|InCallUI|com\.apple\.Preferences\.Cellular|com\.apple\.purplebuddy|com\.apple\.chrono|com\.apple\.shuttle|com\.apple\.usernotificationsui)/i;
-
-function isUserFacingBundle(bundleId: string): boolean {
-  return !NON_UI_BUNDLE_RE.test(bundleId);
-}
-
 function isSimulatorUdid(value: string): boolean {
   return /^[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}$/i.test(value);
 }
@@ -192,13 +178,6 @@ function classifyStaleState(
     return state.pid === selfPid ? "recycle-self" : "recycle-helper";
   }
   return "keep";
-}
-
-export function parseForegroundAppLogMessage(message: string): { bundleId: string; pid: number } | null {
-  // e.g. "[app<com.apple.mobilesafari>:43117] Setting process visibility to: Foreground"
-  const match = /\[app<([^>]+)>:(\d+)\] Setting process visibility to: Foreground/.exec(message);
-  if (!match) return null;
-  return { bundleId: match[1]!, pid: parseInt(match[2]!, 10) };
 }
 
 function detectReactNative(udid: string, bundleId: string): Promise<boolean> {
@@ -1295,6 +1274,7 @@ export function handleMetricsRequest(
   res: SimRes,
   state: ServeSimState | null,
   samplerCache: MetricsSamplerCache = metricsSamplerCache,
+  tracker: ForegroundTrackerCache = foregroundTracker,
 ): void {
   if (!state) {
     res.writeHead(404);
@@ -1308,6 +1288,9 @@ export function handleMetricsRequest(
     "X-Accel-Buffering": "no",
   });
   res.write(":\n\n");
+  // Keep the foreground tail warm for this stream's lifetime so the sampler can scope to the
+  // current app even when no /appstate client is open.
+  const foreground = tracker.subscribe(state.device);
   const { meta, unsubscribe } = samplerCache.subscribe(state.device, (sample) => {
     if (!res.writableEnded) res.write("data: " + JSON.stringify(sample) + "\n\n");
   });
@@ -1319,6 +1302,7 @@ export function handleMetricsRequest(
   req.on("close", () => {
     clearInterval(heartbeat);
     unsubscribe();
+    foreground.unsubscribe();
   });
 }
 
@@ -2045,71 +2029,26 @@ export function simMiddleware(options?: SimMiddlewareOptions): SimMiddleware {
       });
       res.write(":\n\n");
 
-      // Bootstrap: SpringBoard's log feed is edge-triggered, so a fresh
-      // subscriber would otherwise see nothing until the user re-foregrounds
-      // an app (the bug: tools couldn't reconnect after a page reload). Ask
-      // the helper's AX bridge for the current frontmost app via
-      // `proc_pidpath`+Info.plist resolution and emit it before tailing.
+      // SpringBoard's foreground feed is edge-triggered, so a fresh subscriber sees nothing until
+      // the next app switch. The shared tracker seeds itself from the AX bridge on start, so replay
+      // its current app (once known) before streaming changes.
       let lastBundle = "";
-      try {
-        const info = JSON.parse(await axFrontmostAsync(udid)) as { bundleId?: string; pid?: number };
-        if (!info.bundleId || !isUserFacingBundle(info.bundleId)) return;
-        if (res.writableEnded) return;
-        lastBundle = info.bundleId;
-        const isReactNative = await detectReactNative(udid, info.bundleId);
-        if (res.writableEnded) return;
-        res.write("data: " + JSON.stringify({ bundleId: info.bundleId, pid: info.pid, isReactNative }) + "\n\n");
-      } catch {
-        // AX bridge may be warming up — the log tail fills in once anything moves.
-      }
-
-      const child: ChildProcess = spawn("xcrun", [
-        "simctl", "spawn", udid, "log", "stream",
-        "--style", "ndjson",
-        "--level", "info",
-        "--predicate",
-        'process == "SpringBoard" AND eventMessage CONTAINS "Setting process visibility to: Foreground"',
-      ], { stdio: ["ignore", "pipe", "ignore"] });
-
-      let closed = false;
-      const emitApp = async (bundleId: string, pid?: number) => {
-        if (!isUserFacingBundle(bundleId)) return;
-        if (bundleId === lastBundle) return;
-        lastBundle = bundleId;
-        const isReactNative = await detectReactNative(udid, bundleId);
-        if (!closed) {
-          res.write("data: " + JSON.stringify({ bundleId, pid, isReactNative }) + "\n\n");
+      let generation = 0;
+      const emit = async (app: ForegroundApp) => {
+        if (app.bundleId === lastBundle || res.writableEnded) return;
+        lastBundle = app.bundleId;
+        // detectReactNative is awaited, so a later switch can resolve first; only write if no newer
+        // emit has started, otherwise a slow lookup could overwrite the client with a stale app.
+        const generationAtStart = ++generation;
+        const isReactNative = await detectReactNative(udid, app.bundleId);
+        if (!res.writableEnded && generationAtStart === generation) {
+          res.write("data: " + JSON.stringify({ bundleId: app.bundleId, pid: app.pid, isReactNative }) + "\n\n");
         }
       };
-
-
-      let buf = "";
-      child.stdout!.on("data", (chunk: Buffer) => {
-        buf += chunk.toString();
-        let nl: number;
-        while ((nl = buf.indexOf("\n")) !== -1) {
-          const line = buf.slice(0, nl).trim();
-          buf = buf.slice(nl + 1);
-          if (!line) continue;
-          let msg: string;
-          try { msg = JSON.parse(line).eventMessage ?? ""; } catch { continue; }
-          const event = parseForegroundAppLogMessage(msg);
-          if (!event) continue;
-          emitApp(event.bundleId, event.pid);
-        }
-        if (buf.length > SSE_LINE_BUFFER_LIMIT) buf = "";
-      });
-
-      child.on("error", () => {
-        closed = true;
-        try { res.end(); } catch {}
-      });
-      child.on("close", () => res.end());
-      req.on("close", () => {
-        closed = true;
-        child.stdout?.destroy();
-        child.kill();
-      });
+      const subscription = foregroundTracker.subscribe(udid, (app) => void emit(app));
+      const current = foregroundTracker.peek(udid);
+      if (current) void emit(current);
+      req.on("close", () => subscription.unsubscribe());
       return;
     }
 


### PR DESCRIPTION
Live CPU/memory for the app on a booted sim: a sampler, a `/metrics` SSE endpoint, and an "Activity" panel with a sparkline. Built in Expo's fork, seems worth having upstream.

- Scopes to the foreground app (`axFrontmostAsync`); one sampler per udid, shared across viewers.
- CPU is per-core from the delta in cumulative CPU time (usage over the interval, not `ps`'s ~1-min average); memory is `phys_footprint` with an RSS fallback.
- `/metrics` mirrors `/ax`: an `event: meta` frame, then one `data:` sample per line.
- The panel is app-scoped: it shows the running user app and goes idle — with a hover tooltip on the reason — when a system app is in the foreground, rather than a stale graph.
- Prior art: host-side CPU like Instruments/[Appium](https://appium.readthedocs.io/en/latest/en/writing-running-appium/ios/ios-xctest-performance/), `phys_footprint`+RSS like [Sentry's iOS SDK](https://github.com/getsentry/sentry-cocoa/blob/main/Sources/Sentry/SentrySystemWrapper.mm).

Cross-origin reads of `/metrics` for a hosted dashboard are a separate opt-in: #134.

Tests, lint, and native build pass. Verified live against a running app on a booted simulator.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a live “Activity” section to the tools panel with CPU/memory readouts, sparklines, and idle/waiting messaging.
  * Introduced a device-scoped `/metrics` SSE stream that provides metadata and streams sampled activity, with shared sampling across concurrent viewers.
* **Bug Fixes**
  * Improved metrics streaming reliability, including proper stale/errored handling, safe recovery on failures, and prevention of overlapping polling.
  * Refined foreground app tracking used for metrics scoping, including accurate bundle attribution during app switches.
* **Tests**
  * Expanded Bun coverage for CPU/memory sampling, `/metrics` behavior, and cache lifecycle for both samplers and trackers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->