### PR TITLE
feat(cli): add state command (lock state, screen awake, frontmost app)

### DIFF
--- a/packages/serve-sim/README.md
+++ b/packages/serve-sim/README.md
@@ -53,6 +53,8 @@ serve-sim ca-debug <option> <on|off> [-d udid]
                                       (blended|copies|misaligned|offscreen|slow-animations)
 serve-sim memory-warning [-d udid]    Simulate a memory warning
 serve-sim event-log [-d udid]         Show recent simulator events
+serve-sim state [-d udid]             Print device state as JSON
+                                      ({locked, frontmostApp})
 
 serve-sim camera <bundle-id> [-d udid] [source-options]
                                       Inject a synthetic camera feed and (re)launch the app

--- a/packages/serve-sim/src/__tests__/device-state.test.ts
+++ b/packages/serve-sim/src/__tests__/device-state.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import {
+  LOCKSTATE_KEY,
+  parseNotifyState,
+  readDeviceState,
+  type DeviceStateDeps,
+} from "../device-state";
+
+const UDID = "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE";
+
+function deps(overrides: Partial<DeviceStateDeps> = {}): DeviceStateDeps {
+  return {
+    run: async () => `${LOCKSTATE_KEY} 0`,
+    frontmost: async () => JSON.stringify({ bundleId: "com.apple.springboard", pid: 42 }),
+    ...overrides,
+  };
+}
+
+describe("parseNotifyState", () => {
+  test("parses '<key> N' output", () => {
+    expect(parseNotifyState(`${LOCKSTATE_KEY} 1`, LOCKSTATE_KEY)).toBe(1);
+    expect(parseNotifyState(`${LOCKSTATE_KEY} 0`, LOCKSTATE_KEY)).toBe(0);
+  });
+
+  test("finds the key among other lines", () => {
+    const out = `something else\n${LOCKSTATE_KEY} 1\ntrailing`;
+    expect(parseNotifyState(out, LOCKSTATE_KEY)).toBe(1);
+  });
+
+  test("returns null for missing key or malformed value", () => {
+    expect(parseNotifyState("", LOCKSTATE_KEY)).toBeNull();
+    expect(parseNotifyState("other.key 1", LOCKSTATE_KEY)).toBeNull();
+    expect(parseNotifyState(`${LOCKSTATE_KEY} nope`, LOCKSTATE_KEY)).toBeNull();
+    expect(parseNotifyState(LOCKSTATE_KEY, LOCKSTATE_KEY)).toBeNull();
+  });
+});
+
+describe("readDeviceState", () => {
+  test("reports locked=true when SpringBoard says 1", async () => {
+    const state = await readDeviceState(UDID, deps({ run: async () => `${LOCKSTATE_KEY} 1` }));
+    expect(state).toEqual({ locked: true, frontmostApp: "com.apple.springboard" });
+  });
+
+  test("reports locked=false when SpringBoard says 0", async () => {
+    const state = await readDeviceState(UDID, deps());
+    expect(state).toEqual({ locked: false, frontmostApp: "com.apple.springboard" });
+  });
+
+  test("passes the udid to notifyutil via simctl spawn", async () => {
+    const calls: string[][] = [];
+    await readDeviceState(UDID, deps({
+      run: async (file, args) => {
+        calls.push([file, ...args]);
+        return `${LOCKSTATE_KEY} 0`;
+      },
+    }));
+    expect(calls).toEqual([
+      ["xcrun", "simctl", "spawn", UDID, "notifyutil", "-g", LOCKSTATE_KEY],
+    ]);
+  });
+
+  test("locked is null when notifyutil fails or prints garbage", async () => {
+    const failed = await readDeviceState(UDID, deps({
+      run: async () => { throw new Error("Invalid device state"); },
+    }));
+    expect(failed.locked).toBeNull();
+
+    const garbled = await readDeviceState(UDID, deps({ run: async () => "no such key" }));
+    expect(garbled.locked).toBeNull();
+  });
+
+  test("frontmostApp is null when the AX probe fails", async () => {
+    const state = await readDeviceState(UDID, deps({
+      frontmost: async () => { throw new Error("ax unavailable"); },
+    }));
+    expect(state).toEqual({ locked: false, frontmostApp: null });
+  });
+
+  test("frontmostApp is null for malformed or empty probe output", async () => {
+    const malformed = await readDeviceState(UDID, deps({ frontmost: async () => "not json" }));
+    expect(malformed.frontmostApp).toBeNull();
+
+    const empty = await readDeviceState(UDID, deps({ frontmost: async () => "{}" }));
+    expect(empty.frontmostApp).toBeNull();
+  });
+
+  test("one failing probe does not blank the other", async () => {
+    const state = await readDeviceState(UDID, deps({
+      run: async () => { throw new Error("spawn failed"); },
+    }));
+    expect(state).toEqual({ locked: null, frontmostApp: "com.apple.springboard" });
+  });
+});

--- a/packages/serve-sim/src/device-state.ts
+++ b/packages/serve-sim/src/device-state.ts
@@ -1,0 +1,89 @@
+import { execFile } from "child_process";
+import { findBootedDevice, resolveDevice } from "./device";
+import { axFrontmostAsync } from "./native";
+
+// ─── `serve-sim state` ───
+//
+// One-shot device-state probe for agents driving a sim headless (#137):
+// whether SpringBoard considers the device locked, and which app is frontmost.
+// Standalone like `serve-sim ui` — reads go through `simctl spawn notifyutil`
+// and the in-process AX addon, so no serve-sim server needs to be running.
+
+export const LOCKSTATE_KEY = "com.apple.springboard.lockstate";
+
+export interface DeviceState {
+  /** SpringBoard lock state, or null when it can't be read. */
+  locked: boolean | null;
+  /** Bundle id of the frontmost app, or null when the AX probe fails. */
+  frontmostApp: string | null;
+}
+
+/** Injectable backends so tests can run without a simulator. */
+export interface DeviceStateDeps {
+  /** Run `file args…` and resolve with trimmed stdout. */
+  run: (file: string, args: string[]) => Promise<string>;
+  /** Frontmost-app probe returning `{ bundleId, pid }` JSON (native addon). */
+  frontmost: (udid: string) => Promise<string>;
+}
+
+function run(file: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(file, args, { encoding: "utf-8" }, (err, stdout, stderr) => {
+      if (err) reject(new Error(String(stderr).trim() || err.message));
+      else resolve(String(stdout).trim());
+    });
+  });
+}
+
+const defaultDeps: DeviceStateDeps = { run, frontmost: axFrontmostAsync };
+
+/**
+ * Parse `notifyutil -g <key>` output ("<key> N") into its integer state, or
+ * null when the output doesn't match (e.g. notifyutil errored or the key line
+ * is missing).
+ */
+export function parseNotifyState(output: string, key: string): number | null {
+  for (const line of output.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith(key)) continue;
+    const value = trimmed.slice(key.length).trim();
+    if (/^\d+$/.test(value)) return Number(value);
+  }
+  return null;
+}
+
+async function readLocked(udid: string, deps: DeviceStateDeps): Promise<boolean | null> {
+  try {
+    const out = await deps.run("xcrun", ["simctl", "spawn", udid, "notifyutil", "-g", LOCKSTATE_KEY]);
+    const state = parseNotifyState(out, LOCKSTATE_KEY);
+    return state == null ? null : state !== 0;
+  } catch {
+    return null;
+  }
+}
+
+async function readFrontmostApp(udid: string, deps: DeviceStateDeps): Promise<string | null> {
+  try {
+    const info = JSON.parse(await deps.frontmost(udid)) as { bundleId?: unknown };
+    return typeof info.bundleId === "string" && info.bundleId.length > 0 ? info.bundleId : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Probe the device and report its state; fields that can't be read are null. */
+export function readDeviceState(udid: string, deps: DeviceStateDeps = defaultDeps): Promise<DeviceState> {
+  return Promise.all([readLocked(udid, deps), readFrontmostApp(udid, deps)]).then(
+    ([locked, frontmostApp]) => ({ locked, frontmostApp }),
+  );
+}
+
+/** CLI entry (`serve-sim state [-d udid]`): print the state as one JSON object. */
+export async function deviceState(deviceArg?: string): Promise<void> {
+  const udid = deviceArg ? resolveDevice(deviceArg) : findBootedDevice();
+  if (!udid) {
+    console.error("No booted simulator found. Boot one or pass -d <udid>.");
+    process.exit(1);
+  }
+  console.log(JSON.stringify(await readDeviceState(udid)));
+}

--- a/packages/serve-sim/src/index.ts
+++ b/packages/serve-sim/src/index.ts
@@ -10,6 +10,7 @@ import { textToKeyEvents, UnsupportedCharacterError, sendKeyEventsToWs } from ".
 import { dirnameOf, sleepSync, isPortFree, servePreview } from "./runtime";
 import { killPortHolder } from "./ports";
 import { findBootedDevice, resolveDevice } from "./device";
+import { deviceState } from "./device-state";
 import { permissions } from "./permissions";
 import { setUiOption, uiSettings } from "./ui-settings";
 import { debugCli, debugHelper, debugState } from "./debug";
@@ -1858,6 +1859,12 @@ program
   .description("Simulate a memory warning on the device")
   .option(...deviceOpt)
   .action((opts) => memoryWarning(opts.device));
+
+program
+  .command("state")
+  .description("Print device state as JSON (lock state, frontmost app)")
+  .option(...deviceOpt)
+  .action((opts) => deviceState(opts.device));
 
 program
   .command("event-log")


### PR DESCRIPTION
closes #137. when an agent is driving a sim headless it can't tell if the device is locked or what app is up, so we were doing raw notifyutil reads and checking dark pixel fractions on screenshots to guess at state, which is gross. this adds `serve-sim state`:

```
$ serve-sim state
{"locked":false,"frontmostApp":"com.apple.Preferences"}
```

works standalone like `serve-sim ui` (no server needed) — `locked` reads `com.apple.springboard.lockstate` via `simctl spawn notifyutil -g`, `frontmostApp` reuses the `axFrontmost` native probe. fields that can't be read come back null instead of wrong (shutdown device gives `{"locked":null,"frontmostApp":null}`).

i left `screenAwake` out for now: the plan was `com.apple.springboard.hasBlankedScreen`, and it reads fine, but i couldn't get the sim to actually sleep headless to confirm it flips to 1, and reporting a screen as awake when it isn't is exactly the bug this command exists to kill. happy to add it in a follow-up once i can verify it.

added a unit test with mocked probes (bun test, lint, typecheck all pass), verified against booted iOS 26.5 and 27.0 sims — frontmost tracks app launches correctly.

totally open to reshaping the output if you want it different.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `serve-sim state` command that displays the selected simulator’s lock status and frontmost app as JSON.
  * Supports selecting a simulator with the existing device option.
  * Reports unavailable state values as `null`.

* **Documentation**
  * Updated CLI documentation with usage details for the new command.

* **Tests**
  * Added coverage for state parsing, simulator selection, probe failures, malformed output, and independent state results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->