### PR TITLE
Add protected Cloudflare Quick Tunnel previews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 *.tsbuildinfo
 /packages/serve-sim/.xcode-build
 *.bun-build
+.playwright-mcp/

--- a/packages/serve-sim/README.md
+++ b/packages/serve-sim/README.md
@@ -40,6 +40,7 @@ Requires macOS with Xcode command line tools (`xcrun simctl`) and a [maintained 
 
 ```
 serve-sim [device...]                 Start preview server (default: localhost:3200)
+serve-sim --tunnel [device...]        Start a protected Cloudflare Quick Tunnel
 serve-sim --no-preview [device...]    Stream in foreground without a preview server
 serve-sim gesture '<json>' [-d udid]  Send a touch gesture
 serve-sim button [name] [-d udid]     Send a button press (default: home)
@@ -67,9 +68,11 @@ serve-sim camera --stop-webcam [-d udid]
 
 Options:
   -p, --port <port>   Starting port (preview default: 3200; helper default: 3100)
-  -d, --detach        Spawn helper and exit (daemon mode)
+  -d, --detach        Run the stream or public preview in background
   -q, --quiet         JSON-only output
       --no-preview    Skip the web UI; stream in foreground only
+      --tunnel        Publish an access-token-protected Cloudflare Quick Tunnel
+                      (alias: --public)
       --panes <panes> Initially open preview panes: devices, tools, devtools,
                       or none
       --fit           Initially size the simulator to fit the preview viewport
@@ -98,6 +101,8 @@ Camera options (used with `serve-sim camera <bundle-id>`):
 ```sh
 serve-sim                              # auto-detect booted sim, open preview
 serve-sim "iPhone 16 Pro"              # target a specific device
+serve-sim --tunnel                     # print a protected temporary public URL
+serve-sim --tunnel --detach            # keep the public preview in background
 serve-sim --detach                     # start a background helper, return JSON
 serve-sim --list                       # show running streams
 serve-sim --kill                       # stop all helpers
@@ -129,6 +134,24 @@ serve-sim camera --stop-webcam
 ```
 
 Multiple booted simulators are supported — pass several device names, or leave it empty to attach to all of them.
+
+### Public Quick Tunnels
+
+Use `--tunnel` (or its `--public` alias) to reach the full simulator preview from another computer or a mobile browser without exposing a LAN port or using a remote-desktop session:
+
+```sh
+brew install cloudflared
+serve-sim --tunnel
+# → Public: https://random-name.trycloudflare.com/?token=...
+```
+
+Open the complete printed URL on the remote device. Its URL token is exchanged for a secure, HTTP-only, host-only cookie on the browser's first request and then removed from the address bar. HTTP routes and WebSocket upgrades require that cookie, and browser control requests must come from the exact tunnel origin. The preview remains bound to `127.0.0.1`; only `cloudflared` can publish it.
+
+The complete URL is a credential. Anyone who has it can view and control the simulator and use preview features that run commands on the host. Keep it private and stop the tunnel when you are done. Quick Tunnels have no built-in identity login and are intended by Cloudflare for development and testing; use a managed Cloudflare Tunnel with Access when you need stable hostnames, user identity policies, or production guarantees.
+
+`cloudflared` must already be installed, but a Cloudflare account or login is not required. If the executable is missing, serve-sim exits before booting or exposing anything and prints the install command. A user-level Cloudflare configuration is bypassed because Cloudflare documents it as incompatible with Quick Tunnels.
+
+By default the tunnel is attached to serve-sim: `Ctrl+C` closes both processes. Add `--detach` to run it in the background; `serve-sim --kill` then stops the preview owner and its `cloudflared` child. Detached state and persistent diagnostics follow serve-sim's existing runtime-state convention under `$TMPDIR/serve-sim/` (`tunnel.json` and `tunnel.log`). The log records lifecycle and Cloudflare output but never the private access token.
 
 ### Camera
 

--- a/packages/serve-sim/src/__tests__/quick-tunnel.test.ts
+++ b/packages/serve-sim/src/__tests__/quick-tunnel.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, test } from "bun:test";
+import type { IncomingMessage } from "http";
+import {
+  authorizeTunnelRequest,
+  createTunnelAccessToken,
+  createQuickTunnelLaunchConfig,
+  detachedTunnelStartupTimeoutMs,
+  extractQuickTunnelUrl,
+  quickTunnelLaunchMatches,
+  quickTunnelMatchesDeviceStates,
+  stopDetachedProcessGroup,
+} from "../quick-tunnel";
+
+const TOKEN = "a".repeat(43);
+const PUBLIC_HOST = "preview-name.trycloudflare.com";
+
+function request(
+  url: string,
+  init: {
+    method?: string;
+    headers?: Record<string, string>;
+  } = {},
+): Pick<IncomingMessage, "method" | "url" | "headers"> {
+  return {
+    method: init.method ?? "GET",
+    url,
+    headers: {
+      host: PUBLIC_HOST,
+      "x-forwarded-proto": "https",
+      ...init.headers,
+    },
+  };
+}
+
+describe("Quick Tunnel access gate", () => {
+  test("creates a 256-bit URL-safe access token", () => {
+    const token = createTunnelAccessToken();
+    expect(token).toHaveLength(43);
+    expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  test("exchanges the private launch token for a secure host-only cookie", () => {
+    const decision = authorizeTunnelRequest(
+      request(`/?device=DEVICE-A&token=${TOKEN}`),
+      TOKEN,
+    );
+
+    expect(decision).toMatchObject({
+      type: "redirect",
+      status: 302,
+      location: "/?device=DEVICE-A",
+    });
+    if (decision.type !== "redirect") throw new Error("expected redirect");
+    expect(decision.cookie).toContain(`serve_sim_access=${TOKEN}`);
+    expect(decision.cookie).toContain("HttpOnly");
+    expect(decision.cookie).toContain("SameSite=Strict");
+    expect(decision.cookie).toContain("Secure");
+    expect(decision.cookie).not.toContain("Domain=");
+  });
+
+  test("accepts the access cookie for same-origin requests", () => {
+    const decision = authorizeTunnelRequest(
+      request("/grid/api/start", {
+        method: "POST",
+        headers: {
+          cookie: `serve_sim_access=${TOKEN}`,
+          origin: `https://${PUBLIC_HOST}`,
+        },
+      }),
+      TOKEN,
+    );
+
+    expect(decision).toEqual({ type: "allow" });
+  });
+
+  test("rejects missing credentials", () => {
+    expect(authorizeTunnelRequest(request("/"), TOKEN)).toMatchObject({
+      type: "deny",
+      status: 401,
+    });
+  });
+
+  test("rejects a sibling trycloudflare origin even with the cookie", () => {
+    expect(authorizeTunnelRequest(
+      request("/exec-ws", {
+        headers: {
+          cookie: `serve_sim_access=${TOKEN}`,
+          origin: "https://attacker.trycloudflare.com",
+        },
+      }),
+      TOKEN,
+      { allowTokenExchange: false },
+    )).toMatchObject({ type: "deny", status: 403 });
+  });
+
+  test("does not exchange query tokens during WebSocket upgrades", () => {
+    expect(authorizeTunnelRequest(
+      request(`/exec-ws?token=${TOKEN}`),
+      TOKEN,
+      { allowTokenExchange: false },
+    )).toMatchObject({ type: "deny", status: 401 });
+  });
+
+  test("allows credential-free loopback HTTP requests from local CLI state URLs", () => {
+    expect(authorizeTunnelRequest({
+      method: "GET",
+      url: "/api/event-log",
+      headers: { host: "127.0.0.1:3200" },
+    }, TOKEN, { allowLoopback: true })).toEqual({ type: "allow" });
+  });
+
+  test("allows credential-free loopback WebSocket upgrades from local CLI state URLs", () => {
+    expect(authorizeTunnelRequest({
+      method: "GET",
+      url: "/helper/DEVICE-A/ws",
+      headers: { host: "localhost:3200" },
+    }, TOKEN, {
+      allowLoopback: true,
+      allowTokenExchange: false,
+    })).toEqual({ type: "allow" });
+  });
+
+  test("does not treat forwarded public requests as loopback", () => {
+    expect(authorizeTunnelRequest({
+      method: "GET",
+      url: "/",
+      headers: {
+        host: "127.0.0.1:3200",
+        "x-forwarded-proto": "https",
+      },
+    }, TOKEN, { allowLoopback: true })).toMatchObject({
+      type: "deny",
+      status: 401,
+    });
+  });
+});
+
+describe("Quick Tunnel URL parsing", () => {
+  test("extracts a trycloudflare URL from cloudflared output", () => {
+    expect(extractQuickTunnelUrl(
+      "INF Your quick Tunnel has been created! Visit it at https://one-two-three.trycloudflare.com",
+    )).toBe("https://one-two-three.trycloudflare.com");
+  });
+
+  test("ignores unrelated URLs", () => {
+    expect(extractQuickTunnelUrl("INF Metrics server listening on 127.0.0.1:20241"))
+      .toBeNull();
+  });
+});
+
+describe("Quick Tunnel process ownership", () => {
+  const tunnel = {
+    ownerPid: 123,
+    cloudflaredPid: 456,
+    port: 3200,
+    publicUrl: `https://${PUBLIC_HOST}/?token=${TOKEN}`,
+    localUrl: `http://localhost:3200/?token=${TOKEN}`,
+    logFile: "/tmp/serve-sim/tunnel.log",
+    devices: ["DEVICE-A"],
+    startedAt: "2026-07-20T00:00:00.000Z",
+  };
+
+  test("accepts an owner matching current device state", () => {
+    expect(quickTunnelMatchesDeviceStates(tunnel, [{
+      pid: 123,
+      port: 3200,
+      device: "DEVICE-A",
+      url: "http://127.0.0.1:3200",
+      streamUrl: "http://127.0.0.1:3200/helper/DEVICE-A/stream.mjpeg",
+      wsUrl: "ws://127.0.0.1:3200/helper/DEVICE-A/ws",
+    }])).toBe(true);
+  });
+
+  test("rejects stale or reused owner PIDs", () => {
+    expect(quickTunnelMatchesDeviceStates(tunnel, [{
+      pid: 999,
+      port: 3200,
+      device: "DEVICE-A",
+      url: "http://127.0.0.1:3200",
+      streamUrl: "http://127.0.0.1:3200/helper/DEVICE-A/stream.mjpeg",
+      wsUrl: "ws://127.0.0.1:3200/helper/DEVICE-A/ws",
+    }])).toBe(false);
+  });
+
+  test("rejects partially stale multi-device ownership", () => {
+    expect(quickTunnelMatchesDeviceStates({
+      ...tunnel,
+      devices: ["DEVICE-A", "DEVICE-B"],
+    }, [{
+      pid: 123,
+      port: 3200,
+      device: "DEVICE-A",
+      url: "http://127.0.0.1:3200",
+      streamUrl: "http://127.0.0.1:3200/helper/DEVICE-A/stream.mjpeg",
+      wsUrl: "ws://127.0.0.1:3200/helper/DEVICE-A/ws",
+    }])).toBe(false);
+  });
+});
+
+describe("Quick Tunnel detached launch identity", () => {
+  const launch = createQuickTunnelLaunchConfig({
+    devices: ["DEVICE-A"],
+    port: 3200,
+    portExplicit: false,
+    codec: "mjpeg",
+    panes: ["devices", "tools"],
+    fit: true,
+    theme: "dark",
+  });
+
+  test("matches an identical request", () => {
+    expect(quickTunnelLaunchMatches({ launch }, launch)).toBe(true);
+  });
+
+  test.each([
+    ["device", { devices: ["DEVICE-B"] }],
+    ["port", { port: 3300 }],
+    ["explicit port", { portExplicit: true }],
+    ["codec", { codec: "auto" }],
+    ["panes", { panes: ["devices"] }],
+    ["fit", { fit: false }],
+    ["theme", { theme: "light" }],
+  ])("rejects a different %s request", (_name, change) => {
+    const requested = createQuickTunnelLaunchConfig({ ...launch, ...change });
+    expect(quickTunnelLaunchMatches({ launch }, requested)).toBe(false);
+  });
+
+  test("does not reuse legacy state without a launch signature", () => {
+    expect(quickTunnelLaunchMatches({}, launch)).toBe(false);
+  });
+});
+
+describe("Quick Tunnel detached startup lifecycle", () => {
+  test("budgets every simulator boot plus Cloudflare readiness", () => {
+    expect(detachedTunnelStartupTimeoutMs(1)).toBeGreaterThanOrEqual(90_000);
+    expect(detachedTunnelStartupTimeoutMs(2) - detachedTunnelStartupTimeoutMs(1))
+      .toBeGreaterThanOrEqual(60_000);
+  });
+
+  test("terminates the detached process group, not only the launcher child", () => {
+    const calls: Array<[number, NodeJS.Signals | number]> = [];
+    stopDetachedProcessGroup(4321, "SIGTERM", (pid, signal) => {
+      calls.push([pid, signal]);
+      return true;
+    });
+    expect(calls).toEqual([[-4321, "SIGTERM"]]);
+  });
+
+  test("falls back to the direct PID when group signalling fails", () => {
+    const calls: number[] = [];
+    stopDetachedProcessGroup(4321, "SIGTERM", (pid) => {
+      calls.push(pid);
+      if (pid < 0) throw new Error("missing group");
+      return true;
+    });
+    expect(calls).toEqual([-4321, 4321]);
+  });
+});

--- a/packages/serve-sim/src/__tests__/runtime-reexec.test.ts
+++ b/packages/serve-sim/src/__tests__/runtime-reexec.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { reExecCommand } from "../runtime";
+
+describe("reExecCommand", () => {
+  test("keeps an extensionless npm bin shim when running under Node", () => {
+    expect(reExecCommand(["--detach"], {
+      execPath: "/opt/homebrew/bin/node",
+      entrypoint: "/project/node_modules/.bin/serve-sim",
+    })).toEqual({
+      command: "/opt/homebrew/bin/node",
+      args: ["/project/node_modules/.bin/serve-sim", "--detach"],
+    });
+  });
+
+  test("keeps a source entrypoint when running under Bun", () => {
+    expect(reExecCommand(["--tunnel-child"], {
+      execPath: "/opt/homebrew/bin/bun",
+      entrypoint: "/project/packages/serve-sim/src/index.ts",
+    })).toEqual({
+      command: "/opt/homebrew/bin/bun",
+      args: ["/project/packages/serve-sim/src/index.ts", "--tunnel-child"],
+    });
+  });
+
+  test("re-executes a compiled binary without its virtual Bun entrypoint", () => {
+    expect(reExecCommand(["--tunnel-child"], {
+      execPath: "/project/packages/serve-sim/dist/serve-sim",
+      entrypoint: "/$bunfs/root/serve-sim",
+    })).toEqual({
+      command: "/project/packages/serve-sim/dist/serve-sim",
+      args: ["--tunnel-child"],
+    });
+  });
+});

--- a/packages/serve-sim/src/index.ts
+++ b/packages/serve-sim/src/index.ts
@@ -1,13 +1,24 @@
 #!/usr/bin/env node
-import { Command, InvalidArgumentError } from "commander";
+import { Command, InvalidArgumentError, Option } from "commander";
 import { execSync, spawn as nodeSpawn, type ChildProcess } from "child_process";
-import { existsSync, mkdirSync, openSync, closeSync, readSync, readFileSync, unlinkSync, writeFileSync } from "fs";
+import {
+  appendFileSync,
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  closeSync,
+  readSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
 import { createHash } from "crypto";
 import { networkInterfaces } from "os";
 import { join, resolve } from "path";
 import { STATE_DIR, stateFileForDevice, listStateFiles, inProcessServeSimState, type ServeSimDeviceState } from "./state";
 import { textToKeyEvents, UnsupportedCharacterError, sendKeyEventsToWs } from "./text-to-keys";
-import { dirnameOf, sleepSync, isPortFree, servePreview } from "./runtime";
+import { dirnameOf, sleepSync, isPortFree, reExecCommand, servePreview } from "./runtime";
 import { killPortHolder } from "./ports";
 import { findBootedDevice, resolveDevice } from "./device";
 import { permissions } from "./permissions";
@@ -31,6 +42,22 @@ import {
   readInjectedCameraBundles as readInjectedBundles,
   sendCameraHelperCommand as sendHelperCommand,
 } from "./camera-helper";
+import {
+  QUICK_TUNNEL_LOG_FILE,
+  clearQuickTunnelState,
+  createQuickTunnelLaunchConfig,
+  createTunnelAccessToken,
+  detachedTunnelStartupTimeoutMs,
+  findCloudflared,
+  protectTunnelMiddleware,
+  quickTunnelLaunchMatches,
+  quickTunnelMatchesDeviceStates,
+  readQuickTunnelState,
+  startQuickTunnel,
+  stopDetachedProcessGroup,
+  writeQuickTunnelState,
+  type QuickTunnelState,
+} from "./quick-tunnel";
 
 // `import.meta.dir` is Bun-only; resolve once via fileURLToPath so the bundled
 // CLI works under plain `node` too.
@@ -260,7 +287,8 @@ function isProcessAlive(pid: number): boolean {
 }
 
 /** Kill a process and wait for it to actually exit. */
-function stopProcess(pid: number): void {
+function stopProcess(pid: number, stillOwned?: () => boolean): void {
+  if (stillOwned && !stillOwned()) return;
   try { process.kill(pid, "SIGTERM"); } catch { return; }
   const deadline = Date.now() + 500;
   while (Date.now() < deadline) {
@@ -271,11 +299,26 @@ function stopProcess(pid: number): void {
       return;
     }
   }
+  // A persisted PID may have been replaced while we waited. Callers with an
+  // ownership record must revalidate it before escalation.
+  if (stillOwned && !stillOwned()) return;
   try { process.kill(pid, "SIGKILL"); } catch {}
   const deadline2 = Date.now() + 500;
   while (Date.now() < deadline2) {
     try { process.kill(pid, 0); sleepSync(25); } catch { return; }
   }
+}
+
+function quickTunnelStillOwned(expected: QuickTunnelState): boolean {
+  const current = readQuickTunnelState();
+  if (
+    !current ||
+    current.ownerPid !== expected.ownerPid ||
+    current.startedAt !== expected.startedAt
+  ) {
+    return false;
+  }
+  return quickTunnelMatchesDeviceStates(current, readAllStates());
 }
 
 function bootDevice(udid: string): void {
@@ -343,14 +386,128 @@ async function ensureBooted(udid: string): Promise<void> {
 
 // ─── Preview server lifecycle ───
 
-/** Resolve the command to re-exec this CLI (compiled binary or `node …js`). */
-function reExecArgs(extra: string[]): { command: string; args: string[] } {
-  // Compiled standalone binary: argv[0] is the serve-sim binary itself.
-  if (process.argv[0] && /(^|\/)serve-sim$/.test(process.argv[0])) {
-    return { command: process.argv[0], args: extra };
+async function detachTunnelPreview(options: {
+  devices: string[];
+  port: number;
+  portExplicit: boolean;
+  codec?: string;
+  initialState?: PreviewInitialState;
+  theme?: SimulatorTheme;
+}): Promise<QuickTunnelState> {
+  const requestedDevices = resolveTargetDevices(options.devices);
+  const requestedLaunch = createQuickTunnelLaunchConfig({
+    devices: requestedDevices,
+    port: options.port,
+    portExplicit: options.portExplicit,
+    codec: options.codec,
+    panes: options.initialState?.panes,
+    fit: options.initialState?.fit,
+    theme: options.theme,
+  });
+  const existing = readQuickTunnelState();
+  if (
+    existing &&
+    isProcessAlive(existing.ownerPid) &&
+    quickTunnelMatchesDeviceStates(existing, readAllStates())
+  ) {
+    if (quickTunnelLaunchMatches(existing, requestedLaunch)) return existing;
+    throw new Error(
+      "A detached Quick Tunnel is already running with different devices or preview options. " +
+      "Stop it with `serve-sim --kill` before starting another.",
+    );
   }
-  // Running the JS bundle: `node /path/to/serve-sim.js`.
-  return { command: process.argv[0]!, args: [process.argv[1]!, ...extra] };
+  clearQuickTunnelState();
+  ensureStateDir();
+  writeFileSync(
+    QUICK_TUNNEL_LOG_FILE,
+    `[${new Date().toISOString()}] [serve-sim] launching detached public preview\n`,
+    { mode: 0o600 },
+  );
+  chmodSync(QUICK_TUNNEL_LOG_FILE, 0o600);
+
+  const childArgs = ["--tunnel", "--tunnel-child"];
+  if (options.portExplicit) childArgs.push("--port", String(options.port));
+  if (options.codec) childArgs.push("--codec", options.codec);
+  if (options.initialState?.panes) {
+    childArgs.push(
+      "--panes",
+      options.initialState.panes.length > 0 ? options.initialState.panes.join(",") : "none",
+    );
+  }
+  if (options.initialState?.fit) childArgs.push("--fit");
+  if (options.theme) childArgs.push("--theme", options.theme);
+  childArgs.push(...requestedDevices);
+
+  const { command, args } = reExecCommand(childArgs);
+  const logFd = openSync(QUICK_TUNNEL_LOG_FILE, "a", 0o600);
+  let childPid: number | undefined;
+  const signalHandlers = new Map<NodeJS.Signals, () => void>();
+  const removeSignalHandlers = () => {
+    for (const [signal, handler] of signalHandlers) {
+      process.removeListener(signal, handler);
+    }
+    signalHandlers.clear();
+  };
+  const exitCodes: Record<"SIGHUP" | "SIGINT" | "SIGTERM", number> = {
+    SIGHUP: 129,
+    SIGINT: 130,
+    SIGTERM: 143,
+  };
+  for (const signal of ["SIGHUP", "SIGINT", "SIGTERM"] as const) {
+    const handler = () => {
+      if (childPid) stopDetachedProcessGroup(childPid);
+      removeSignalHandlers();
+      process.exit(exitCodes[signal]);
+    };
+    signalHandlers.set(signal, handler);
+    process.once(signal, handler);
+  }
+
+  const child = nodeSpawn(command, args, {
+    detached: true,
+    stdio: ["ignore", logFd, logFd],
+  });
+  closeSync(logFd);
+  child.unref();
+  if (!child.pid) {
+    removeSignalHandlers();
+    throw new Error("Failed to spawn detached public preview");
+  }
+  childPid = child.pid;
+
+  // Keep the host awake while a deliberately detached public preview exists.
+  // caffeinate exits automatically when the preview owner exits.
+  if (process.platform === "darwin" && existsSync("/usr/bin/caffeinate")) {
+    const caffeinate = nodeSpawn("/usr/bin/caffeinate", ["-i", "-w", String(child.pid)], {
+      detached: true,
+      stdio: "ignore",
+    });
+    caffeinate.unref();
+  }
+
+  try {
+    const deadline = Date.now() + detachedTunnelStartupTimeoutMs(requestedDevices.length);
+    while (Date.now() < deadline) {
+      const state = readQuickTunnelState();
+      if (
+        state?.ownerPid === child.pid &&
+        isProcessAlive(state.ownerPid) &&
+        quickTunnelMatchesDeviceStates(state, readAllStates()) &&
+        quickTunnelLaunchMatches(state, requestedLaunch)
+      ) {
+        return state;
+      }
+      if (!isProcessAlive(child.pid)) break;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  } finally {
+    removeSignalHandlers();
+  }
+
+  stopDetachedProcessGroup(child.pid);
+  let diagnostics = "";
+  try { diagnostics = readFileSync(QUICK_TUNNEL_LOG_FILE, "utf-8").slice(-16_000); } catch {}
+  throw new Error(`Detached public preview did not become ready.\n${diagnostics.trim()}`);
 }
 
 /** Poll for the state file a re-exec'd preview server writes once it's serving. */
@@ -383,7 +540,7 @@ async function startHelper(
 
   const logFile = join(STATE_DIR, `server-${udid}.log`);
   const logFd = openSync(logFile, "w");
-  const { command, args } = reExecArgs([udid, "--port", String(port), "--host", host]);
+  const { command, args } = reExecCommand([udid, "--port", String(port), "--host", host]);
   const child = nodeSpawn(command, args, {
     detached: opts.detach,
     stdio: ["ignore", logFd, logFd],
@@ -627,18 +784,42 @@ function killStreams(deviceArg?: string) {
       console.log(JSON.stringify({ disconnected: true, device: udid }));
       return;
     }
-    try { process.kill(state.pid, "SIGTERM"); } catch {}
+    const tunnel = readQuickTunnelState();
+    if (
+      tunnel &&
+      tunnel.ownerPid === state.pid &&
+      tunnel.port === state.port &&
+      tunnel.devices.includes(state.device) &&
+      quickTunnelStillOwned(tunnel)
+    ) {
+      stopProcess(tunnel.ownerPid, () => quickTunnelStillOwned(tunnel));
+      if (!isProcessAlive(tunnel.ownerPid)) clearQuickTunnelState(tunnel.ownerPid);
+    } else {
+      try { process.kill(state.pid, "SIGTERM"); } catch {}
+    }
     clearState(udid);
     console.log(JSON.stringify({ disconnected: true, device: state.device }));
   } else {
     const states = readAllStates();
+    const tunnel = readQuickTunnelState();
+    const tunnelOwned = !!tunnel && quickTunnelMatchesDeviceStates(tunnel, states);
+    if (tunnel && !tunnelOwned) clearQuickTunnelState();
     if (states.length === 0) {
       console.log(JSON.stringify({ disconnected: true, devices: [] }));
       return;
     }
     const devices: string[] = [];
+    const signaled = new Set<number>();
+    if (tunnel && tunnelOwned && quickTunnelStillOwned(tunnel)) {
+      stopProcess(tunnel.ownerPid, () => quickTunnelStillOwned(tunnel));
+      signaled.add(tunnel.ownerPid);
+      if (!isProcessAlive(tunnel.ownerPid)) clearQuickTunnelState(tunnel.ownerPid);
+    }
     for (const state of states) {
-      try { process.kill(state.pid, "SIGTERM"); } catch {}
+      if (!signaled.has(state.pid)) {
+        try { process.kill(state.pid, "SIGTERM"); } catch {}
+        signaled.add(state.pid);
+      }
       devices.push(state.device);
     }
     clearState();
@@ -1600,7 +1781,18 @@ async function serve(
   codec: string | undefined,
   initialState: PreviewInitialState | undefined,
   theme: SimulatorTheme | undefined,
+  tunnelMode = false,
+  detachedTunnelChild = false,
 ) {
+  const cloudflaredPath = tunnelMode ? findCloudflared() : null;
+  if (tunnelMode && !cloudflaredPath) {
+    console.error(
+      "Cloudflare public mode requires cloudflared. Install it with " +
+      "`brew install cloudflared`, then rerun serve-sim --tunnel.",
+    );
+    process.exit(1);
+  }
+
   // Boot the target simulators; the preview server streams them in-process
   // (no spawned helper). Sessions are created lazily on the first stream request.
   const targetDevices = resolveTargetDevices(devices);
@@ -1612,27 +1804,52 @@ async function serve(
     for (const udid of targetDevices) await setUiOption(udid, "appearance", theme);
   }
   const targetDevice = targetDevices[0];
+  const tunnelLaunch = tunnelMode ? createQuickTunnelLaunchConfig({
+    devices: targetDevices,
+    port: servePort,
+    portExplicit,
+    codec,
+    panes: initialState?.panes,
+    fit: initialState?.fit,
+    theme,
+  }) : undefined;
 
   const { simMiddleware } = await import("./middleware");
   // Standalone serve-sim owns its HTTP server and wires WebSocket upgrades, so
   // it can route helper/DevTools sockets through the single preview port.
-  const middleware = simMiddleware({
+  const baseMiddleware = simMiddleware({
     basePath: "/",
     device: targetDevice,
     codec,
     initialState,
     proxyHelpers: true,
   });
+  const tunnelAccessToken = tunnelMode ? createTunnelAccessToken() : null;
+  const middleware = tunnelAccessToken
+    ? protectTunnelMiddleware(baseMiddleware, tunnelAccessToken)
+    : baseMiddleware;
+
+  if (tunnelMode) {
+    ensureStateDir();
+    const message = `[${new Date().toISOString()}] [serve-sim] launching previewPid=${process.pid}\n`;
+    if (detachedTunnelChild) {
+      appendFileSync(QUICK_TUNNEL_LOG_FILE, message);
+    } else {
+      writeFileSync(QUICK_TUNNEL_LOG_FILE, message, { mode: 0o600 });
+    }
+    chmodSync(QUICK_TUNNEL_LOG_FILE, 0o600);
+  }
 
   // Try requested port; if busy and the user didn't pin it, scan forward.
   const maxScan = portExplicit ? 1 : 50;
   let boundPort = servePort;
   let lastErr: unknown;
   let bound = false;
+  let previewServer: Awaited<ReturnType<typeof bindPreviewServer>> | null = null;
   for (let i = 0; i < maxScan; i++) {
     const p = servePort + i;
     try {
-      await bindPreviewServer(p, middleware, host);
+      previewServer = await bindPreviewServer(p, middleware, host);
       boundPort = p;
       bound = true;
       break;
@@ -1659,29 +1876,120 @@ async function serve(
   for (const udid of targetDevices) {
     writeState(inProcessServeSimState(udid, boundPort, "/", host));
   }
-  const clearAll = () => {
+
+  let shuttingDown = false;
+  let cloudflaredChild: ChildProcess | null = null;
+  const logTunnelEvent = (message: string) => {
+    if (!tunnelMode) return;
+    try {
+      appendFileSync(
+        QUICK_TUNNEL_LOG_FILE,
+        `[${new Date().toISOString()}] [serve-sim] ${message}\n`,
+      );
+    } catch {}
+  };
+  const clearOwnedDeviceStates = () => {
     for (const udid of targetDevices) {
-      try { clearState(udid); } catch {}
+      try {
+        if (readState(udid)?.pid === process.pid) clearState(udid);
+      } catch {}
     }
   };
-  process.on("exit", clearAll);
+  const cleanup = (exitCode: number, reason: string) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    logTunnelEvent(`shutdown reason=${reason} exitCode=${exitCode}`);
+    if (cloudflaredChild?.pid) cloudflaredChild.kill("SIGTERM");
+    previewServer?.stop(true);
+    clearOwnedDeviceStates();
+    if (tunnelMode) clearQuickTunnelState(process.pid);
+    process.exit(exitCode);
+  };
 
-  const exposedToLan = host !== "127.0.0.1" && host !== "localhost" && host !== "::1";
-  const networkIP = getLocalNetworkIP();
-  console.log("");
-  console.log(`  - Local:   http://localhost:${boundPort}`);
-  if (exposedToLan && networkIP) {
-    console.log(`  - Network: http://${networkIP}:${boundPort}`);
-  } else if (networkIP) {
-    console.log(`  - Network: \x1b[2muse --host 0.0.0.0 to expose on http://${networkIP}:${boundPort}\x1b[0m`);
+  process.once("SIGINT", () => cleanup(0, "received SIGINT"));
+  process.once("SIGTERM", () => cleanup(0, "received SIGTERM"));
+  process.once("SIGHUP", () => cleanup(0, "received SIGHUP"));
+  process.on("exit", () => {
+    clearOwnedDeviceStates();
+    if (tunnelMode) clearQuickTunnelState(process.pid);
+    if (cloudflaredChild?.pid) {
+      try { cloudflaredChild.kill("SIGTERM"); } catch {}
+    }
+  });
+
+  if (tunnelMode) {
+    logTunnelEvent(`starting origin=http://127.0.0.1:${boundPort}`);
+    try {
+      const tunnel = await startQuickTunnel(
+        cloudflaredPath!,
+        `http://127.0.0.1:${boundPort}`,
+        QUICK_TUNNEL_LOG_FILE,
+        { onSpawn: (child) => { cloudflaredChild = child; } },
+      );
+      cloudflaredChild = tunnel.child;
+      if (!cloudflaredChild.pid || cloudflaredChild.exitCode !== null) {
+        throw new Error("cloudflared exited before the Quick Tunnel became ready");
+      }
+
+      const publicUrl = new URL(tunnel.url);
+      publicUrl.searchParams.set("token", tunnelAccessToken!);
+      const localUrl = new URL(`http://localhost:${boundPort}`);
+      localUrl.searchParams.set("token", tunnelAccessToken!);
+      const state: QuickTunnelState = {
+        ownerPid: process.pid,
+        cloudflaredPid: cloudflaredChild.pid,
+        port: boundPort,
+        publicUrl: publicUrl.toString(),
+        localUrl: localUrl.toString(),
+        logFile: QUICK_TUNNEL_LOG_FILE,
+        devices: targetDevices,
+        startedAt: new Date().toISOString(),
+        launch: tunnelLaunch,
+      };
+      writeQuickTunnelState(state);
+      logTunnelEvent(
+        `ready cloudflaredPid=${cloudflaredChild.pid} publicUrl=${tunnel.url}`,
+      );
+
+      cloudflaredChild.once("exit", (code, signal) => {
+        if (shuttingDown) return;
+        const reason = `cloudflared exited code=${code ?? "unknown"} signal=${signal ?? "none"}`;
+        console.error(`Cloudflare Quick Tunnel exited unexpectedly (${reason}).`);
+        cleanup(code === null || code === 0 ? 1 : code, reason);
+      });
+
+      if (!detachedTunnelChild) {
+        console.log("");
+        console.log(`  - Local:   ${localUrl}`);
+        console.log(`  - Public:  ${publicUrl}`);
+        console.log("");
+        console.log("  Anyone with the complete URL can control the simulator and run host commands.");
+        console.log("  Keep it private. Ctrl+C closes this temporary tunnel.");
+        console.log(`  Diagnostics: ${QUICK_TUNNEL_LOG_FILE}`);
+        console.log("");
+      }
+    } catch (error) {
+      logTunnelEvent(`startup failed error=${error instanceof Error ? error.message : String(error)}`);
+      console.error(
+        `Failed to start Cloudflare Quick Tunnel: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      cleanup(1, "tunnel startup failed");
+    }
   } else {
-    console.log("  - Network: \x1b[2muse --host 0.0.0.0 to expose on the LAN\x1b[0m");
+    const exposedToLan = host !== "127.0.0.1" && host !== "localhost" && host !== "::1";
+    const networkIP = getLocalNetworkIP();
+    console.log("");
+    console.log(`  - Local:   http://localhost:${boundPort}`);
+    if (exposedToLan && networkIP) {
+      console.log(`  - Network: http://${networkIP}:${boundPort}`);
+    } else if (networkIP) {
+      console.log(`  - Network: \x1b[2muse --host 0.0.0.0 to expose on http://${networkIP}:${boundPort}\x1b[0m`);
+    } else {
+      console.log("  - Network: \x1b[2muse --host 0.0.0.0 to expose on the LAN\x1b[0m");
+    }
+    console.log("");
   }
-  console.log("");
 
-  // Exit cleanly on Ctrl+C
-  process.on("SIGINT", () => process.exit(0));
-  process.on("SIGTERM", () => process.exit(0));
   await new Promise(() => {});
 }
 
@@ -1708,7 +2016,15 @@ program
       "shell-exec route.",
     "127.0.0.1",
   )
-  .option("--detach", "Spawn helper and exit (daemon mode)")
+  .addOption(
+    new Option(
+      "--tunnel",
+      "Publish an access-token-protected Cloudflare Quick Tunnel",
+    ),
+  )
+  .addOption(new Option("--public").hideHelp().implies({ tunnel: true }))
+  .addOption(new Option("--tunnel-child").hideHelp())
+  .option("--detach", "Run the stream or public preview in background")
   .option("-q, --quiet", "Suppress human-readable output, JSON only")
   .option("--no-preview", "Skip the web preview server; stream in foreground only")
   .option(
@@ -1754,6 +2070,8 @@ program
     `
 Examples:
   serve-sim                              Open simulator preview at localhost:3200
+  serve-sim --tunnel                     Open a private temporary URL from anywhere
+  serve-sim --tunnel --detach            Keep a public preview running in background
   serve-sim -p 8080                      Preview on a custom port
   serve-sim --codec mjpeg                Force MJPEG (e.g. on VMs without H.264 encode)
   serve-sim --panes devices,tools --fit  Open panes and fit the simulator to the viewport
@@ -1765,6 +2083,17 @@ Examples:
   serve-sim --kill                       Stop all streams`,
   )
   .action(async (devices: string[], opts) => {
+    const tunnelMode = !!opts.tunnel || !!opts.tunnelChild;
+    if (tunnelMode && (opts.list !== undefined || opts.kill !== undefined || opts.preview === false)) {
+      console.error("--tunnel is only available with the preview server (not --no-preview, --list, or --kill).");
+      process.exitCode = 1;
+      return;
+    }
+    if (tunnelMode && opts.host !== "127.0.0.1") {
+      console.error("--tunnel always binds the preview to 127.0.0.1 and cannot be combined with --host.");
+      process.exitCode = 1;
+      return;
+    }
     if (opts.list !== undefined) {
       listStreams(typeof opts.list === "string" ? opts.list : undefined);
       return;
@@ -1774,17 +2103,32 @@ Examples:
       return;
     }
     const startPort: number | undefined = opts.port;
-    if (opts.detach) {
+    const initialState: PreviewInitialState | undefined =
+      opts.panes !== undefined || opts.fit ? {
+        ...(opts.panes !== undefined ? { panes: opts.panes } : {}),
+        ...(opts.fit ? { fit: true } : {}),
+      } : undefined;
+    if (tunnelMode && opts.detach && !opts.tunnelChild) {
+      try {
+        const state = await detachTunnelPreview({
+          devices,
+          port: startPort ?? 3200,
+          portExplicit: startPort !== undefined,
+          codec: opts.codec,
+          initialState,
+          theme: opts.theme,
+        });
+        console.log(JSON.stringify(state));
+      } catch (error) {
+        console.error(error instanceof Error ? error.message : String(error));
+        process.exitCode = 1;
+      }
+    } else if (opts.detach) {
       const states = await detach(devices, startPort ?? 3100);
       printStatesJSON(states);
     } else if (opts.preview === false) {
       await follow(devices, startPort ?? 3100, !!opts.quiet);
     } else {
-      const initialState: PreviewInitialState | undefined =
-        opts.panes !== undefined || opts.fit ? {
-          ...(opts.panes !== undefined ? { panes: opts.panes } : {}),
-          ...(opts.fit ? { fit: true } : {}),
-        } : undefined;
       await serve(
         startPort ?? 3200,
         devices,
@@ -1793,6 +2137,8 @@ Examples:
         opts.codec,
         initialState,
         opts.theme,
+        tunnelMode,
+        !!opts.tunnelChild,
       );
     }
   });

--- a/packages/serve-sim/src/index.ts
+++ b/packages/serve-sim/src/index.ts
@@ -309,6 +309,7 @@ function stopProcess(pid: number, stillOwned?: () => boolean): void {
   }
 }
 
+/** Revalidate persisted tunnel ownership before signalling a recorded PID. */
 function quickTunnelStillOwned(expected: QuickTunnelState): boolean {
   const current = readQuickTunnelState();
   if (
@@ -386,6 +387,7 @@ async function ensureBooted(udid: string): Promise<void> {
 
 // ─── Preview server lifecycle ───
 
+/** Launch a detached tunnel owner and wait until its verified state is ready. */
 async function detachTunnelPreview(options: {
   devices: string[];
   port: number;

--- a/packages/serve-sim/src/quick-tunnel.ts
+++ b/packages/serve-sim/src/quick-tunnel.ts
@@ -64,10 +64,12 @@ export type TunnelAccessDecision =
 
 type TunnelRequest = Pick<IncomingMessage, "method" | "url" | "headers">;
 
+/** Return one normalized value from a Node request header. */
 function firstHeader(value: string | string[] | undefined): string | undefined {
   return Array.isArray(value) ? value[0] : value;
 }
 
+/** Compare access tokens without leaking a matching prefix through timing. */
 function tokensMatch(actual: string | null | undefined, expected: string): boolean {
   if (!actual) return false;
   const actualBytes = Buffer.from(actual);
@@ -75,6 +77,7 @@ function tokensMatch(actual: string | null | undefined, expected: string): boole
   return actualBytes.length === expectedBytes.length && timingSafeEqual(actualBytes, expectedBytes);
 }
 
+/** Read a named value from a Cookie header without decoding unrelated cookies. */
 function cookieValue(header: string | undefined, name: string): string | null {
   if (!header) return null;
   for (const part of header.split(";")) {
@@ -87,10 +90,12 @@ function cookieValue(header: string | undefined, name: string): string | null {
   return null;
 }
 
+/** Read the protocol reported by the first forwarding hop. */
 function forwardedProtocol(headers: IncomingHttpHeaders): string | undefined {
   return firstHeader(headers["x-forwarded-proto"])?.split(",", 1)[0]?.trim().toLowerCase();
 }
 
+/** Identify direct loopback traffic that did not arrive through a proxy. */
 function isLoopbackRequest(request: TunnelRequest): boolean {
   if (forwardedProtocol(request.headers) !== undefined) return false;
   const host = firstHeader(request.headers.host);
@@ -104,6 +109,7 @@ function isLoopbackRequest(request: TunnelRequest): boolean {
   }
 }
 
+/** Require browser control requests to originate from their exact request host. */
 function requestOriginMatchesHost(request: TunnelRequest): boolean {
   const origin = firstHeader(request.headers.origin);
   if (!origin) return true;
@@ -119,10 +125,12 @@ function requestOriginMatchesHost(request: TunnelRequest): boolean {
   }
 }
 
+/** Create the per-owner 256-bit credential embedded in the private launch URL. */
 export function createTunnelAccessToken(): string {
   return randomBytes(32).toString("base64url");
 }
 
+/** Normalize the options that determine whether a detached tunnel can be reused. */
 export function createQuickTunnelLaunchConfig(input: {
   devices: string[];
   port: number;
@@ -143,6 +151,7 @@ export function createQuickTunnelLaunchConfig(input: {
   };
 }
 
+/** Validate launch metadata loaded from the persisted tunnel state file. */
 function validQuickTunnelLaunchConfig(value: unknown): value is QuickTunnelLaunchConfig {
   if (!value || typeof value !== "object") return false;
   const launch = value as Partial<QuickTunnelLaunchConfig>;
@@ -160,6 +169,7 @@ function validQuickTunnelLaunchConfig(value: unknown): value is QuickTunnelLaunc
     (launch.theme === null || typeof launch.theme === "string");
 }
 
+/** Check whether live tunnel state represents the exact requested launch. */
 export function quickTunnelLaunchMatches(
   state: Pick<QuickTunnelState, "launch">,
   requested: QuickTunnelLaunchConfig,
@@ -186,6 +196,7 @@ const SIMULATOR_BOOT_TIMEOUT_MS = 60_000;
 const QUICK_TUNNEL_READY_TIMEOUT_MS = 30_000;
 const DETACHED_STARTUP_GRACE_MS = 15_000;
 
+/** Budget sequential simulator boots, Quick Tunnel readiness, and launcher grace. */
 export function detachedTunnelStartupTimeoutMs(deviceCount: number): number {
   return Math.max(1, deviceCount) * SIMULATOR_BOOT_TIMEOUT_MS +
     QUICK_TUNNEL_READY_TIMEOUT_MS +
@@ -208,6 +219,7 @@ export function stopDetachedProcessGroup(
   }
 }
 
+/** Read and validate the persisted detached tunnel state. */
 export function readQuickTunnelState(): QuickTunnelState | null {
   try {
     const state = JSON.parse(readFileSync(QUICK_TUNNEL_STATE_FILE, "utf-8")) as QuickTunnelState;
@@ -234,6 +246,7 @@ export function readQuickTunnelState(): QuickTunnelState | null {
   }
 }
 
+/** Atomically persist owner-only detached tunnel state. */
 export function writeQuickTunnelState(state: QuickTunnelState): void {
   mkdirSync(STATE_DIR, { recursive: true });
   const tempFile = `${QUICK_TUNNEL_STATE_FILE}.${process.pid}.tmp`;
@@ -242,6 +255,7 @@ export function writeQuickTunnelState(state: QuickTunnelState): void {
   renameSync(tempFile, QUICK_TUNNEL_STATE_FILE);
 }
 
+/** Remove tunnel state, optionally only when it still belongs to an owner PID. */
 export function clearQuickTunnelState(ownerPid?: number): void {
   if (ownerPid !== undefined && readQuickTunnelState()?.ownerPid !== ownerPid) return;
   try { unlinkSync(QUICK_TUNNEL_STATE_FILE); } catch {}
@@ -319,6 +333,7 @@ export function authorizeTunnelRequest(
   return { type: "allow" };
 }
 
+/** Write a redirect or authorization error to an HTTP response. */
 function writeHttpDecision(res: ServerResponse, decision: Exclude<TunnelAccessDecision, { type: "allow" }>): void {
   const commonHeaders = {
     "Cache-Control": "no-store",
@@ -340,6 +355,7 @@ function writeHttpDecision(res: ServerResponse, decision: Exclude<TunnelAccessDe
   res.end(decision.body);
 }
 
+/** Reject an unauthorized WebSocket upgrade with a complete HTTP response. */
 function rejectUpgrade(socket: Socket, decision: Exclude<TunnelAccessDecision, { type: "allow" }>): void {
   const status = decision.type === "redirect" ? 401 : decision.status;
   const body = decision.type === "redirect"
@@ -384,10 +400,12 @@ export function protectTunnelMiddleware(
   return protectedMiddleware;
 }
 
+/** Extract the first Quick Tunnel hostname emitted by cloudflared. */
 export function extractQuickTunnelUrl(output: string): string | null {
   return output.match(QUICK_TUNNEL_URL_RE)?.[0] ?? null;
 }
 
+/** Locate an installed cloudflared executable on PATH. */
 export function findCloudflared(): string | null {
   for (const directory of (process.env.PATH ?? "").split(delimiter)) {
     if (!directory) continue;
@@ -397,6 +415,7 @@ export function findCloudflared(): string | null {
   return null;
 }
 
+/** Start cloudflared and resolve once it emits a usable Quick Tunnel URL. */
 export function startQuickTunnel(
   cloudflaredPath: string,
   originUrl: string,

--- a/packages/serve-sim/src/quick-tunnel.ts
+++ b/packages/serve-sim/src/quick-tunnel.ts
@@ -1,0 +1,456 @@
+import { randomBytes, timingSafeEqual } from "crypto";
+import { spawn, type ChildProcess } from "child_process";
+import {
+  appendFileSync,
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
+import type { IncomingHttpHeaders, IncomingMessage, ServerResponse } from "http";
+import { delimiter, join } from "path";
+import type { Socket } from "net";
+import type { SimMiddleware } from "./middleware";
+import { STATE_DIR, type ServeSimDeviceState } from "./state";
+
+const ACCESS_COOKIE = "serve_sim_access";
+const QUICK_TUNNEL_URL_RE = /https:\/\/[a-z0-9-]+\.trycloudflare\.com/i;
+export const QUICK_TUNNEL_STATE_FILE = join(STATE_DIR, "tunnel.json");
+export const QUICK_TUNNEL_LOG_FILE = join(STATE_DIR, "tunnel.log");
+
+export interface QuickTunnel {
+  url: string;
+  child: ChildProcess;
+}
+
+export interface QuickTunnelState {
+  ownerPid: number;
+  cloudflaredPid: number;
+  port: number;
+  publicUrl: string;
+  localUrl: string;
+  logFile: string;
+  devices: string[];
+  startedAt: string;
+  launch?: QuickTunnelLaunchConfig;
+}
+
+export interface QuickTunnelLaunchConfig {
+  devices: string[];
+  port: number;
+  portExplicit: boolean;
+  codec: string | null;
+  panes: string[] | null;
+  fit: boolean;
+  theme: string | null;
+}
+
+export type TunnelAccessDecision =
+  | { type: "allow" }
+  | {
+      type: "redirect";
+      status: 302;
+      location: string;
+      cookie: string;
+    }
+  | {
+      type: "deny";
+      status: 401 | 403;
+      body: string;
+    };
+
+type TunnelRequest = Pick<IncomingMessage, "method" | "url" | "headers">;
+
+function firstHeader(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function tokensMatch(actual: string | null | undefined, expected: string): boolean {
+  if (!actual) return false;
+  const actualBytes = Buffer.from(actual);
+  const expectedBytes = Buffer.from(expected);
+  return actualBytes.length === expectedBytes.length && timingSafeEqual(actualBytes, expectedBytes);
+}
+
+function cookieValue(header: string | undefined, name: string): string | null {
+  if (!header) return null;
+  for (const part of header.split(";")) {
+    const separator = part.indexOf("=");
+    if (separator === -1) continue;
+    if (part.slice(0, separator).trim() === name) {
+      return part.slice(separator + 1).trim();
+    }
+  }
+  return null;
+}
+
+function forwardedProtocol(headers: IncomingHttpHeaders): string | undefined {
+  return firstHeader(headers["x-forwarded-proto"])?.split(",", 1)[0]?.trim().toLowerCase();
+}
+
+function isLoopbackRequest(request: TunnelRequest): boolean {
+  if (forwardedProtocol(request.headers) !== undefined) return false;
+  const host = firstHeader(request.headers.host);
+  if (!host) return false;
+  try {
+    const hostname = new URL(`http://${host}`).hostname.toLowerCase();
+    return hostname === "127.0.0.1" || hostname === "localhost" ||
+      hostname === "::1" || hostname === "[::1]";
+  } catch {
+    return false;
+  }
+}
+
+function requestOriginMatchesHost(request: TunnelRequest): boolean {
+  const origin = firstHeader(request.headers.origin);
+  if (!origin) return true;
+  const host = firstHeader(request.headers.host);
+  if (!host) return false;
+  try {
+    const parsed = new URL(origin);
+    if (parsed.host !== host) return false;
+    const protocol = forwardedProtocol(request.headers);
+    return !protocol || parsed.protocol === `${protocol}:`;
+  } catch {
+    return false;
+  }
+}
+
+export function createTunnelAccessToken(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+export function createQuickTunnelLaunchConfig(input: {
+  devices: string[];
+  port: number;
+  portExplicit: boolean;
+  codec?: string | null;
+  panes?: readonly string[] | null;
+  fit?: boolean;
+  theme?: string | null;
+}): QuickTunnelLaunchConfig {
+  return {
+    devices: [...input.devices],
+    port: input.port,
+    portExplicit: input.portExplicit,
+    codec: input.codec ?? null,
+    panes: input.panes ? [...input.panes] : null,
+    fit: input.fit ?? false,
+    theme: input.theme ?? null,
+  };
+}
+
+function validQuickTunnelLaunchConfig(value: unknown): value is QuickTunnelLaunchConfig {
+  if (!value || typeof value !== "object") return false;
+  const launch = value as Partial<QuickTunnelLaunchConfig>;
+  return Array.isArray(launch.devices) &&
+    launch.devices.every((device) => typeof device === "string") &&
+    Number.isSafeInteger(launch.port) &&
+    (launch.port ?? 0) > 0 &&
+    typeof launch.portExplicit === "boolean" &&
+    (launch.codec === null || typeof launch.codec === "string") &&
+    (launch.panes === null || (
+      Array.isArray(launch.panes) &&
+      launch.panes.every((pane) => typeof pane === "string")
+    )) &&
+    typeof launch.fit === "boolean" &&
+    (launch.theme === null || typeof launch.theme === "string");
+}
+
+export function quickTunnelLaunchMatches(
+  state: Pick<QuickTunnelState, "launch">,
+  requested: QuickTunnelLaunchConfig,
+): boolean {
+  const launch = state.launch;
+  if (!launch) return false;
+  const launchPanes = launch.panes;
+  const requestedPanes = requested.panes;
+  return launch.port === requested.port &&
+    launch.portExplicit === requested.portExplicit &&
+    launch.codec === requested.codec &&
+    launch.fit === requested.fit &&
+    launch.theme === requested.theme &&
+    launch.devices.length === requested.devices.length &&
+    launch.devices.every((device, index) => device === requested.devices[index]) &&
+    (launchPanes === null
+      ? requestedPanes === null
+      : requestedPanes !== null &&
+        launchPanes.length === requestedPanes.length &&
+        launchPanes.every((pane, index) => pane === requestedPanes[index]));
+}
+
+const SIMULATOR_BOOT_TIMEOUT_MS = 60_000;
+const QUICK_TUNNEL_READY_TIMEOUT_MS = 30_000;
+const DETACHED_STARTUP_GRACE_MS = 15_000;
+
+export function detachedTunnelStartupTimeoutMs(deviceCount: number): number {
+  return Math.max(1, deviceCount) * SIMULATOR_BOOT_TIMEOUT_MS +
+    QUICK_TUNNEL_READY_TIMEOUT_MS +
+    DETACHED_STARTUP_GRACE_MS;
+}
+
+type KillProcess = (pid: number, signal: NodeJS.Signals | number) => boolean;
+
+/** Stop a detached launch and every child that inherited its process group. */
+export function stopDetachedProcessGroup(
+  pid: number,
+  signal: NodeJS.Signals | number = "SIGTERM",
+  killProcess: KillProcess = (target, targetSignal) => process.kill(target, targetSignal),
+): void {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return;
+  try {
+    killProcess(-pid, signal);
+  } catch {
+    try { killProcess(pid, signal); } catch {}
+  }
+}
+
+export function readQuickTunnelState(): QuickTunnelState | null {
+  try {
+    const state = JSON.parse(readFileSync(QUICK_TUNNEL_STATE_FILE, "utf-8")) as QuickTunnelState;
+    if (
+      !Number.isSafeInteger(state.ownerPid) ||
+      state.ownerPid <= 0 ||
+      !Number.isSafeInteger(state.cloudflaredPid) ||
+      state.cloudflaredPid <= 0 ||
+      !Number.isSafeInteger(state.port) ||
+      state.port <= 0 ||
+      typeof state.publicUrl !== "string" ||
+      typeof state.localUrl !== "string" ||
+      typeof state.logFile !== "string" ||
+      !Array.isArray(state.devices) ||
+      !state.devices.every((device) => typeof device === "string") ||
+      typeof state.startedAt !== "string" ||
+      (state.launch !== undefined && !validQuickTunnelLaunchConfig(state.launch))
+    ) {
+      return null;
+    }
+    return state;
+  } catch {
+    return null;
+  }
+}
+
+export function writeQuickTunnelState(state: QuickTunnelState): void {
+  mkdirSync(STATE_DIR, { recursive: true });
+  const tempFile = `${QUICK_TUNNEL_STATE_FILE}.${process.pid}.tmp`;
+  writeFileSync(tempFile, JSON.stringify(state, null, 2), { mode: 0o600 });
+  chmodSync(tempFile, 0o600);
+  renameSync(tempFile, QUICK_TUNNEL_STATE_FILE);
+}
+
+export function clearQuickTunnelState(ownerPid?: number): void {
+  if (ownerPid !== undefined && readQuickTunnelState()?.ownerPid !== ownerPid) return;
+  try { unlinkSync(QUICK_TUNNEL_STATE_FILE); } catch {}
+}
+
+/** Confirm runtime ownership before a controller signals a tunnel owner PID. */
+export function quickTunnelMatchesDeviceStates(
+  tunnel: QuickTunnelState,
+  states: ServeSimDeviceState[],
+): boolean {
+  return tunnel.devices.length > 0 && tunnel.devices.every((device) => states.some((state) => (
+    state.device === device &&
+    state.pid === tunnel.ownerPid &&
+    state.port === tunnel.port
+  )));
+}
+
+/**
+ * Exchange the unguessable launch URL for a host-only browser cookie. Quick
+ * Tunnels do not provide authentication, and serve-sim's preview can execute
+ * simulator-management commands on the host.
+ */
+export function authorizeTunnelRequest(
+  request: TunnelRequest,
+  expectedToken: string,
+  options: { allowTokenExchange?: boolean; allowLoopback?: boolean } = {},
+): TunnelAccessDecision {
+  const url = new URL(request.url ?? "/", "http://serve-sim.local");
+  const queryToken = url.searchParams.get("token");
+  const allowTokenExchange = options.allowTokenExchange ?? true;
+
+  if (
+    allowTokenExchange &&
+    request.method === "GET" &&
+    tokensMatch(queryToken, expectedToken)
+  ) {
+    url.searchParams.delete("token");
+    const secure = forwardedProtocol(request.headers) === "https";
+    const cookie = [
+      `${ACCESS_COOKIE}=${expectedToken}`,
+      "HttpOnly",
+      "SameSite=Strict",
+      "Path=/",
+      "Max-Age=86400",
+      secure ? "Secure" : "",
+    ].filter(Boolean).join("; ");
+    return {
+      type: "redirect",
+      status: 302,
+      location: `${url.pathname}${url.search}`,
+      cookie,
+    };
+  }
+
+  if (options.allowLoopback && isLoopbackRequest(request)) {
+    return { type: "allow" };
+  }
+
+  const cookie = firstHeader(request.headers.cookie);
+  if (!tokensMatch(cookieValue(cookie, ACCESS_COOKIE), expectedToken)) {
+    return {
+      type: "deny",
+      status: 401,
+      body: "Unauthorized. Use the complete private URL printed by serve-sim.\n",
+    };
+  }
+
+  // A sibling trycloudflare.com page is considered same-site by browsers.
+  // Check the exact origin as well so it cannot drive host commands or open a
+  // simulator-control WebSocket with the host-only cookie.
+  if (!requestOriginMatchesHost(request)) {
+    return { type: "deny", status: 403, body: "Forbidden origin.\n" };
+  }
+
+  return { type: "allow" };
+}
+
+function writeHttpDecision(res: ServerResponse, decision: Exclude<TunnelAccessDecision, { type: "allow" }>): void {
+  const commonHeaders = {
+    "Cache-Control": "no-store",
+    "Referrer-Policy": "no-referrer",
+  };
+  if (decision.type === "redirect") {
+    res.writeHead(decision.status, {
+      ...commonHeaders,
+      Location: decision.location,
+      "Set-Cookie": decision.cookie,
+    });
+    res.end();
+    return;
+  }
+  res.writeHead(decision.status, {
+    ...commonHeaders,
+    "Content-Type": "text/plain; charset=utf-8",
+  });
+  res.end(decision.body);
+}
+
+function rejectUpgrade(socket: Socket, decision: Exclude<TunnelAccessDecision, { type: "allow" }>): void {
+  const status = decision.type === "redirect" ? 401 : decision.status;
+  const body = decision.type === "redirect"
+    ? "Unauthorized. Open the private URL in a browser before connecting.\n"
+    : decision.body;
+  const reason = status === 403 ? "Forbidden" : "Unauthorized";
+  socket.end(
+    `HTTP/1.1 ${status} ${reason}\r\n` +
+    "Content-Type: text/plain; charset=utf-8\r\n" +
+    "Cache-Control: no-store\r\n" +
+    "Connection: close\r\n" +
+    `Content-Length: ${Buffer.byteLength(body)}\r\n\r\n` +
+    body,
+  );
+}
+
+/** Keep the tunnel access gate CLI-internal while preserving middleware APIs. */
+export function protectTunnelMiddleware(
+  middleware: SimMiddleware,
+  accessToken: string,
+): SimMiddleware {
+  const protectedMiddleware = (async (req, res, next) => {
+    const decision = authorizeTunnelRequest(req, accessToken, { allowLoopback: true });
+    if (decision.type !== "allow") {
+      writeHttpDecision(res, decision);
+      return;
+    }
+    return middleware(req, res, next);
+  }) as SimMiddleware;
+
+  protectedMiddleware.handleUpgrade = (req, socket, head) => {
+    const decision = authorizeTunnelRequest(req, accessToken, {
+      allowLoopback: true,
+      allowTokenExchange: false,
+    });
+    if (decision.type !== "allow") {
+      rejectUpgrade(socket, decision);
+      return;
+    }
+    middleware.handleUpgrade(req, socket, head);
+  };
+  return protectedMiddleware;
+}
+
+export function extractQuickTunnelUrl(output: string): string | null {
+  return output.match(QUICK_TUNNEL_URL_RE)?.[0] ?? null;
+}
+
+export function findCloudflared(): string | null {
+  for (const directory of (process.env.PATH ?? "").split(delimiter)) {
+    if (!directory) continue;
+    const candidate = join(directory, "cloudflared");
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+export function startQuickTunnel(
+  cloudflaredPath: string,
+  originUrl: string,
+  logFile: string,
+  options: { onSpawn?: (child: ChildProcess) => void } = {},
+): Promise<QuickTunnel> {
+  return new Promise((resolve, reject) => {
+    // /dev/null deliberately bypasses a user-level config.yml, which
+    // Cloudflare documents as incompatible with Quick Tunnels.
+    const child = spawn(cloudflaredPath, [
+      "tunnel",
+      "--config", "/dev/null",
+      "--no-autoupdate",
+      "--url", originUrl,
+      "--loglevel", "info",
+    ], { stdio: ["ignore", "pipe", "pipe"] });
+    options.onSpawn?.(child);
+
+    let settled = false;
+    let diagnostics = "";
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill("SIGTERM");
+      reject(new Error(`Timed out waiting for a Quick Tunnel URL.\n${diagnostics.trim()}`));
+    }, QUICK_TUNNEL_READY_TIMEOUT_MS);
+
+    const consume = (chunk: Buffer | string) => {
+      const text = chunk.toString();
+      try { appendFileSync(logFile, text); } catch {}
+      diagnostics = (diagnostics + text).slice(-16_000);
+      if (settled) return;
+      const url = extractQuickTunnelUrl(diagnostics);
+      if (!url) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolve({ url, child });
+    };
+
+    child.stdout?.on("data", consume);
+    child.stderr?.on("data", consume);
+    child.once("error", (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.once("exit", (code, signal) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      reject(new Error(
+        `cloudflared exited before creating a Quick Tunnel (code=${code}, signal=${signal}).\n${diagnostics.trim()}`,
+      ));
+    });
+  });
+}

--- a/packages/serve-sim/src/runtime.ts
+++ b/packages/serve-sim/src/runtime.ts
@@ -1,12 +1,27 @@
 /** Node runtime helpers for the bundled CLI. */
 import { fileURLToPath } from "url";
-import { dirname } from "path";
+import { basename, dirname } from "path";
 import { createServer as createHttpServer, type IncomingMessage, type ServerResponse } from "http";
 import type { Socket } from "net";
 import { createConnection, createServer as createNetServer, type Server as NetServer } from "net";
 
 export function dirnameOf(metaUrl: string): string {
   return dirname(fileURLToPath(metaUrl));
+}
+
+/** Resolve how the current CLI should re-exec under Node, Bun, or Bun compile. */
+export function reExecCommand(
+  extra: string[],
+  runtime: { execPath?: string; entrypoint?: string } = {},
+): { command: string; args: string[] } {
+  const execPath = runtime.execPath ?? process.execPath;
+  const entrypoint = runtime.entrypoint ?? process.argv[1];
+  const runtimeName = basename(execPath).toLowerCase();
+  const isScriptRuntime = /^(?:node(?:js)?\d*|bun)(?:\.exe)?$/.test(runtimeName);
+  return {
+    command: execPath,
+    args: isScriptRuntime && entrypoint ? [entrypoint, ...extra] : extra,
+  };
 }
 
 /** Block the current thread for `ms` milliseconds without busy-waiting. */

--- a/skills/serve-sim/README.md
+++ b/skills/serve-sim/README.md
@@ -17,8 +17,9 @@ Once installed, your agent knows how to:
 - Simulate a memory warning.
 - Discover the running stream's URL and read the simulator's accessibility tree to find UI elements.
 - Hand the stream URL off to the host agent's preview pane (`preview_start` in Claude Code, equivalents elsewhere) so the user sees the simulator inline.
+- Publish an access-token-protected Cloudflare Quick Tunnel for remote PC or mobile access, hand off the complete private URL, and clean up the detached tunnel safely.
 
-It also teaches the agent the **gotchas** (use `tap`, not `gesture`, for plain taps), the **prerequisites** (macOS, Xcode CLI tools, Node 18+, macOS 14+ for camera), and **anti-patterns** to avoid.
+It also teaches the agent the **gotchas** (use `tap`, not `gesture`, for plain taps), the **prerequisites** (macOS, Xcode CLI tools, Node 20+, macOS 14+ for camera, and `cloudflared` for tunnels), and **anti-patterns** to avoid.
 
 ## Install
 
@@ -57,8 +58,9 @@ The agent checks these for you, but for reference:
 
 - macOS host (any recent version).
 - Xcode command line tools (`xcode-select --install`).
-- Node.js 18+.
+- Node.js 20+ (a maintained LTS release).
 - macOS 14+ if you want camera injection.
+- `cloudflared` if you want a public Quick Tunnel (`brew install cloudflared`).
 - At least one booted iOS, iPad, or Apple Watch simulator.
 
 `serve-sim` itself is invoked via `npx serve-sim` — no global install required.
@@ -74,12 +76,13 @@ serve-sim/
 │   ├── camera.md                     (camera injection: sources, mirroring, hot-swap)
 │   ├── ca-debug.md                   (CoreAnimation debug flags)
 │   ├── endpoints.md                  (HTTP + WebSocket surface)
+│   ├── tunnels.md                    (protected Quick Tunnel workflow + security)
 │   └── workflows.md                  (end-to-end recipes incl. preview handoff)
 ├── scripts/
 │   ├── check-prereqs.sh              (verify host satisfies requirements)
 │   └── ensure-running.sh             (idempotent start of the helper)
 └── evals/
-    └── evals.json                    (6 test prompts for agent quality)
+    └── evals.json                    (7 test prompts for agent quality)
 ```
 
 Following Anthropic's recommended structure: short `SKILL.md`, references one level deep, executable scripts that the agent can run without loading their source into context.
@@ -98,7 +101,7 @@ Every claim in this skill — the six button names, the four orientations, the g
 
 ## Evals
 
-`evals/evals.json` contains six representative prompts with expected behaviors, suitable for running through Anthropic's `skill-creator` eval framework. When changing the skill, re-run the evals to catch regressions.
+`evals/evals.json` contains seven representative prompts with expected behaviors, suitable for running through Anthropic's `skill-creator` eval framework. When changing the skill, re-run the evals to catch regressions.
 
 ## Contributing
 

--- a/skills/serve-sim/SKILL.md
+++ b/skills/serve-sim/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: serve-sim
-description: Control and stream a running iOS, iPad, or Apple Watch Simulator with npx serve-sim. Use for simulator preview, taps, gestures, hardware buttons, rotation, camera injection, permissions, accessibility, and CoreAnimation debug.
+description: Control and stream a running iOS, iPad, or Apple Watch Simulator with npx serve-sim. Use for local or protected public previews, taps, gestures, hardware buttons, rotation, camera injection, permissions, accessibility, and CoreAnimation debug.
 license: Apache-2.0
 ---
 
@@ -33,10 +33,11 @@ Before any other action, verify the host satisfies these. If something is missin
 |---|---|---|
 | macOS host | `uname -s` returns `Darwin` | serve-sim only runs on macOS |
 | Xcode CLI tools | `xcrun --version` exits 0 | `simctl` is the underlying simulator driver |
-| Node.js ≥18 | `node --version` ≥18 | serve-sim is an npm package run via `npx` |
+| Node.js ≥20 | `node --version` ≥20 | serve-sim supports maintained Node.js LTS releases |
+| cloudflared (tunnels only) | `command -v cloudflared` exits 0 | Required only for `--tunnel` / `--public` |
 | macOS 14+ (optional) | `sw_vers -productVersion` ≥14 | Required ONLY for `camera` subcommand |
 
-A bundled helper script is available: `scripts/check-prereqs.sh`. Run it; if it exits non-zero, surface the message to the user.
+A bundled helper script is available: `scripts/check-prereqs.sh`. Run it; if it exits non-zero, surface the message to the user. Pass `--tunnel` when preparing a public preview so it also verifies `cloudflared`.
 
 A booted simulator is required for most subcommands. Check with `xcrun simctl list devices booted`. If none are booted, tell the user to open Xcode → Simulator or to run `xcrun simctl boot <UDID>`.
 
@@ -61,6 +62,7 @@ Key invariants the agent must respect:
 - **All coordinates are normalized 0..1**, with `(0, 0)` at top-left and `(1, 1)` at bottom-right of the display. Never pass pixel coordinates.
 - **One helper per device**. Multiple booted simulators are supported by passing several device names or by attaching to all.
 - **State lives in `$TMPDIR/serve-sim/server-{udid}.json`**. Use `serve-sim --list` to query it; do not read the JSON directly unless you know what you are doing.
+- **Detached tunnel state lives in `$TMPDIR/serve-sim/tunnel.json`**. Use the JSON returned by `--tunnel --detach -q`; do not scrape the state file for its private URL.
 - **The orientation set via `rotate` is remembered by the helper**, and subsequent gestures are rotated client-side. An agent that sends raw coords after a rotation does not need to compensate manually.
 
 ## Common operations
@@ -68,7 +70,9 @@ Key invariants the agent must respect:
 | Goal | Command | Notes |
 |---|---|---|
 | Start preview server | `npx serve-sim [device]` | Default preview at `http://localhost:3200`, stream at `:3100`. Foreground process. |
-| Start headless / daemon | `npx serve-sim --detach [device]` | Returns JSON with `pid`, `port`, `url`. Use for agent loops. |
+| Start headless / daemon | `npx serve-sim --detach [device]` | Returns JSON with `port`, `url`, and stream endpoints. Use for agent loops. |
+| Start protected public preview | `npx serve-sim --tunnel [device]` | Attached Cloudflare Quick Tunnel; prints a private tokenized URL. `--public` is an alias. |
+| Start public preview in background | `npx serve-sim --tunnel --detach -q [device]` | Returns JSON; give the user the complete `publicUrl`. See [references/tunnels.md](references/tunnels.md). |
 | Show stream in host's preview | `npx serve-sim --detach -q` → hand off `url` to host preview tool | See "Showing the stream in your agent's preview" section. |
 | List running streams | `npx serve-sim --list` | Add `-q` for JSON-only output. |
 | Stop all helpers | `npx serve-sim --kill` | Pass `[device]` to stop a specific one. |
@@ -110,6 +114,7 @@ By default, serve-sim prints human-readable status to stdout. For agent loops, p
 ```sh
 npx serve-sim --list -q          # JSON array of running streams
 npx serve-sim --detach -q        # JSON with pid/port/url after spawn
+npx serve-sim --tunnel --detach -q # JSON with publicUrl/localUrl after spawn
 npx serve-sim camera status -q   # JSON with {alive, source, mirror, ...}
 ```
 
@@ -141,6 +146,19 @@ The stream stays alive until `npx serve-sim --kill`. Multiple clients (the host'
 
 See [references/workflows.md](references/workflows.md) workflow "Show the simulator stream in the host's preview" for the full recipe.
 
+## Publishing the preview over the Internet
+
+When the user wants to connect from a remote PC or mobile device, use serve-sim's built-in protected Quick Tunnel instead of publishing the local URL yourself:
+
+```sh
+scripts/check-prereqs.sh --tunnel
+npx serve-sim --tunnel --detach -q
+```
+
+Parse and surface the complete `publicUrl`, including its `token` query parameter. Treat that URL as a credential: anyone who has it can view/control the simulator and use preview features that run host commands. Quick Tunnels do not provide an identity login or Cloudflare Access and are intended for temporary development/testing.
+
+If the user asks to keep it running, leave it detached and tell them that `npx serve-sim --kill` stops both the preview owner and its `cloudflared` child. Otherwise clean it up when the task finishes. Read [references/tunnels.md](references/tunnels.md) for prerequisites, browser handoff, security, lifecycle, and diagnostics.
+
 ## Workflows
 
 For complete end-to-end recipes (UI automation, camera testing, accessibility-driven taps, deep-link flows, preview handoff), see [references/workflows.md](references/workflows.md). The reference covers the patterns documented in serve-sim's own `AGENTS.md`.
@@ -154,14 +172,17 @@ npx serve-sim --kill            # stop all
 npx serve-sim --kill "iPhone 16 Pro"  # stop one
 ```
 
-Orphan helpers occupy ports 3200/3100 and prevent fresh starts.
+Orphan helpers occupy ports 3200/3100 and prevent fresh starts. `--kill` also stops a detached Quick Tunnel and its owned `cloudflared` child. Prefer it over signalling persisted PIDs directly.
 
 ## Anti-patterns
 
 - **Do not pass pixel coordinates.** All coords are normalized `0..1`. If the user gives pixel values, divide by the screen dimensions reported by `GET /config`.
 - **Do not use `gesture` for plain taps.** Use `tap`. See "Critical gotcha" above.
 - **Do not assume `npx serve-sim` is already running.** Verify with `--list` or by checking `$TMPDIR/serve-sim/server-{udid}.json`. If absent, start it explicitly.
-- **Do not skip the prerequisites check** on the first invocation in a session. Wrong macOS version, missing Xcode CLI tools, or Node <18 produce confusing errors downstream.
+- **Do not skip the prerequisites check** on the first invocation in a session. Wrong macOS version, missing Xcode CLI tools, or Node <20 produce confusing errors downstream.
+- **Do not publish a tunnel URL without its token.** A new remote browser needs the complete `publicUrl` once to establish its access cookie.
+- **Do not treat a Quick Tunnel as identity authentication.** The complete URL is a credential; use a managed tunnel with Cloudflare Access when the user needs identity policies.
+- **Do not use `kill -9` for cleanup.** Use `serve-sim --kill` so the preview owner can terminate its `cloudflared` child and remove runtime state.
 - **Do not invent button names.** Only these six are valid: `home`, `swipe_home`, `app_switcher`, `lock`, `siri`, `side_button`. See [references/buttons-rotation.md](references/buttons-rotation.md) for the source-of-truth list.
 - **Do not parse the non-quiet human output.** Use `-q` for JSON.
 - **Do not leave camera helpers running** across unrelated tasks. Stop them with `npx serve-sim camera --stop-webcam` when done.
@@ -175,4 +196,5 @@ Orphan helpers occupy ports 3200/3100 and prevent fresh starts.
 - [references/permissions.md](references/permissions.md) — granting/revoking app privacy permissions, including push notifications.
 - [references/ca-debug.md](references/ca-debug.md) — the five CoreAnimation debug flags and when each one helps.
 - [references/endpoints.md](references/endpoints.md) — HTTP and WebSocket endpoints for agents that bypass the CLI.
+- [references/tunnels.md](references/tunnels.md) — protected Quick Tunnel setup, remote handoff, security, lifecycle, and diagnostics.
 - [references/workflows.md](references/workflows.md) — end-to-end recipes for UI automation, camera testing, deep-link flows.

--- a/skills/serve-sim/evals/evals.json
+++ b/skills/serve-sim/evals/evals.json
@@ -31,7 +31,7 @@
       "name": "stream-and-pull-notification-center",
       "prompt": "Stream my simulator so I can share the URL remotely. Then drag down from the top edge to open Notification Center.",
       "expected_behavior": [
-        "Runs `npx serve-sim --detach -q` and surfaces the returned URL to the user.",
+        "Verifies `cloudflared` is installed, then runs `npx serve-sim --tunnel --detach -q` and surfaces the complete returned `publicUrl` to the user.",
         "Issues a gesture sequence (begin → move → end) with `edge: 2` (top), starting at low y (~0.02) and dragging down to y ~0.4.",
         "Each gesture call uses `npx serve-sim gesture '<json>'` with valid normalized coordinates.",
         "Does NOT use `tap` for this multi-step gesture."
@@ -73,6 +73,21 @@
         "If no such tool is available, explicitly tells the user that and instructs them to open the URL in their host's browser/preview pane.",
         "Does NOT try to install, build, or launch the app — assumes the simulator + app are already running per the prompt.",
         "Does NOT invent a host-specific tool name that doesn't exist in the current session."
+      ],
+      "files": []
+    },
+    {
+      "id": 7,
+      "name": "protected-quick-tunnel",
+      "prompt": "My simulator is already open. Publish serve-sim so I can control it from my phone, give me the URL, and keep it running in the background until I say I am done.",
+      "expected_behavior": [
+        "Runs `scripts/check-prereqs.sh --tunnel` or otherwise verifies macOS, Node 20+, Xcode tools, a booted simulator, and `cloudflared` before starting.",
+        "Runs `npx serve-sim --tunnel --detach -q` (the `--public` alias is also accepted).",
+        "Parses the returned JSON and surfaces the complete `publicUrl`, including its `token` query parameter, plainly to the user.",
+        "Warns that the complete URL is a credential: anyone with it can view/control the simulator and invoke preview features that run host commands.",
+        "Does not claim that Quick Tunnels provide Cloudflare Access, identity login, a stable hostname, or production guarantees.",
+        "Leaves the tunnel running because the user explicitly requested that, and explains that `npx serve-sim --kill` stops both the detached preview owner and its `cloudflared` child.",
+        "Does not expose the token in diagnostics, issues, or unrelated output."
       ],
       "files": []
     }

--- a/skills/serve-sim/references/tunnels.md
+++ b/skills/serve-sim/references/tunnels.md
@@ -1,0 +1,113 @@
+# Public Quick Tunnels
+
+Use this workflow when the user wants to open and control serve-sim from a
+different computer or mobile device without RDP, a VPN, or a LAN connection.
+
+## Prerequisites
+
+Quick Tunnel mode requires `cloudflared` on the macOS host in addition to the
+normal serve-sim prerequisites:
+
+```sh
+scripts/check-prereqs.sh --tunnel
+```
+
+If it is missing, tell the user to install it and stop. Do not silently install
+software:
+
+```sh
+brew install cloudflared
+```
+
+A Cloudflare account or login is not required for a Quick Tunnel.
+
+## Start and hand off a detached tunnel
+
+For an agent workflow, prefer detached JSON output:
+
+```sh
+TUNNEL_JSON=$(npx serve-sim --tunnel --detach -q)
+PUBLIC_URL=$(echo "$TUNNEL_JSON" | jq -r '.publicUrl')
+
+if [[ -z "$PUBLIC_URL" || "$PUBLIC_URL" == "null" ]]; then
+  echo "serve-sim did not return a public tunnel URL" >&2
+  exit 1
+fi
+
+echo "Simulator public URL: $PUBLIC_URL"
+```
+
+`--public` is an alias for `--tunnel`. The returned `publicUrl` is the
+human-facing preview. Always give the user the complete URL, including the
+`token` query parameter, so they can copy it into a remote PC or mobile
+browser. Do not substitute the local URL or a raw stream URL.
+
+The first browser request exchanges the query token for a secure, HTTP-only,
+host-only cookie and redirects to a clean URL. Each new browser profile or
+device must open the complete tokenized URL once.
+
+## Security model
+
+Treat the complete URL as a credential:
+
+- Anyone with it can view and control the simulator.
+- An authorized preview can use features that execute commands on the host.
+- Do not paste it into logs, issues, PRs, or unrelated chat messages.
+- Quick Tunnels do not add Cloudflare Access or an identity login. The random
+  hostname plus serve-sim's access token are the protection.
+- Quick Tunnels are for temporary development/testing. For a stable hostname,
+  identity policy, or production guarantees, recommend a managed Cloudflare
+  Tunnel with Cloudflare Access instead.
+
+The preview origin remains bound to `127.0.0.1`; serve-sim does not open a LAN
+listener in tunnel mode.
+
+## Attached versus detached lifecycle
+
+Attached mode:
+
+```sh
+npx serve-sim --tunnel
+```
+
+The terminal stays attached. `Ctrl+C` stops both serve-sim and its
+`cloudflared` child.
+
+Detached mode:
+
+```sh
+npx serve-sim --tunnel --detach -q
+```
+
+The preview owner and `cloudflared` continue in the background. Stop them with:
+
+```sh
+npx serve-sim --kill
+```
+
+Ending the preview owner through the normal process-termination paths
+(`SIGINT`, `SIGTERM`, `SIGHUP`, or `--kill`) also ends its `cloudflared` child.
+Do not use `kill -9`: `SIGKILL` prevents every application from running its
+cleanup handlers.
+
+When the user explicitly asks to keep the tunnel running, leave it running and
+state how to stop it. Otherwise, follow the skill's normal cleanup rule and run
+`npx serve-sim --kill` when the task is finished.
+
+## Diagnostics
+
+Tunnel state and diagnostics follow serve-sim's runtime-state convention:
+
+```text
+$TMPDIR/serve-sim/tunnel.json
+$TMPDIR/serve-sim/tunnel.log
+```
+
+Both files are owner-only (`0600`). The log contains lifecycle events and raw
+`cloudflared` output but not the private access token. Prefer the log when a
+tunnel exits or never becomes ready; do not add polling, heartbeats, or a
+second logging system.
+
+If `cloudflared` is absent, serve-sim exits before booting or publishing the
+preview and prints the install command. If a detached launch fails, surface the
+reported error and the diagnostics path rather than guessing at a URL.

--- a/skills/serve-sim/scripts/check-prereqs.sh
+++ b/skills/serve-sim/scripts/check-prereqs.sh
@@ -5,6 +5,14 @@
 
 set -u
 
+TUNNEL_MODE=false
+if [[ "${1:-}" == "--tunnel" ]]; then
+  TUNNEL_MODE=true
+elif [[ "$#" -gt 0 ]]; then
+  echo "usage: $0 [--tunnel]" >&2
+  exit 2
+fi
+
 fail() {
   echo "serve-sim prereq check failed: $1" >&2
   exit 1
@@ -23,13 +31,18 @@ if ! xcrun --find simctl >/dev/null 2>&1; then
   fail "simctl not found via xcrun. Install Xcode command line tools."
 fi
 
-# Node 18+
+# Maintained Node.js LTS (20+)
 if ! command -v node >/dev/null 2>&1; then
-  fail "node not found. Install Node.js 18 or newer (https://nodejs.org)."
+  fail "node not found. Install Node.js 20 or newer (https://nodejs.org)."
 fi
 NODE_MAJOR="$(node -e 'console.log(process.versions.node.split(".")[0])')"
-if [[ "$NODE_MAJOR" -lt 18 ]]; then
-  fail "node $NODE_MAJOR detected. serve-sim requires Node.js 18+."
+if [[ "$NODE_MAJOR" -lt 20 ]]; then
+  fail "node $NODE_MAJOR detected. serve-sim requires Node.js 20+."
+fi
+
+# cloudflared is optional unless the caller intends to publish a Quick Tunnel.
+if [[ "$TUNNEL_MODE" == true ]] && ! command -v cloudflared >/dev/null 2>&1; then
+  fail "cloudflared not found. Install it with: brew install cloudflared"
 fi
 
 # macOS 14+ is optional (camera-only), so warn rather than fail

--- a/skills/serve-sim/scripts/check-prereqs.sh
+++ b/skills/serve-sim/scripts/check-prereqs.sh
@@ -8,7 +8,10 @@ set -u
 TUNNEL_MODE=false
 if [[ "${1:-}" == "--tunnel" ]]; then
   TUNNEL_MODE=true
-elif [[ "$#" -gt 0 ]]; then
+  shift
+fi
+
+if [[ "$#" -gt 0 ]]; then
   echo "usage: $0 [--tunnel]" >&2
   exit 2
 fi


### PR DESCRIPTION
## Summary

This adds an opt-in Cloudflare Quick Tunnel mode to `serve-sim` so the full simulator preview can be opened from a remote computer or mobile browser without exposing a LAN listener or using a remote-desktop session.

The new workflow is available through:

```sh
serve-sim --tunnel [device...]
serve-sim --tunnel --detach [device...]
```

`--public` is retained as a hidden alias for `--tunnel`. Quick Tunnel mode requires an existing `cloudflared` installation, but does not require a Cloudflare account or login.

The implementation includes an application-level access gate because a Cloudflare Quick Tunnel provides transport and a random hostname, not identity authentication. It also makes the tunnel lifecycle part of the existing `serve-sim` process lifecycle, including detached startup, diagnostics, ownership validation, and cleanup.

## Motivation

`serve-sim` already exposes a complete browser-based simulator control surface, but its normal preview URL is local to the Mac running Simulator. Reaching that preview from another device otherwise requires LAN connectivity, a VPN, manual reverse-proxy setup, or an RDP-style session.

This change makes temporary remote access a deliberate CLI choice while preserving the existing local default:

- Normal `serve-sim` behavior is unchanged.
- Tunnel mode binds the preview origin to `127.0.0.1`.
- `cloudflared` publishes that loopback origin through a temporary `trycloudflare.com` URL.
- The complete printed URL acts as a private launch credential.
- Attached and detached modes have explicit, observable cleanup behavior.

## User-facing behavior

### Attached mode

```sh
serve-sim --tunnel
```

The CLI prints both the local URL and a tokenized public URL. The process stays attached to the terminal, and `Ctrl+C`, `SIGTERM`, or `SIGHUP` stops the preview and its owned `cloudflared` child.

### Detached mode

```sh
serve-sim --tunnel --detach -q
```

The launcher waits until the simulator preview and Quick Tunnel are ready, then returns JSON containing `publicUrl`, `localUrl`, process IDs, selected devices, the bound port, and the normalized launch configuration. `serve-sim --kill` stops the detached preview owner and its `cloudflared` child.

If an identical detached tunnel is already running, the command returns that state. If devices or preview options differ, it fails with an explicit instruction to stop the existing tunnel first instead of silently returning the wrong preview.

### Missing dependency

If `cloudflared` is absent, tunnel mode exits before booting or publishing the preview and prints the Homebrew install command:

```sh
brew install cloudflared
```

The command passes `--config /dev/null` to `cloudflared` so a user-level named-tunnel configuration cannot interfere with Quick Tunnel startup.

## Access protection

Quick Tunnels do not add Cloudflare Access or an identity login, so `serve-sim` protects the public control surface itself:

- A cryptographically random 256-bit URL-safe token is generated for every tunnel owner.
- The complete public URL includes that token as a query parameter.
- The browser's first request exchanges the token for an HTTP-only, host-only, `SameSite=Strict` cookie; public HTTPS requests also receive the `Secure` attribute.
- The redirect removes the token from the browser address bar.
- Public HTTP routes and WebSocket upgrades require the cookie.
- Browser control requests with an `Origin` header must match the exact tunnel origin, preventing a sibling `trycloudflare.com` page from driving the control surface with an existing cookie.
- The preview origin remains bound to `127.0.0.1`; tunnel mode rejects a conflicting `--host` value.

Local CLI commands continue to use the credential-free loopback URLs stored in the existing per-device state files. The access gate allows those requests only when the request host is loopback and no proxy forwarding protocol is present. Forwarded requests remain protected even if they present a loopback `Host` header.

The complete URL is still a credential: anyone who receives it can view and control the simulator and use preview features that execute commands on the host. The README and bundled AI skill call this out directly and recommend a managed Cloudflare Tunnel with Access for stable hostnames or identity policies.

## Process ownership and lifecycle

The tunnel owner writes owner-only state and diagnostics under the existing runtime-state directory:

```text
$TMPDIR/serve-sim/tunnel.json
$TMPDIR/serve-sim/tunnel.log
```

Both files are mode `0600`. The log follows the project's existing persistent runtime diagnostics convention and records lifecycle events plus `cloudflared` output without writing the private access token.

Lifecycle handling includes:

- Owner-verified cleanup before signalling a persisted PID.
- A second ownership check before escalating from `SIGTERM` to `SIGKILL`, avoiding stale PID reuse.
- Complete multi-device ownership validation rather than accepting a partially matching state set.
- Automatic `cloudflared` termination when the preview owner exits through normal signal paths.
- Detached launcher signal handlers that terminate the detached process group if startup is interrupted.
- Process-group signalling with a direct-PID fallback for platforms or test environments where the group is unavailable.
- A macOS `caffeinate -w` companion for deliberately detached public previews; it exits with the preview owner.
- State removal only by the process that still owns it.

## Detached launch identity

Detached state persists a normalized launch signature containing:

- resolved device UDIDs and order
- requested port and whether it was explicitly supplied
- codec
- initial panes
- fit mode
- theme

An existing tunnel is reused only when this signature matches exactly. Legacy state without a launch signature is not silently reused.

## Runtime re-execution fix

Both regular `--detach` and tunnel detachment re-execute the CLI. npm/npx commonly invokes the package through an extensionless `.bin/serve-sim` symlink, which cannot be classified by filename extension.

Re-execution now classifies the runtime through `process.execPath`:

- Node and Bun script runtimes include `process.argv[1]`, even when the entrypoint is extensionless.
- A Bun-compiled binary re-executes itself without appending its virtual `/$bunfs/...` entrypoint.

This preserves compiled-binary behavior while fixing both the existing npm/npx `--detach` path and the documented `npx serve-sim --tunnel --detach` path.

## Startup timing and diagnostics

The detached launcher previously used a fixed deadline that could be shorter than the child process's supported startup behavior. Its deadline now includes:

- 60 seconds for each simulator's `simctl bootstatus`
- 30 seconds for Quick Tunnel readiness
- 15 seconds of launcher/scheduling grace

If startup still fails, the launcher terminates the detached process group and surfaces the tail of the persistent tunnel log instead of leaving an orphaned preview or tunnel.

## Review findings addressed

This version includes regression coverage and fixes for the blocking review findings found during local testing:

1. Extensionless npm/npx entrypoints now retain the CLI script when re-executing under Node.
2. Local CLI HTTP and WebSocket commands remain usable while the public access gate is active.
3. Interrupting the detached launcher during readiness tears down the detached process group.
4. Existing tunnels are reused only for an exact device and preview-option match.
5. The launcher startup budget covers all simulator boot waits plus Cloudflare readiness.
6. Persisted process ownership is revalidated before signalling and again before escalation.
7. Tunnel-only access/proxy behavior remains internal to the standalone CLI instead of adding a partially implemented public middleware mode.
8. Generated `.playwright-mcp/` logs and snapshots are ignored and are not part of the published change set.

## Documentation and AI skill

The package README now documents:

- `--tunnel` and detached usage
- remote PC/mobile access
- `cloudflared` installation and failure behavior
- the token/cookie security model
- attached and detached cleanup
- diagnostics locations
- Quick Tunnel limitations and the managed Tunnel + Access alternative

The bundled `serve-sim` skill now includes:

- Node 20+ and tunnel-specific prerequisite checks
- `scripts/check-prereqs.sh --tunnel`
- public preview commands and URL handoff guidance
- lifecycle and security anti-patterns
- a dedicated `references/tunnels.md` workflow
- an additional tunnel-focused evaluation prompt

## Validation

Automated checks:

```sh
bun run typecheck
bun run lint
bun run packages/serve-sim/build.ts
bun test packages/serve-sim/src/__tests__/bundle-portability.test.ts \
  packages/serve-sim/src/__tests__/runtime-reexec.test.ts \
  packages/serve-sim/src/__tests__/quick-tunnel.test.ts
jq empty skills/serve-sim/evals/evals.json
bash -n skills/serve-sim/scripts/check-prereqs.sh
```

Results:

- TypeScript passed.
- oxlint reported 0 warnings and 0 errors.
- The complete JS, compiled CLI, camera dylib/helper, AX helper, and N-API native build passed.
- 31 focused portability, re-execution, access-control, ownership, launch-identity, timeout, and process-group tests passed.
- The skill eval JSON and prerequisite script syntax validated.

Manual CLI validation covered:

- Regular detached startup through an extensionless npm-style `serve-sim` entrypoint.
- Detached tunnel startup through that same extensionless entrypoint.
- Identical launch reuse without spawning a replacement owner.
- Rejection of a codec/configuration mismatch while preserving the existing owner.
- Credential-free local `event-log` HTTP access during tunnel mode.
- Credential-free local `tap` WebSocket access during tunnel mode.
- Successful direct-loopback preview access and `401` for unauthenticated forwarded traffic.
- `Ctrl+C` during detached startup leaving no preview process, `cloudflared` process, state file, or listening port.
- `serve-sim --kill` and direct owner termination cleaning up the owned `cloudflared` process and runtime state.
- Real Quick Tunnel creation, token-to-cookie exchange, preview configuration, helper streaming, and control WebSocket access with `cloudflared 2026.7.1`.

The broader real-Simulator suite produced 375 passes and 3 skips. Two teardown-time failures were investigated separately: the camera-helper shutdown test passed on isolated rerun, while all 10 UI-settings assertions pass but its serial `afterAll` reset exceeds Bun's default hook timeout on this machine.

## Scope and compatibility

- Existing local and LAN preview behavior remains the default.
- The public `simMiddleware` package API is unchanged by tunnel authentication.
- Node support follows the repository's maintained-LTS policy (`>=20`).
- `cloudflared` is required only when the user explicitly selects tunnel mode.
- Quick Tunnels remain a temporary development/testing feature, not a replacement for Cloudflare Access or production tunnel management.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added protected Cloudflare Quick Tunnel support to `serve-sim`, including `--tunnel` and `--public` tokenized URL sharing.
  - Introduced detached tunnel preview lifecycle handling, including safe cleanup and `--kill`.
  - Updated runtime behavior to support re-execution across Node/Bun/bin entrypoints.

- **Documentation**
  - Expanded CLI, skill, and reference docs with tunnel prerequisites (Node 20+ and `cloudflared`), security notes, and updated tunnel examples/evals.

- **Tests**
  - Added Bun test coverage for tunnel access protection, URL parsing, ownership matching, detached startup/shutdown behavior, and runtime re-exec.

- **Chores**
  - Updated ignore rules to exclude Playwright tunnel state artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->