### PR TITLE
fix(serve-sim): restore Xcode 27 Device Hub streaming and input

### DIFF
--- a/packages/serve-sim/Package.swift
+++ b/packages/serve-sim/Package.swift
@@ -31,8 +31,12 @@ let package = Package(
     ],
     targets: [
         .target(
+            name: "SimNativeSupport"
+        ),
+        .target(
             name: "SimNative",
             dependencies: [
+                "SimNativeSupport",
                 .product(name: "NodeAPI", package: "node-swift"),
                 .product(name: "NodeModuleSupport", package: "node-swift"),
             ],
@@ -45,6 +49,10 @@ let package = Package(
                     "-Xlinker", "dynamic_lookup",
                 ])
             ]
+        ),
+        .testTarget(
+            name: "SimNativeSupportTests",
+            dependencies: ["SimNativeSupport"]
         ),
     ],
     // The reused SimStreamHelper logic was written against the standalone helper

--- a/packages/serve-sim/README.md
+++ b/packages/serve-sim/README.md
@@ -36,6 +36,8 @@ Requires macOS with Xcode command line tools (`xcrun simctl`) and a [maintained 
 
 > **Note:** Apple Silicon (arm64) only. The bundled `serve-sim-bin` helper ships as an arm64 binary and does not run on Intel (x86_64) Macs.
 
+> **Xcode 27 keyboard input:** Device Hub must be running with the target simulator window visible and frontmost. macOS may also require the app that launched `serve-sim` (for example Terminal) to be enabled in **System Settings → Privacy & Security → Accessibility**. Xcode 26 and older keep using the legacy simulator HID path. Set `SERVE_SIM_DISABLE_DEVICE_HUB_KEYBOARD=1` to opt out of the Xcode 27 bridge.
+
 ## CLI
 
 ```

--- a/packages/serve-sim/Sources/SimNative/CaptureEngine.swift
+++ b/packages/serve-sim/Sources/SimNative/CaptureEngine.swift
@@ -48,7 +48,7 @@ actor CaptureConsumer<E: FrameEncoder>: CaptureConsuming {
                     let encoded = try await encoder.encode(frame)
                     await onFrame(encoded)
                 } catch {
-                    print("error encoding frame: \(error)")
+                    print("error encoding \(E.self) frame: \(error)")
                     continue
                 }
             }
@@ -101,6 +101,8 @@ actor CaptureEngine {
         } catch {
             // Preserve retryability after an ordinary start failure, but never
             // overwrite a concurrent stop() that moved the actor to .stopped.
+            frameContinuation.finish()
+            await frameCapture.stop()
             if phase == .starting { phase = .unstarted }
             throw error
         }
@@ -163,7 +165,7 @@ actor CaptureEngine {
             let flagDescription: Int32 = 1 << 0
             let flagKeyframe: Int32 = 1 << 1
 
-            guard let self else { return }
+            guard let self, let encoded else { return }
             if let description = encoded.description {
                 await onFrame(
                     screenSize,
@@ -218,13 +220,13 @@ actor AVCCEncoder: FrameEncoder {
 
     init() {}
 
-    func encode(_ frame: Frame) async throws -> H264Encoder.Encoded {
+    func encode(_ frame: Frame) async throws -> H264Encoder.Encoded? {
         // TODO: cancel after timeout using TaskGroup
         let result = try await h264Encoder.encode(
             frame.pixelBuffer,
             forceKeyframe: forceKeyframe,
         )
-        forceKeyframe = false
+        if result != nil { forceKeyframe = false }
         return result
     }
 

--- a/packages/serve-sim/Sources/SimNative/CaptureEngine.swift
+++ b/packages/serve-sim/Sources/SimNative/CaptureEngine.swift
@@ -94,8 +94,23 @@ actor CaptureEngine {
             // drop old frames if there's backpressure
             bufferingPolicy: .bufferingNewest(1)
         )
-        try await frameCapture.start(deviceUDID: deviceUDID) { pixelBuffer, _ in
-            frameContinuation.yield(Frame(pixelBuffer: pixelBuffer))
+        do {
+            try await frameCapture.start(deviceUDID: deviceUDID) { pixelBuffer, _ in
+                frameContinuation.yield(Frame(pixelBuffer: pixelBuffer))
+            }
+        } catch {
+            // Preserve retryability after an ordinary start failure, but never
+            // overwrite a concurrent stop() that moved the actor to .stopped.
+            if phase == .starting { phase = .unstarted }
+            throw error
+        }
+        // Actor methods are reentrant across the await above. A simulator can
+        // be shut down while FrameCapture is starting; do not resurrect a
+        // session that stop() already marked stopped.
+        guard phase == .starting else {
+            frameContinuation.finish()
+            await frameCapture.stop()
+            throw CancellationError()
         }
         Task {
             for await frame in frames {

--- a/packages/serve-sim/Sources/SimNative/DeviceHubKeyboardBridge.swift
+++ b/packages/serve-sim/Sources/SimNative/DeviceHubKeyboardBridge.swift
@@ -1,3 +1,4 @@
+import ApplicationServices
 import AppKit
 import CoreGraphics
 import Foundation
@@ -13,9 +14,11 @@ import SimNativeSupport
 ///
 /// CGEvent can target an application, not one of its windows. To avoid typing
 /// into a different simulator, the first key-down is accepted only when the
-/// target device name identifies one visible, frontmost Device Hub window. That
-/// route remains latched until every posted key is released, so one chord never
-/// splits between Device Hub and the legacy Indigo fallback.
+/// target device name identifies one visible, focused Device Hub window through
+/// Accessibility. Accessibility titles remain available when CGWindow titles
+/// are redacted without Screen Recording permission. The route remains latched
+/// until every posted key is released, so one chord never splits between Device
+/// Hub and the legacy Indigo fallback.
 final class DeviceHubKeyboardBridge {
     private static let bundleIdentifier = "com.apple.dt.Devices"
     private static let minimumXcodeMajorVersion = 27
@@ -27,6 +30,7 @@ final class DeviceHubKeyboardBridge {
     private let expectedBundleURL: URL
     private let deviceUDID: String
     private let deviceName: String
+    private let targetWindowTitle: String
 
     private var activeTarget: ActiveTarget?
     private var pressedUsages = Set<UInt32>()
@@ -35,16 +39,26 @@ final class DeviceHubKeyboardBridge {
     private init(
         expectedBundleURL: URL,
         deviceUDID: String,
-        deviceName: String
+        deviceName: String,
+        runtimeName: String
     ) {
         self.expectedBundleURL = expectedBundleURL.resolvingSymlinksInPath().standardizedFileURL
         self.deviceUDID = deviceUDID
         self.deviceName = deviceName
+        self.targetWindowTitle = "\(deviceName) – \(runtimeName)"
     }
 
-    static func makeIfSupported(deviceUDID: String, deviceName: String) -> DeviceHubKeyboardBridge? {
+    static func makeIfSupported(
+        deviceUDID: String,
+        deviceName: String,
+        runtimeName: String?
+    ) -> DeviceHubKeyboardBridge? {
         let environment = ProcessInfo.processInfo.environment
-        guard environment["SERVE_SIM_DISABLE_DEVICE_HUB_KEYBOARD"] == nil else { return nil }
+        guard !DeviceHubKeyboardConfiguration.isDisabled(
+            environmentValue: environment["SERVE_SIM_DISABLE_DEVICE_HUB_KEYBOARD"]
+        ) else {
+            return nil
+        }
 
         let developerURL = URL(fileURLWithPath: Xcode.developerDir(), isDirectory: true)
         let xcodeURL = developerURL
@@ -61,10 +75,12 @@ final class DeviceHubKeyboardBridge {
             .appendingPathComponent("DeviceHub.app", isDirectory: true)
         guard FileManager.default.fileExists(atPath: deviceHubURL.path) else { return nil }
 
+        guard let runtimeName, !runtimeName.isEmpty else { return nil }
         return DeviceHubKeyboardBridge(
             expectedBundleURL: deviceHubURL,
             deviceUDID: deviceUDID,
-            deviceName: deviceName
+            deviceName: deviceName,
+            runtimeName: runtimeName
         )
     }
 
@@ -147,9 +163,9 @@ final class DeviceHubKeyboardBridge {
 
         let processIdentifier = application.processIdentifier
         let route = DeviceHubWindowRouter.route(
-            windows: Self.visibleWindows(),
+            windows: Self.visibleWindows(processIdentifier: processIdentifier),
             processIdentifier: processIdentifier,
-            targetDeviceName: deviceName
+            targetWindowTitle: targetWindowTitle
         )
         switch route {
         case .success:
@@ -173,34 +189,64 @@ final class DeviceHubKeyboardBridge {
         runningDeviceHubs().contains { $0.processIdentifier == processIdentifier }
     }
 
-    /// CGWindowList is ordered front-to-back. Preserve that ordering for the
-    /// pure router and include all records so it can enforce PID/layer/visibility.
-    private static func visibleWindows() -> [DeviceHubWindow] {
-        guard let descriptions = CGWindowListCopyWindowInfo(
-            [.optionOnScreenOnly],
-            kCGNullWindowID
-        ) as? [[String: Any]] else {
+    /// Return visible standard Device Hub windows with its key window first.
+    /// AX is already covered by the event-posting Accessibility permission and,
+    /// unlike CGWindowList, does not require Screen Recording to expose titles.
+    private static func visibleWindows(processIdentifier: pid_t) -> [DeviceHubWindow] {
+        let application = AXUIElementCreateApplication(processIdentifier)
+        guard
+            let windows: [AXUIElement] = accessibilityValue(
+                kAXWindowsAttribute,
+                from: application
+            ),
+            let focusedWindow: AXUIElement = accessibilityValue(
+                kAXFocusedWindowAttribute,
+                from: application
+            ),
+            windows.contains(where: { CFEqual($0, focusedWindow) }),
+            isVisibleStandardWindow(focusedWindow) == true
+        else {
             return []
         }
 
-        return descriptions.compactMap { description in
+        let orderedWindows = [focusedWindow] + windows.filter { !CFEqual($0, focusedWindow) }
+        var snapshot = [DeviceHubWindow]()
+        for (index, window) in orderedWindows.enumerated() {
+            // A partial AX snapshot is unsafe: dropping an unreadable focused
+            // window would make a different window appear to own keyboard focus.
             guard
-                let ownerPID = description[kCGWindowOwnerPID as String] as? NSNumber,
-                let windowNumber = description[kCGWindowNumber as String] as? NSNumber
-            else {
-                return nil
-            }
-            let name = description[kCGWindowName as String] as? String ?? ""
-            let layer = (description[kCGWindowLayer as String] as? NSNumber)?.intValue ?? 0
-            let isOnScreen = (description[kCGWindowIsOnscreen as String] as? NSNumber)?.boolValue ?? true
-            return DeviceHubWindow(
-                processIdentifier: ownerPID.int32Value,
-                windowNumber: windowNumber.uint32Value,
-                name: name,
-                layer: layer,
-                isOnScreen: isOnScreen
-            )
+                let isVisible = isVisibleStandardWindow(window),
+                let title: String = accessibilityValue(kAXTitleAttribute, from: window)
+            else { return [] }
+            guard isVisible else { continue }
+            snapshot.append(DeviceHubWindow(
+                processIdentifier: processIdentifier,
+                // The router only needs stable identity within this snapshot.
+                windowNumber: UInt32(index + 1),
+                name: title
+            ))
         }
+        return snapshot
+    }
+
+    private static func isVisibleStandardWindow(_ window: AXUIElement) -> Bool? {
+        guard
+            let role: String = accessibilityValue(kAXRoleAttribute, from: window),
+            let subrole: String = accessibilityValue(kAXSubroleAttribute, from: window),
+            let minimized: Bool = accessibilityValue(kAXMinimizedAttribute, from: window)
+        else { return nil }
+        return role == kAXWindowRole && subrole == kAXStandardWindowSubrole && !minimized
+    }
+
+    private static func accessibilityValue<T>(
+        _ attribute: String,
+        from element: AXUIElement
+    ) -> T? {
+        var value: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, attribute as CFString, &value) == .success else {
+            return nil
+        }
+        return value as? T
     }
 
     private func unavailable(_ reason: String) -> Bool {

--- a/packages/serve-sim/Sources/SimNative/DeviceHubKeyboardBridge.swift
+++ b/packages/serve-sim/Sources/SimNative/DeviceHubKeyboardBridge.swift
@@ -1,0 +1,254 @@
+import AppKit
+import CoreGraphics
+import Foundation
+import SimNativeSupport
+
+/// Keyboard transport used by Xcode 27's Device Hub.
+///
+/// CoreSimulator still accepts legacy Indigo keyboard messages on Xcode 27,
+/// but the iOS 27 guest no longer consumes them. Device Hub owns the new input
+/// route, so this bridge posts ordinary macOS key events to its process and lets
+/// the selected simulator window forward them. Xcode 26 and older never create
+/// the bridge and continue using Indigo unchanged.
+///
+/// CGEvent can target an application, not one of its windows. To avoid typing
+/// into a different simulator, the first key-down is accepted only when the
+/// target device name identifies one visible, frontmost Device Hub window. That
+/// route remains latched until every posted key is released, so one chord never
+/// splits between Device Hub and the legacy Indigo fallback.
+final class DeviceHubKeyboardBridge {
+    private static let bundleIdentifier = "com.apple.dt.Devices"
+    private static let minimumXcodeMajorVersion = 27
+
+    private struct ActiveTarget {
+        let processIdentifier: pid_t
+    }
+
+    private let expectedBundleURL: URL
+    private let deviceUDID: String
+    private let deviceName: String
+
+    private var activeTarget: ActiveTarget?
+    private var pressedUsages = Set<UInt32>()
+    private var lastUnavailableReason: String?
+
+    private init(
+        expectedBundleURL: URL,
+        deviceUDID: String,
+        deviceName: String
+    ) {
+        self.expectedBundleURL = expectedBundleURL.resolvingSymlinksInPath().standardizedFileURL
+        self.deviceUDID = deviceUDID
+        self.deviceName = deviceName
+    }
+
+    static func makeIfSupported(deviceUDID: String, deviceName: String) -> DeviceHubKeyboardBridge? {
+        let environment = ProcessInfo.processInfo.environment
+        guard environment["SERVE_SIM_DISABLE_DEVICE_HUB_KEYBOARD"] == nil else { return nil }
+
+        let developerURL = URL(fileURLWithPath: Xcode.developerDir(), isDirectory: true)
+        let xcodeURL = developerURL
+            .deletingLastPathComponent() // Contents
+            .deletingLastPathComponent() // Xcode.app
+
+        guard let bundle = Bundle(url: xcodeURL), xcodeMajorVersion(in: bundle) >= minimumXcodeMajorVersion else {
+            return nil
+        }
+
+        let deviceHubURL = xcodeURL
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("Applications", isDirectory: true)
+            .appendingPathComponent("DeviceHub.app", isDirectory: true)
+        guard FileManager.default.fileExists(atPath: deviceHubURL.path) else { return nil }
+
+        return DeviceHubKeyboardBridge(
+            expectedBundleURL: deviceHubURL,
+            deviceUDID: deviceUDID,
+            deviceName: deviceName
+        )
+    }
+
+    /// Returns true only when this event was posted through the guarded Device
+    /// Hub route. False lets HIDInjector use Indigo for backward compatibility
+    /// and for usages Device Hub cannot safely route.
+    func send(type: String, usage: UInt32) -> Bool {
+        let keyDown: Bool
+        switch type {
+        case "down": keyDown = true
+        case "up": keyDown = false
+        default: return false
+        }
+
+        guard let rawKeyCode = HIDKeyboardMapping.macVirtualKeyCode(for: usage) else { return false }
+        guard CGPreflightPostEventAccess() else {
+            return unavailable(
+                "macOS Accessibility permission is not granted "
+                + "(System Settings > Privacy & Security > Accessibility)"
+            )
+        }
+        let keyCode = CGKeyCode(rawKeyCode)
+
+        let target: ActiveTarget
+        if keyDown {
+            if let activeTarget {
+                guard isExpectedDeviceHubRunning(processIdentifier: activeTarget.processIdentifier) else {
+                    resetSequence()
+                    return unavailable("Device Hub exited during a key sequence")
+                }
+                target = activeTarget
+            } else {
+                guard let resolved = resolveTarget() else { return false }
+                activeTarget = resolved
+                target = resolved
+            }
+        } else {
+            // An up event whose down used Indigo must stay on Indigo too.
+            guard pressedUsages.contains(usage), let activeTarget else { return false }
+            guard isExpectedDeviceHubRunning(processIdentifier: activeTarget.processIdentifier) else {
+                resetSequence()
+                return unavailable("Device Hub exited during a key sequence")
+            }
+            target = activeTarget
+        }
+
+        var nextPressedUsages = pressedUsages
+        if keyDown {
+            nextPressedUsages.insert(usage)
+        } else {
+            nextPressedUsages.remove(usage)
+        }
+
+        guard
+            let source = CGEventSource(stateID: .hidSystemState),
+            let event = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: keyDown)
+        else {
+            if pressedUsages.isEmpty { resetSequence() }
+            return unavailable("CoreGraphics could not create a keyboard event")
+        }
+
+        event.flags = Self.eventFlags(for: nextPressedUsages)
+        event.postToPid(target.processIdentifier)
+
+        pressedUsages = nextPressedUsages
+        lastUnavailableReason = nil
+        if pressedUsages.isEmpty { resetSequence() }
+        return true
+    }
+
+    private func resolveTarget() -> ActiveTarget? {
+        let applications = runningDeviceHubs()
+        guard applications.count == 1, let application = applications.first else {
+            let reason = applications.isEmpty
+                ? "Device Hub from the selected Xcode is not running"
+                : "multiple matching Device Hub processes are running"
+            _ = unavailable(reason)
+            return nil
+        }
+
+        let processIdentifier = application.processIdentifier
+        let route = DeviceHubWindowRouter.route(
+            windows: Self.visibleWindows(),
+            processIdentifier: processIdentifier,
+            targetDeviceName: deviceName
+        )
+        switch route {
+        case .success:
+            return ActiveTarget(processIdentifier: processIdentifier)
+        case .failure(let failure):
+            _ = unavailable(failure.description)
+            return nil
+        }
+    }
+
+    private func runningDeviceHubs() -> [NSRunningApplication] {
+        NSRunningApplication
+            .runningApplications(withBundleIdentifier: Self.bundleIdentifier)
+            .filter { application in
+                guard !application.isTerminated, let bundleURL = application.bundleURL else { return false }
+                return bundleURL.resolvingSymlinksInPath().standardizedFileURL == expectedBundleURL
+            }
+    }
+
+    private func isExpectedDeviceHubRunning(processIdentifier: pid_t) -> Bool {
+        runningDeviceHubs().contains { $0.processIdentifier == processIdentifier }
+    }
+
+    /// CGWindowList is ordered front-to-back. Preserve that ordering for the
+    /// pure router and include all records so it can enforce PID/layer/visibility.
+    private static func visibleWindows() -> [DeviceHubWindow] {
+        guard let descriptions = CGWindowListCopyWindowInfo(
+            [.optionOnScreenOnly],
+            kCGNullWindowID
+        ) as? [[String: Any]] else {
+            return []
+        }
+
+        return descriptions.compactMap { description in
+            guard
+                let ownerPID = description[kCGWindowOwnerPID as String] as? NSNumber,
+                let windowNumber = description[kCGWindowNumber as String] as? NSNumber
+            else {
+                return nil
+            }
+            let name = description[kCGWindowName as String] as? String ?? ""
+            let layer = (description[kCGWindowLayer as String] as? NSNumber)?.intValue ?? 0
+            let isOnScreen = (description[kCGWindowIsOnscreen as String] as? NSNumber)?.boolValue ?? true
+            return DeviceHubWindow(
+                processIdentifier: ownerPID.int32Value,
+                windowNumber: windowNumber.uint32Value,
+                name: name,
+                layer: layer,
+                isOnScreen: isOnScreen
+            )
+        }
+    }
+
+    private func unavailable(_ reason: String) -> Bool {
+        if lastUnavailableReason != reason {
+            let shortUDID = String(deviceUDID.prefix(8))
+            print(
+                "[hid] Device Hub keyboard unavailable for \(deviceName) (\(shortUDID)): "
+                + "\(reason); using legacy HID"
+            )
+            lastUnavailableReason = reason
+        }
+        return false
+    }
+
+    private func resetSequence() {
+        activeTarget = nil
+        pressedUsages.removeAll()
+    }
+
+    private static func eventFlags(for usages: Set<UInt32>) -> CGEventFlags {
+        var flags: CGEventFlags = []
+        for usage in usages {
+            switch HIDKeyboardMapping.modifier(for: usage) {
+            case .control: flags.insert(.maskControl)
+            case .shift: flags.insert(.maskShift)
+            case .option: flags.insert(.maskAlternate)
+            case .command: flags.insert(.maskCommand)
+            case nil: break
+            }
+        }
+        return flags
+    }
+
+    private static func xcodeMajorVersion(in bundle: Bundle) -> Int {
+        if
+            let version = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String,
+            let major = Int(version.split(separator: ".").first ?? "")
+        {
+            return major
+        }
+
+        if let dtxcode = bundle.object(forInfoDictionaryKey: "DTXcode") as? String,
+           let value = Int(dtxcode) {
+            return value / 100
+        }
+        if let dtxcode = bundle.object(forInfoDictionaryKey: "DTXcode") as? NSNumber {
+            return dtxcode.intValue / 100
+        }
+        return 0
+    }
+}

--- a/packages/serve-sim/Sources/SimNative/FrameCapture.swift
+++ b/packages/serve-sim/Sources/SimNative/FrameCapture.swift
@@ -43,6 +43,7 @@ actor FrameCapture {
     private var ioClient: NSObject?
     private var expectedScreenSize: FramebufferSurfaceSize?
     private var didLogRejectedPresentationSurface = false
+    private var didLogMissingExpectedSurface = false
 
     func start(deviceUDID: String, onFrame: @escaping @Sendable (CVPixelBuffer, CMTime) -> Void) throws {
         self.onFrame = onFrame
@@ -179,6 +180,18 @@ actor FrameCapture {
                 )
                 didLogRejectedPresentationSurface = true
             }
+        } else if
+            !selection.matchedExpectedSize,
+            let expectedScreenSize,
+            !didLogMissingExpectedSurface
+        {
+            let selected = sizes[selection.index]
+            print(
+                "[capture] No framebuffer matches native screen "
+                + "\(expectedScreenSize.width)x\(expectedScreenSize.height); "
+                + "falling back to \(selected.width)x\(selected.height)"
+            )
+            didLogMissingExpectedSurface = true
         }
         return descriptors[selection.index]
     }
@@ -296,9 +309,16 @@ actor FrameCapture {
         callbackUUIDs.removeAll()
         descriptors.removeAll()
         lastSeeds.removeAll()
+        onFrame = nil
+        frameCount = 0
+        capturedWidth = 0
+        capturedHeight = 0
+        rewireTickCount = 0
+        lastCaptureTime = .now
         ioClient = nil
         expectedScreenSize = nil
         didLogRejectedPresentationSurface = false
+        didLogMissingExpectedSurface = false
     }
 
     // MARK: - Helpers
@@ -309,8 +329,11 @@ actor FrameCapture {
     }
 
     /// SimDeviceType.mainScreenSize is private but stable across the same
-    /// SimulatorKit versions already used by this file. It reports native pixel
-    /// dimensions (not points), which match the primary IOSurface exactly.
+    /// SimulatorKit versions already used by this file. Runtime validation on
+    /// Xcode 27 confirms that it reports native pixels, not logical points, and
+    /// matches the primary IOSurface exactly. The `@convention(c)` IMP type is
+    /// intentional: it preserves the platform CGSize return ABI (registers on
+    /// arm64 and the appropriate struct-return convention on x86_64).
     private static func nativeScreenSize(for device: NSObject) -> FramebufferSurfaceSize? {
         let deviceTypeSelector = NSSelectorFromString("deviceType")
         guard

--- a/packages/serve-sim/Sources/SimNative/FrameCapture.swift
+++ b/packages/serve-sim/Sources/SimNative/FrameCapture.swift
@@ -4,6 +4,7 @@ import CoreMedia
 import CoreGraphics
 import IOSurface
 import ObjectiveC
+import SimNativeSupport
 
 /// Headless simulator frame capture via direct IOSurface access.
 ///
@@ -40,6 +41,8 @@ actor FrameCapture {
     private var descriptors: [NSObject] = []
     private var callbackUUIDs: [ObjectIdentifier: UUID] = [:]
     private var ioClient: NSObject?
+    private var expectedScreenSize: FramebufferSurfaceSize?
+    private var didLogRejectedPresentationSurface = false
 
     func start(deviceUDID: String, onFrame: @escaping @Sendable (CVPixelBuffer, CMTime) -> Void) throws {
         self.onFrame = onFrame
@@ -53,6 +56,7 @@ actor FrameCapture {
         guard state == "Booted" else {
             throw makeError(2, "Device not booted (state: \(state))")
         }
+        self.expectedScreenSize = Self.nativeScreenSize(for: device)
 
         guard let io = device.perform(NSSelectorFromString("io"))?.takeUnretainedValue() as? NSObject else {
             throw makeError(3, "Failed to get device IO")
@@ -139,22 +143,44 @@ actor FrameCapture {
         return candidates
     }
 
-    /// Return the descriptor whose live surface has the largest area.
-    /// Secondary planes/overlays are typically smaller than the main screen.
+    /// Return the descriptor matching the device type's native screen size.
+    /// Xcode 27 can expose an additional 7680x4320 presentation surface while
+    /// Device Hub is resizing; selecting the historical largest surface then
+    /// feeds a non-device frame to VideoToolbox and produces `encodingFailed`.
+    /// If screen metadata is unavailable, retain the old largest-live fallback.
     private func pickBestDescriptor() -> NSObject? {
         let surfSel = NSSelectorFromString("framebufferSurface")
-        var best: NSObject?
-        var bestArea: Int = 0
-        for desc in descriptors {
-            guard let surfObj = desc.perform(surfSel)?.takeUnretainedValue() else { continue }
+        let sizes = descriptors.map { desc -> FramebufferSurfaceSize in
+            guard let surfObj = desc.perform(surfSel)?.takeUnretainedValue() else {
+                return FramebufferSurfaceSize(width: 0, height: 0)
+            }
             let surf = unsafeBitCast(surfObj, to: IOSurface.self)
-            let area = IOSurfaceGetWidth(surf) * IOSurfaceGetHeight(surf)
-            if area > bestArea {
-                best = desc
-                bestArea = area
+            return FramebufferSurfaceSize(
+                width: IOSurfaceGetWidth(surf),
+                height: IOSurfaceGetHeight(surf)
+            )
+        }
+        guard let selection = FramebufferSurfaceSelector.select(
+            from: sizes,
+            expectedSize: expectedScreenSize
+        ) else {
+            return nil
+        }
+
+        if selection.matchedExpectedSize, !didLogRejectedPresentationSurface {
+            let selected = sizes[selection.index]
+            let selectedArea = Int64(selected.width) * Int64(selected.height)
+            if let larger = sizes.filter(\.isLive).max(by: {
+                Int64($0.width) * Int64($0.height) < Int64($1.width) * Int64($1.height)
+            }), Int64(larger.width) * Int64(larger.height) > selectedArea {
+                print(
+                    "[capture] Ignoring non-device framebuffer \(larger.width)x\(larger.height); "
+                    + "native screen is \(selected.width)x\(selected.height)"
+                )
+                didLogRejectedPresentationSurface = true
             }
         }
-        return best
+        return descriptors[selection.index]
     }
 
     // MARK: - Frame callbacks via objc_msgSend
@@ -271,6 +297,8 @@ actor FrameCapture {
         descriptors.removeAll()
         lastSeeds.removeAll()
         ioClient = nil
+        expectedScreenSize = nil
+        didLogRejectedPresentationSurface = false
     }
 
     // MARK: - Helpers
@@ -278,6 +306,31 @@ actor FrameCapture {
     private func makeError(_ code: Int, _ msg: String) -> NSError {
         NSError(domain: "FrameCapture", code: code,
                 userInfo: [NSLocalizedDescriptionKey: msg])
+    }
+
+    /// SimDeviceType.mainScreenSize is private but stable across the same
+    /// SimulatorKit versions already used by this file. It reports native pixel
+    /// dimensions (not points), which match the primary IOSurface exactly.
+    private static func nativeScreenSize(for device: NSObject) -> FramebufferSurfaceSize? {
+        let deviceTypeSelector = NSSelectorFromString("deviceType")
+        guard
+            device.responds(to: deviceTypeSelector),
+            let deviceType = device.perform(deviceTypeSelector)?.takeUnretainedValue() as? NSObject
+        else {
+            return nil
+        }
+        let selector = NSSelectorFromString("mainScreenSize")
+        guard deviceType.responds(to: selector) else { return nil }
+
+        typealias GetSize = @convention(c) (AnyObject, Selector) -> CGSize
+        let getSize = unsafeBitCast(deviceType.method(for: selector), to: GetSize.self)
+        let size = getSize(deviceType, selector)
+        guard size.width.isFinite, size.height.isFinite else { return nil }
+
+        let width = Int(size.width.rounded())
+        let height = Int(size.height.rounded())
+        guard width > 0, height > 0 else { return nil }
+        return FramebufferSurfaceSize(width: width, height: height)
     }
 
     static func findSimDevice(udid: String) -> NSObject? {

--- a/packages/serve-sim/Sources/SimNative/H264Encoder.swift
+++ b/packages/serve-sim/Sources/SimNative/H264Encoder.swift
@@ -41,8 +41,9 @@ actor H264Encoder {
         if let session { VTCompressionSessionInvalidate(session) }
     }
 
-    /// Submit a frame. Returns immediately; `onEncoded` fires on VT's queue.
-    func encode(_ source: CVPixelBuffer, forceKeyframe: Bool = false) async throws -> Encoded {
+    /// Encode one frame. Real-time VideoToolbox sessions may deliberately drop
+    /// a frame under pressure; that is reported as `nil`, not as an error.
+    func encode(_ source: CVPixelBuffer, forceKeyframe: Bool = false) async throws -> Encoded? {
         let w = Int32(CVPixelBufferGetWidth(source))
         let h = Int32(CVPixelBufferGetHeight(source))
         if session == nil || w != width || h != height {
@@ -60,7 +61,7 @@ actor H264Encoder {
             ? [kVTEncodeFrameOptionKey_ForceKeyFrame: kCFBooleanTrue!] as NSDictionary
             : nil
 
-        let buffer: CMSampleBuffer? = await withCheckedContinuation { continuation in
+        let result: (buffer: CMSampleBuffer?, status: OSStatus, flags: VTEncodeInfoFlags) = await withCheckedContinuation { continuation in
             let status = VTCompressionSessionEncodeFrame(
                 session,
                 imageBuffer: source,
@@ -68,18 +69,20 @@ actor H264Encoder {
                 duration: .invalid,
                 frameProperties: frameProps,
                 infoFlagsOut: nil
-            ) { @Sendable status, _, sampleBuffer in
-                guard status == noErr, let sb = sampleBuffer else {
-                    continuation.resume(returning: nil)
+            ) { @Sendable status, flags, sampleBuffer in
+                guard status == noErr, let sampleBuffer else {
+                    continuation.resume(returning: (nil, status, flags))
                     return
                 }
-                continuation.resume(returning: sb)
+                continuation.resume(returning: (sampleBuffer, status, flags))
             }
             if status != noErr {
-                continuation.resume(returning: nil)
+                continuation.resume(returning: (nil, status, []))
             }
         }
-        guard let buffer else { throw Errors.encodingFailed }
+        if result.status == noErr, result.flags.contains(.frameDropped) { return nil }
+        guard result.status == noErr else { throw Errors.encodingFailed(result.status) }
+        guard let buffer = result.buffer else { throw Errors.missingSampleBuffer }
         return try extract(from: buffer)
     }
 
@@ -219,7 +222,8 @@ actor H264Encoder {
 
     enum Errors: Error {
         case couldNotCreateSession
-        case encodingFailed
+        case encodingFailed(OSStatus)
+        case missingSampleBuffer
         case invalidSampleBuffer
     }
 }

--- a/packages/serve-sim/Sources/SimNative/HIDInjector.swift
+++ b/packages/serve-sim/Sources/SimNative/HIDInjector.swift
@@ -142,9 +142,12 @@ actor HIDInjector {
         self.hidClient = clientObj
         self.sendSel = NSSelectorFromString("sendWithMessage:freeWhenDone:completionQueue:completion:")
         let deviceName = device.value(forKey: "name") as? String ?? deviceUDID
+        let runtimeName = (device.value(forKey: "runtime") as? NSObject)?
+            .value(forKey: "name") as? String
         self.deviceHubKeyboardBridge = DeviceHubKeyboardBridge.makeIfSupported(
             deviceUDID: deviceUDID,
-            deviceName: deviceName
+            deviceName: deviceName,
+            runtimeName: runtimeName
         )
         hidLog("[hid] SimDeviceLegacyHIDClient created")
         hidLog("[hid] IndigoHIDMessageForMouseNSEvent loaded (with edge gesture support)")

--- a/packages/serve-sim/Sources/SimNative/HIDInjector.swift
+++ b/packages/serve-sim/Sources/SimNative/HIDInjector.swift
@@ -39,6 +39,7 @@ actor HIDInjector {
     private var hidClient: NSObject?
     private var sendSel: Selector?
     private var simDevice: NSObject?
+    private var deviceHubKeyboardBridge: DeviceHubKeyboardBridge?
 
     // IndigoHIDMessageForMouseNSEvent(CGPoint*, CGPoint*, IndigoHIDTarget, NSEventType, NSSize, IndigoHIDEdge)
     // arm64 ABI: pointer/int params → x0-x4, float params → d0-d1 (independent numbering).
@@ -140,6 +141,11 @@ actor HIDInjector {
 
         self.hidClient = clientObj
         self.sendSel = NSSelectorFromString("sendWithMessage:freeWhenDone:completionQueue:completion:")
+        let deviceName = device.value(forKey: "name") as? String ?? deviceUDID
+        self.deviceHubKeyboardBridge = DeviceHubKeyboardBridge.makeIfSupported(
+            deviceUDID: deviceUDID,
+            deviceName: deviceName
+        )
         hidLog("[hid] SimDeviceLegacyHIDClient created")
         hidLog("[hid] IndigoHIDMessageForMouseNSEvent loaded (with edge gesture support)")
     }
@@ -253,16 +259,21 @@ actor HIDInjector {
     ///   - type: "down" or "up"
     ///   - usage: HID usage code (e.g. 0x04 = 'A', 0x28 = Enter, 0xE1 = LeftShift)
     func sendKey(type: String, usage: UInt32) {
-        guard let keyboardFunc = keyboardFunc else {
-            print("[hid] Keyboard injection unavailable")
-            return
-        }
-
         let direction: UInt32
         switch type {
         case "down": direction = 1
         case "up":   direction = 2
         default: return
+        }
+
+        if deviceHubKeyboardBridge?.send(type: type, usage: usage) == true {
+            hidLog("[hid] Posted Device Hub key \(type) usage=0x\(String(usage, radix: 16))")
+            return
+        }
+
+        guard let keyboardFunc = keyboardFunc else {
+            print("[hid] Keyboard injection unavailable")
+            return
         }
 
         guard let msg = keyboardFunc(usage, direction) else {

--- a/packages/serve-sim/Sources/SimNativeSupport/DeviceHubKeyboardRouting.swift
+++ b/packages/serve-sim/Sources/SimNativeSupport/DeviceHubKeyboardRouting.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+public struct DeviceHubWindow: Equatable, Sendable {
+    public let processIdentifier: Int32
+    public let windowNumber: UInt32
+    public let name: String
+    public let layer: Int
+    public let isOnScreen: Bool
+
+    public init(
+        processIdentifier: Int32,
+        windowNumber: UInt32,
+        name: String,
+        layer: Int = 0,
+        isOnScreen: Bool = true
+    ) {
+        self.processIdentifier = processIdentifier
+        self.windowNumber = windowNumber
+        self.name = name
+        self.layer = layer
+        self.isOnScreen = isOnScreen
+    }
+}
+
+public enum DeviceHubWindowRoutingFailure: Error, Equatable, Sendable, CustomStringConvertible {
+    case noEligibleWindows
+    case targetNotFound
+    case ambiguousTarget(count: Int)
+    case targetNotFrontmost(frontmostName: String)
+
+    public var description: String {
+        switch self {
+        case .noEligibleWindows:
+            return "Device Hub has no visible simulator window"
+        case .targetNotFound:
+            return "the target simulator window is not visible"
+        case .ambiguousTarget(let count):
+            return "the target simulator name matches \(count) windows"
+        case .targetNotFrontmost(let frontmostName):
+            return "another Device Hub window is frontmost (\(frontmostName))"
+        }
+    }
+}
+
+/// Chooses a Device Hub simulator window from CGWindowList's front-to-back
+/// ordering. A simulator name is not globally unique, so duplicate matches are
+/// deliberately rejected instead of risking keyboard input in the wrong guest.
+public enum DeviceHubWindowRouter {
+    public static func route(
+        windows: [DeviceHubWindow],
+        processIdentifier: Int32,
+        targetDeviceName: String
+    ) -> Result<DeviceHubWindow, DeviceHubWindowRoutingFailure> {
+        let eligible = windows.filter {
+            $0.processIdentifier == processIdentifier
+                && $0.layer == 0
+                && $0.isOnScreen
+                && !$0.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        guard let frontmost = eligible.first else { return .failure(.noEligibleWindows) }
+
+        let matches = eligible.filter { $0.name == targetDeviceName }
+        guard !matches.isEmpty else { return .failure(.targetNotFound) }
+        guard matches.count == 1 else { return .failure(.ambiguousTarget(count: matches.count)) }
+        guard matches[0].windowNumber == frontmost.windowNumber else {
+            return .failure(.targetNotFrontmost(frontmostName: frontmost.name))
+        }
+        return .success(matches[0])
+    }
+}
+
+public enum HIDModifier: Equatable, Sendable {
+    case control
+    case shift
+    case option
+    case command
+}
+
+/// USB HID Keyboard/Keypad usage (page 0x07) to macOS virtual key code.
+public enum HIDKeyboardMapping {
+    public static func macVirtualKeyCode(for usage: UInt32) -> UInt16? {
+        keyCodes[usage]
+    }
+
+    public static func modifier(for usage: UInt32) -> HIDModifier? {
+        switch usage {
+        case 0xE0, 0xE4: return .control
+        case 0xE1, 0xE5: return .shift
+        case 0xE2, 0xE6: return .option
+        case 0xE3, 0xE7: return .command
+        default: return nil
+        }
+    }
+
+    private static let keyCodes: [UInt32: UInt16] = [
+        // A-Z
+        0x04: 0,  0x05: 11, 0x06: 8,  0x07: 2,  0x08: 14, 0x09: 3,
+        0x0A: 5,  0x0B: 4,  0x0C: 34, 0x0D: 38, 0x0E: 40, 0x0F: 37,
+        0x10: 46, 0x11: 45, 0x12: 31, 0x13: 35, 0x14: 12, 0x15: 15,
+        0x16: 1,  0x17: 17, 0x18: 32, 0x19: 9,  0x1A: 13, 0x1B: 7,
+        0x1C: 16, 0x1D: 6,
+
+        // Number row
+        0x1E: 18, 0x1F: 19, 0x20: 20, 0x21: 21, 0x22: 23,
+        0x23: 22, 0x24: 26, 0x25: 28, 0x26: 25, 0x27: 29,
+
+        // Editing and punctuation
+        0x28: 36, 0x29: 53, 0x2A: 51, 0x2B: 48, 0x2C: 49,
+        0x2D: 27, 0x2E: 24, 0x2F: 33, 0x30: 30, 0x31: 42,
+        0x32: 42, 0x33: 41, 0x34: 39, 0x35: 50, 0x36: 43,
+        0x37: 47, 0x38: 44, 0x39: 57,
+
+        // Function keys
+        0x3A: 122, 0x3B: 120, 0x3C: 99,  0x3D: 118, 0x3E: 96, 0x3F: 97,
+        0x40: 98,  0x41: 100, 0x42: 101, 0x43: 109, 0x44: 103, 0x45: 111,
+        0x46: 105, 0x47: 107, 0x48: 113,
+
+        // Navigation
+        0x49: 114, 0x4A: 115, 0x4B: 116, 0x4C: 117, 0x4D: 119,
+        0x4E: 121, 0x4F: 124, 0x50: 123, 0x51: 125, 0x52: 126,
+
+        // Numeric keypad
+        0x53: 71, 0x54: 75, 0x55: 67, 0x56: 78, 0x57: 69, 0x58: 76,
+        0x59: 83, 0x5A: 84, 0x5B: 85, 0x5C: 86, 0x5D: 87, 0x5E: 88,
+        0x5F: 89, 0x60: 91, 0x61: 92, 0x62: 82, 0x63: 65,
+        0x64: 10, 0x67: 81,
+
+        // Media keys commonly emitted by browsers
+        0x7F: 74, 0x80: 72, 0x81: 73,
+
+        // Modifiers
+        0xE0: 59, 0xE1: 56, 0xE2: 58, 0xE3: 55,
+        0xE4: 62, 0xE5: 60, 0xE6: 61, 0xE7: 54,
+    ]
+}

--- a/packages/serve-sim/Sources/SimNativeSupport/DeviceHubKeyboardRouting.swift
+++ b/packages/serve-sim/Sources/SimNativeSupport/DeviceHubKeyboardRouting.swift
@@ -1,5 +1,14 @@
 import Foundation
 
+/// Environment policy for the optional Xcode 27 Device Hub keyboard route.
+public enum DeviceHubKeyboardConfiguration {
+    /// Only the documented value `1` opts out. Values such as `0` and `false`
+    /// leave the route enabled.
+    public static func isDisabled(environmentValue: String?) -> Bool {
+        environmentValue == "1"
+    }
+}
+
 public struct DeviceHubWindow: Equatable, Sendable {
     public let processIdentifier: Int32
     public let windowNumber: UInt32
@@ -26,7 +35,7 @@ public enum DeviceHubWindowRoutingFailure: Error, Equatable, Sendable, CustomStr
     case noEligibleWindows
     case targetNotFound
     case ambiguousTarget(count: Int)
-    case targetNotFrontmost(frontmostName: String)
+    case targetNotFocused(focusedName: String)
 
     public var description: String {
         switch self {
@@ -36,20 +45,20 @@ public enum DeviceHubWindowRoutingFailure: Error, Equatable, Sendable, CustomStr
             return "the target simulator window is not visible"
         case .ambiguousTarget(let count):
             return "the target simulator name matches \(count) windows"
-        case .targetNotFrontmost(let frontmostName):
-            return "another Device Hub window is frontmost (\(frontmostName))"
+        case .targetNotFocused(let focusedName):
+            return "another Device Hub window has keyboard focus (\(focusedName))"
         }
     }
 }
 
-/// Chooses a Device Hub simulator window from CGWindowList's front-to-back
-/// ordering. A simulator name is not globally unique, so duplicate matches are
-/// deliberately rejected instead of risking keyboard input in the wrong guest.
+/// Chooses a Device Hub simulator window from a key-window-first snapshot. A
+/// simulator name is not globally unique, so duplicate matches are deliberately
+/// rejected instead of risking keyboard input in the wrong guest.
 public enum DeviceHubWindowRouter {
     public static func route(
         windows: [DeviceHubWindow],
         processIdentifier: Int32,
-        targetDeviceName: String
+        targetWindowTitle: String
     ) -> Result<DeviceHubWindow, DeviceHubWindowRoutingFailure> {
         let eligible = windows.filter {
             $0.processIdentifier == processIdentifier
@@ -57,13 +66,16 @@ public enum DeviceHubWindowRouter {
                 && $0.isOnScreen
                 && !$0.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         }
-        guard let frontmost = eligible.first else { return .failure(.noEligibleWindows) }
+        guard let focused = eligible.first else { return .failure(.noEligibleWindows) }
 
-        let matches = eligible.filter { $0.name == targetDeviceName }
+        // Device Hub's AX title is canonical (`<device> – <runtime>`). Match
+        // it exactly: simulator names are user-controlled and prefix matching
+        // could route input to a different device with a longer name.
+        let matches = eligible.filter { $0.name == targetWindowTitle }
         guard !matches.isEmpty else { return .failure(.targetNotFound) }
         guard matches.count == 1 else { return .failure(.ambiguousTarget(count: matches.count)) }
-        guard matches[0].windowNumber == frontmost.windowNumber else {
-            return .failure(.targetNotFrontmost(frontmostName: frontmost.name))
+        guard matches[0].windowNumber == focused.windowNumber else {
+            return .failure(.targetNotFocused(focusedName: focused.name))
         }
         return .success(matches[0])
     }

--- a/packages/serve-sim/Sources/SimNativeSupport/FramebufferSurfaceSelector.swift
+++ b/packages/serve-sim/Sources/SimNativeSupport/FramebufferSurfaceSelector.swift
@@ -1,0 +1,55 @@
+public struct FramebufferSurfaceSize: Equatable, Sendable {
+    public let width: Int
+    public let height: Int
+
+    public init(width: Int, height: Int) {
+        self.width = width
+        self.height = height
+    }
+
+    public var isLive: Bool { width > 0 && height > 0 }
+
+    fileprivate func matches(_ other: FramebufferSurfaceSize) -> Bool {
+        (width == other.width && height == other.height)
+            || (width == other.height && height == other.width)
+    }
+}
+
+public struct FramebufferSurfaceSelection: Equatable, Sendable {
+    public let index: Int
+    public let matchedExpectedSize: Bool
+
+    public init(index: Int, matchedExpectedSize: Bool) {
+        self.index = index
+        self.matchedExpectedSize = matchedExpectedSize
+    }
+}
+
+/// Selects the simulator's main display without relying on a maximum-size
+/// heuristic. Newer Device Hub versions may publish an additional presentation
+/// surface (for example 7680x4320 while resizing); the device type's native
+/// screen size identifies the real display. When that private metadata is not
+/// available, the historical largest-live-surface behavior is preserved.
+public enum FramebufferSurfaceSelector {
+    public static func select(
+        from candidates: [FramebufferSurfaceSize],
+        expectedSize: FramebufferSurfaceSize?
+    ) -> FramebufferSurfaceSelection? {
+        let live = candidates.indices.filter { candidates[$0].isLive }
+        guard !live.isEmpty else { return nil }
+
+        if let expectedSize, expectedSize.isLive,
+           let exact = live.first(where: { candidates[$0].matches(expectedSize) }) {
+            return FramebufferSurfaceSelection(index: exact, matchedExpectedSize: true)
+        }
+
+        let largest = live.max { lhs, rhs in
+            area(of: candidates[lhs]) < area(of: candidates[rhs])
+        }!
+        return FramebufferSurfaceSelection(index: largest, matchedExpectedSize: false)
+    }
+
+    private static func area(of size: FramebufferSurfaceSize) -> Int64 {
+        Int64(size.width) * Int64(size.height)
+    }
+}

--- a/packages/serve-sim/Tests/SimNativeSupportTests/DeviceHubKeyboardRoutingTests.swift
+++ b/packages/serve-sim/Tests/SimNativeSupportTests/DeviceHubKeyboardRoutingTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+@testable import SimNativeSupport
+
+final class DeviceHubKeyboardRoutingTests: XCTestCase {
+    private let pid: Int32 = 42
+
+    func testRoutesOnlyVisibleTargetWindow() throws {
+        let target = window(number: 10, name: "iPhone 17 Pro")
+        let routed = try DeviceHubWindowRouter.route(
+            windows: [target],
+            processIdentifier: pid,
+            targetDeviceName: "iPhone 17 Pro"
+        ).get()
+
+        XCTAssertEqual(routed, target)
+    }
+
+    func testRoutesFrontmostTargetAmongMultipleSimulatorWindows() throws {
+        let target = window(number: 10, name: "iPhone 17 Pro")
+        let other = window(number: 11, name: "iPad Air")
+        let routed = try DeviceHubWindowRouter.route(
+            windows: [target, other],
+            processIdentifier: pid,
+            targetDeviceName: "iPhone 17 Pro"
+        ).get()
+
+        XCTAssertEqual(routed, target)
+    }
+
+    func testRejectsTargetThatIsNotFrontmost() {
+        let result = DeviceHubWindowRouter.route(
+            windows: [
+                window(number: 11, name: "iPad Air"),
+                window(number: 10, name: "iPhone 17 Pro"),
+            ],
+            processIdentifier: pid,
+            targetDeviceName: "iPhone 17 Pro"
+        )
+
+        XCTAssertEqual(result.failure, .targetNotFrontmost(frontmostName: "iPad Air"))
+    }
+
+    func testRejectsDuplicateDeviceNames() {
+        let result = DeviceHubWindowRouter.route(
+            windows: [
+                window(number: 10, name: "iPhone 17 Pro"),
+                window(number: 11, name: "iPhone 17 Pro"),
+            ],
+            processIdentifier: pid,
+            targetDeviceName: "iPhone 17 Pro"
+        )
+
+        XCTAssertEqual(result.failure, .ambiguousTarget(count: 2))
+    }
+
+    func testIgnoresHiddenUtilityAndOtherProcessWindows() {
+        let result = DeviceHubWindowRouter.route(
+            windows: [
+                window(number: 1, name: "iPhone 17 Pro", layer: 1),
+                window(number: 2, name: "iPhone 17 Pro", isOnScreen: false),
+                DeviceHubWindow(
+                    processIdentifier: 99,
+                    windowNumber: 3,
+                    name: "iPhone 17 Pro"
+                ),
+            ],
+            processIdentifier: pid,
+            targetDeviceName: "iPhone 17 Pro"
+        )
+
+        XCTAssertEqual(result.failure, .noEligibleWindows)
+    }
+
+    func testKeyboardUsageMappingIncludesModifiersAndRejectsUnknownUsage() {
+        XCTAssertEqual(HIDKeyboardMapping.macVirtualKeyCode(for: 0x04), 0)
+        XCTAssertEqual(HIDKeyboardMapping.macVirtualKeyCode(for: 0x2A), 51)
+        XCTAssertEqual(HIDKeyboardMapping.modifier(for: 0xE1), .shift)
+        XCTAssertNil(HIDKeyboardMapping.macVirtualKeyCode(for: 0xFFFF))
+        XCTAssertNil(HIDKeyboardMapping.modifier(for: 0x04))
+    }
+
+    private func window(
+        number: UInt32,
+        name: String,
+        layer: Int = 0,
+        isOnScreen: Bool = true
+    ) -> DeviceHubWindow {
+        DeviceHubWindow(
+            processIdentifier: pid,
+            windowNumber: number,
+            name: name,
+            layer: layer,
+            isOnScreen: isOnScreen
+        )
+    }
+}
+
+private extension Result {
+    var failure: Failure? {
+        guard case .failure(let error) = self else { return nil }
+        return error
+    }
+}

--- a/packages/serve-sim/Tests/SimNativeSupportTests/DeviceHubKeyboardRoutingTests.swift
+++ b/packages/serve-sim/Tests/SimNativeSupportTests/DeviceHubKeyboardRoutingTests.swift
@@ -4,40 +4,60 @@ import XCTest
 final class DeviceHubKeyboardRoutingTests: XCTestCase {
     private let pid: Int32 = 42
 
+    func testKeyboardOptOutRequiresDocumentedValue() {
+        XCTAssertTrue(DeviceHubKeyboardConfiguration.isDisabled(environmentValue: "1"))
+        for value: String? in [nil, "", "0", "false", "true"] {
+            XCTAssertFalse(DeviceHubKeyboardConfiguration.isDisabled(environmentValue: value))
+        }
+    }
+
     func testRoutesOnlyVisibleTargetWindow() throws {
-        let target = window(number: 10, name: "iPhone 17 Pro")
+        let target = window(number: 10, name: "iPhone 17 Pro – iOS 27.0")
         let routed = try DeviceHubWindowRouter.route(
             windows: [target],
             processIdentifier: pid,
-            targetDeviceName: "iPhone 17 Pro"
+            targetWindowTitle: "iPhone 17 Pro – iOS 27.0"
         ).get()
 
         XCTAssertEqual(routed, target)
     }
 
-    func testRoutesFrontmostTargetAmongMultipleSimulatorWindows() throws {
-        let target = window(number: 10, name: "iPhone 17 Pro")
-        let other = window(number: 11, name: "iPad Air")
+    func testRoutesFocusedTargetAmongMultipleSimulatorWindows() throws {
+        let target = window(number: 10, name: "iPhone 17 Pro – iOS 27.0")
+        let other = window(number: 11, name: "iPad Air – iOS 27.0")
         let routed = try DeviceHubWindowRouter.route(
             windows: [target, other],
             processIdentifier: pid,
-            targetDeviceName: "iPhone 17 Pro"
+            targetWindowTitle: "iPhone 17 Pro – iOS 27.0"
         ).get()
 
         XCTAssertEqual(routed, target)
     }
 
-    func testRejectsTargetThatIsNotFrontmost() {
+    func testRejectsNonCanonicalAndLongerDeviceTitles() {
+        let result = DeviceHubWindowRouter.route(
+            windows: [
+                window(number: 10, name: "iPhone 17 Pro"),
+                window(number: 11, name: "iPhone 17 Pro Max – iOS 27.0"),
+            ],
+            processIdentifier: pid,
+            targetWindowTitle: "iPhone 17 Pro – iOS 27.0"
+        )
+
+        XCTAssertEqual(result.failure, .targetNotFound)
+    }
+
+    func testRejectsTargetThatDoesNotHaveDeviceHubFocus() {
         let result = DeviceHubWindowRouter.route(
             windows: [
                 window(number: 11, name: "iPad Air"),
-                window(number: 10, name: "iPhone 17 Pro"),
+                window(number: 10, name: "iPhone 17 Pro – iOS 27.0"),
             ],
             processIdentifier: pid,
-            targetDeviceName: "iPhone 17 Pro"
+            targetWindowTitle: "iPhone 17 Pro – iOS 27.0"
         )
 
-        XCTAssertEqual(result.failure, .targetNotFrontmost(frontmostName: "iPad Air"))
+        XCTAssertEqual(result.failure, .targetNotFocused(focusedName: "iPad Air"))
     }
 
     func testRejectsDuplicateDeviceNames() {
@@ -47,7 +67,7 @@ final class DeviceHubKeyboardRoutingTests: XCTestCase {
                 window(number: 11, name: "iPhone 17 Pro"),
             ],
             processIdentifier: pid,
-            targetDeviceName: "iPhone 17 Pro"
+            targetWindowTitle: "iPhone 17 Pro"
         )
 
         XCTAssertEqual(result.failure, .ambiguousTarget(count: 2))
@@ -65,7 +85,7 @@ final class DeviceHubKeyboardRoutingTests: XCTestCase {
                 ),
             ],
             processIdentifier: pid,
-            targetDeviceName: "iPhone 17 Pro"
+            targetWindowTitle: "iPhone 17 Pro – iOS 27.0"
         )
 
         XCTAssertEqual(result.failure, .noEligibleWindows)

--- a/packages/serve-sim/Tests/SimNativeSupportTests/FramebufferSurfaceSelectorTests.swift
+++ b/packages/serve-sim/Tests/SimNativeSupportTests/FramebufferSurfaceSelectorTests.swift
@@ -1,0 +1,68 @@
+import XCTest
+@testable import SimNativeSupport
+
+final class FramebufferSurfaceSelectorTests: XCTestCase {
+    func testExpectedDeviceSurfaceBeatsLargerPresentationSurface() {
+        let candidates = [
+            FramebufferSurfaceSize(width: 7680, height: 4320),
+            FramebufferSurfaceSize(width: 0, height: 0),
+            FramebufferSurfaceSize(width: 1206, height: 2622),
+        ]
+
+        XCTAssertEqual(
+            FramebufferSurfaceSelector.select(
+                from: candidates,
+                expectedSize: FramebufferSurfaceSize(width: 1206, height: 2622)
+            ),
+            FramebufferSurfaceSelection(index: 2, matchedExpectedSize: true)
+        )
+    }
+
+    func testExpectedSizeMatchesRotatedSurface() {
+        XCTAssertEqual(
+            FramebufferSurfaceSelector.select(
+                from: [FramebufferSurfaceSize(width: 2622, height: 1206)],
+                expectedSize: FramebufferSurfaceSize(width: 1206, height: 2622)
+            ),
+            FramebufferSurfaceSelection(index: 0, matchedExpectedSize: true)
+        )
+    }
+
+    func testZeroSizedSurfacesAreIgnored() {
+        XCTAssertNil(
+            FramebufferSurfaceSelector.select(
+                from: [
+                    FramebufferSurfaceSize(width: 0, height: 0),
+                    FramebufferSurfaceSize(width: 1206, height: 0),
+                ],
+                expectedSize: FramebufferSurfaceSize(width: 1206, height: 2622)
+            )
+        )
+    }
+
+    func testMissingMetadataPreservesLargestSurfaceFallback() {
+        XCTAssertEqual(
+            FramebufferSurfaceSelector.select(
+                from: [
+                    FramebufferSurfaceSize(width: 320, height: 240),
+                    FramebufferSurfaceSize(width: 1179, height: 2556),
+                ],
+                expectedSize: nil
+            ),
+            FramebufferSurfaceSelection(index: 1, matchedExpectedSize: false)
+        )
+    }
+
+    func testNoExactMatchPreservesLargestSurfaceFallback() {
+        XCTAssertEqual(
+            FramebufferSurfaceSelector.select(
+                from: [
+                    FramebufferSurfaceSize(width: 1000, height: 2000),
+                    FramebufferSurfaceSize(width: 1100, height: 2200),
+                ],
+                expectedSize: FramebufferSurfaceSize(width: 1206, height: 2622)
+            ),
+            FramebufferSurfaceSelection(index: 1, matchedExpectedSize: false)
+        )
+    }
+}

--- a/packages/serve-sim/package.json
+++ b/packages/serve-sim/package.json
@@ -35,6 +35,7 @@
     "src/camera-helper.ts",
     "src/middleware.ts",
     "src/native.ts",
+    "src/simctl.ts",
     "src/state.ts",
     "Sources/SimCameraInjector/SimCameraInjector.m",
     "Sources/SimCameraInjector/SimCam*.h",
@@ -48,6 +49,8 @@
     "dist/native/serve-sim-native.node",
     "Package.swift",
     "Sources/SimNative/*.swift",
+    "Sources/SimNativeSupport/*.swift",
+    "Tests/SimNativeSupportTests/*.swift",
     "Sources/SimNative/build.sh"
   ],
   "exports": {

--- a/packages/serve-sim/src/__tests__/device-session-lifecycle.test.ts
+++ b/packages/serve-sim/src/__tests__/device-session-lifecycle.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { EventEmitter } from "events";
+import { createServer, type Server } from "http";
+import type { IncomingMessage, ServerResponse } from "http";
+import type { AddressInfo } from "net";
+import {
+  DeviceSession,
+  type DeviceSessionDependencies,
+} from "../device-session";
+
+const servers: Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => new Promise<void>((resolve) => {
+    server.close(() => resolve());
+    server.closeAllConnections();
+  })));
+});
+
+describe("DeviceSession capture lifecycle", () => {
+  test("a capture start rejection returns 503 instead of becoming unhandled", async () => {
+    const session = new DeviceSession("TEST-UDID", dependencies({
+      start: async () => { throw new Error("Device not booted (state: Shutting Down)"); },
+    }));
+    const baseUrl = await serve(session);
+
+    const response = await fetch(`${baseUrl}/stream.mjpeg`);
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({
+      error: "capture_unavailable",
+      message: "Device not booted (state: Shutting Down)",
+    });
+    expect((await fetch(`${baseUrl}/health`)).status).toBe(200);
+  });
+
+  test("closing while capture starts cannot resurrect or crash the session", async () => {
+    let rejectStart!: (error: Error) => void;
+    let notifyStartCalled!: () => void;
+    let stopCalls = 0;
+    const pendingStart = new Promise<void>((_resolve, reject) => { rejectStart = reject; });
+    const startCalled = new Promise<void>((resolve) => { notifyStartCalled = resolve; });
+    const session = new DeviceSession("TEST-UDID", dependencies({
+      start: () => {
+        notifyStartCalled();
+        return pendingStart;
+      },
+      stop: async () => { stopCalls++; },
+    }));
+    const baseUrl = await serve(session);
+
+    const streamResponse = fetch(`${baseUrl}/stream.mjpeg`);
+    await startCalled;
+    session.close();
+    rejectStart(new Error("Device not booted (state: Shutting Down)"));
+
+    expect((await streamResponse).status).toBe(503);
+    expect(stopCalls).toBe(1);
+    expect((await fetch(`${baseUrl}/health`)).status).toBe(200);
+  });
+
+  test("a static simulator replays its cached JPEG to keep MJPEG clients live", async () => {
+    const callbacks: Array<(frame: { data: Uint8Array; width: number; height: number }) => Promise<void>> = [];
+    const session = new DeviceSession("TEST-UDID", dependencies({
+      subscribeMjpeg: async (callback) => {
+        callbacks.push(callback);
+        return () => {};
+      },
+    }));
+    await session.start();
+    await callbacks[0]!({ data: new Uint8Array([0xff, 0xd8, 0xff, 0xd9]), width: 10, height: 20 });
+
+    const baseUrl = await serve(session);
+    const controller = new AbortController();
+    const response = await fetch(`${baseUrl}/stream.mjpeg?raw=1`, { signal: controller.signal });
+    expect(response.status).toBe(200);
+    const reader = response.body!.getReader();
+    const decoder = new TextDecoder("latin1");
+    let wire = "";
+    const deadline = Date.now() + 2_500;
+    while ((wire.match(/Content-Length:/g)?.length ?? 0) < 2 && Date.now() < deadline) {
+      const chunk = await Promise.race([
+        reader.read(),
+        new Promise<null>((resolve) => setTimeout(() => resolve(null), 1_250)),
+      ]);
+      if (!chunk || chunk.done) break;
+      wire += decoder.decode(chunk.value, { stream: true });
+    }
+    controller.abort();
+    await reader.cancel().catch(() => {});
+    session.close();
+
+    expect(wire.match(/Content-Length:/g)?.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("holds a native JPEG buffer until HTTP backpressure drains", async () => {
+    const callbacks: Array<(frame: { data: Uint8Array; width: number; height: number }) => Promise<void>> = [];
+    const session = new DeviceSession("TEST-UDID", dependencies({
+      subscribeMjpeg: async (callback) => {
+        callbacks.push(callback);
+        return () => {};
+      },
+    }));
+    await session.start();
+
+    const response = new FakeServerResponse();
+    response.writableNeedDrain = true;
+    session.handleMjpeg(
+      { url: "/stream.mjpeg" } as IncomingMessage,
+      response as unknown as ServerResponse,
+    );
+    await waitFor(() => callbacks.length === 2);
+
+    let callbackSettled = false;
+    const delivery = callbacks[1]!({
+      data: new Uint8Array([0xff, 0xd8, 0xff, 0xd9]),
+      width: 10,
+      height: 20,
+    }).then(() => { callbackSettled = true; });
+    await Promise.resolve();
+    expect(callbackSettled).toBe(false);
+
+    response.writableNeedDrain = false;
+    response.emit("drain");
+    await delivery;
+    expect(callbackSettled).toBe(true);
+    expect(Buffer.concat(response.chunks).includes(Buffer.from([0xff, 0xd8, 0xff, 0xd9]))).toBe(true);
+
+    response.writableEnded = true;
+    response.emit("close");
+    session.close();
+  });
+});
+
+class FakeServerResponse extends EventEmitter {
+  writableEnded = false;
+  destroyed = false;
+  writableNeedDrain = false;
+  headersSent = false;
+  readonly chunks: Buffer[] = [];
+
+  writeHead(): this {
+    this.headersSent = true;
+    return this;
+  }
+
+  write(chunk: Uint8Array | string): boolean {
+    this.chunks.push(Buffer.from(chunk));
+    return !this.writableNeedDrain;
+  }
+
+  destroy(): this {
+    this.destroyed = true;
+    this.emit("close");
+    return this;
+  }
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("condition not reached");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+function dependencies(
+  captureOverrides: Partial<DeviceSessionDependencies["capture"]> = {},
+): DeviceSessionDependencies {
+  return {
+    capture: {
+      start: async () => {},
+      stop: async () => {},
+      subscribeMjpeg: async () => () => {},
+      subscribeAvcc: async () => () => {},
+      ...captureOverrides,
+    },
+    hid: {
+      touch: async () => {},
+      multiTouch: async () => {},
+      button: async () => {},
+      buttonHid: async () => {},
+      key: async () => {},
+      scroll: async () => {},
+      digitalCrown: async () => {},
+      orientation: async () => false,
+      memoryWarning: async () => {},
+      softwareKeyboard: async () => {},
+      caDebug: async () => false,
+    },
+  };
+}
+
+async function serve(session: DeviceSession): Promise<string> {
+  const server = createServer((req, res) => {
+    if (req.url === "/health") session.handleHealth(req, res);
+    else session.handleMjpeg(req, res);
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return `http://127.0.0.1:${port}`;
+}

--- a/packages/serve-sim/src/__tests__/device-session-lifecycle.test.ts
+++ b/packages/serve-sim/src/__tests__/device-session-lifecycle.test.ts
@@ -76,7 +76,7 @@ describe("DeviceSession capture lifecycle", () => {
     const reader = response.body!.getReader();
     const decoder = new TextDecoder("latin1");
     let wire = "";
-    const deadline = Date.now() + 2_500;
+    const deadline = Date.now() + 5_000;
     while ((wire.match(/Content-Length:/g)?.length ?? 0) < 2 && Date.now() < deadline) {
       const chunk = await Promise.race([
         reader.read(),
@@ -103,16 +103,21 @@ describe("DeviceSession capture lifecycle", () => {
     await session.start();
 
     const response = new FakeServerResponse();
-    response.writableNeedDrain = true;
     session.handleMjpeg(
       { url: "/stream.mjpeg" } as IncomingMessage,
       response as unknown as ServerResponse,
     );
     await waitFor(() => callbacks.length === 2);
 
+    const jpeg = Buffer.from([0xff, 0xd8, 0xff, 0xd9]);
+    response.onWrite = (chunk) => {
+      if (!chunk.equals(jpeg)) return;
+      response.writableNeedDrain = true;
+      return false;
+    };
     let callbackSettled = false;
     const delivery = callbacks[1]!({
-      data: new Uint8Array([0xff, 0xd8, 0xff, 0xd9]),
+      data: jpeg,
       width: 10,
       height: 20,
     }).then(() => { callbackSettled = true; });
@@ -129,6 +134,79 @@ describe("DeviceSession capture lifecycle", () => {
     response.emit("close");
     session.close();
   });
+
+  test("holds a native AVCC buffer until its queued write drains", async () => {
+    const callbacks: Array<(frame: {
+      data: Uint8Array;
+      width: number;
+      height: number;
+      isDescription: boolean;
+      isKeyframe: boolean;
+    }) => Promise<void>> = [];
+    const session = new DeviceSession("TEST-UDID", dependencies({
+      subscribeAvcc: async (callback) => {
+        callbacks.push(callback);
+        return () => {};
+      },
+    }));
+    await session.start();
+
+    const response = new FakeServerResponse();
+    const payload = Buffer.from([0, 0, 0, 1, 0x65]);
+    response.onWrite = (chunk) => {
+      if (!chunk.equals(payload)) return;
+      response.writableNeedDrain = true;
+      return false;
+    };
+    session.handleAvcc(
+      {} as IncomingMessage,
+      response as unknown as ServerResponse,
+    );
+    await waitFor(() => callbacks.length === 1);
+
+    let callbackSettled = false;
+    const delivery = callbacks[0]!({
+      data: payload,
+      width: 10,
+      height: 20,
+      isDescription: false,
+      isKeyframe: true,
+    }).then(() => { callbackSettled = true; });
+    await Promise.resolve();
+    expect(callbackSettled).toBe(false);
+
+    response.writableNeedDrain = false;
+    response.emit("drain");
+    await delivery;
+    expect(callbackSettled).toBe(true);
+
+    response.destroy();
+    session.close();
+  });
+
+  test("closing a session terminates active streams and unsubscribes them", async () => {
+    const callbacks: Array<(frame: { data: Uint8Array; width: number; height: number }) => Promise<void>> = [];
+    const unsubscribed: number[] = [];
+    const session = new DeviceSession("TEST-UDID", dependencies({
+      subscribeMjpeg: async (callback) => {
+        callbacks.push(callback);
+        const subscription = callbacks.length;
+        return () => { unsubscribed.push(subscription); };
+      },
+    }));
+    await session.start();
+
+    const response = new FakeServerResponse();
+    session.handleMjpeg(
+      { url: "/stream.mjpeg" } as IncomingMessage,
+      response as unknown as ServerResponse,
+    );
+    await waitFor(() => callbacks.length === 2);
+
+    session.close();
+    await waitFor(() => response.destroyed && unsubscribed.length === 2);
+    expect(unsubscribed.sort()).toEqual([1, 2]);
+  });
 });
 
 class FakeServerResponse extends EventEmitter {
@@ -137,6 +215,7 @@ class FakeServerResponse extends EventEmitter {
   writableNeedDrain = false;
   headersSent = false;
   readonly chunks: Buffer[] = [];
+  onWrite?: (chunk: Buffer) => boolean | undefined;
 
   writeHead(): this {
     this.headersSent = true;
@@ -144,8 +223,18 @@ class FakeServerResponse extends EventEmitter {
   }
 
   write(chunk: Uint8Array | string): boolean {
-    this.chunks.push(Buffer.from(chunk));
+    const buffer = Buffer.from(chunk);
+    this.chunks.push(buffer);
+    const accepted = this.onWrite?.(buffer);
+    if (accepted != null) return accepted;
     return !this.writableNeedDrain;
+  }
+
+  end(chunk?: Uint8Array | string): this {
+    if (chunk) this.chunks.push(Buffer.from(chunk));
+    this.writableEnded = true;
+    this.emit("close");
+    return this;
   }
 
   destroy(): this {

--- a/packages/serve-sim/src/__tests__/selected-stream-config.test.ts
+++ b/packages/serve-sim/src/__tests__/selected-stream-config.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import type { HostEventStream } from "../client/utils/exec";
+import {
+  bindSelectedConfigStream,
+  fetchSelectedStreamConfig,
+  selectedConfigEndpoint,
+} from "../client/utils/selected-stream-config";
+
+const config = {
+  url: "http://127.0.0.1:3200/helper/DEVICE-A",
+  streamUrl: "http://127.0.0.1:3200/helper/DEVICE-A/stream.mjpeg",
+  wsUrl: "ws://127.0.0.1:3200/helper/DEVICE-A/ws",
+  pid: 123,
+  port: 3200,
+  device: "DEVICE-A",
+  basePath: "",
+  execToken: "token",
+};
+
+describe("selected stream config recovery", () => {
+  test("preserves mount queries when selecting a device", () => {
+    expect(selectedConfigEndpoint("/.sim/api?source=grid", "DEVICE A")).toBe(
+      "/.sim/api?source=grid&device=DEVICE%20A",
+    );
+  });
+
+  test("fetches only a config for the requested device without caching", async () => {
+    const requests: Array<{ input: string; init?: RequestInit }> = [];
+    const fetched = await fetchSelectedStreamConfig("/.sim/api", "DEVICE-A", {
+      fetchImpl: async (input, init) => {
+        requests.push({ input: String(input), init });
+        return new Response(JSON.stringify(config), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      },
+    });
+
+    expect(fetched).toEqual(config);
+    expect(requests[0]?.input).toBe("/.sim/api?device=DEVICE-A");
+    expect(requests[0]?.init?.cache).toBe("no-store");
+  });
+
+  test("rejects a stale config for another selection", async () => {
+    const fetched = await fetchSelectedStreamConfig("/api", "DEVICE-B", {
+      fetchImpl: async () => new Response(JSON.stringify(config)),
+    });
+    expect(fetched).toBeNull();
+  });
+
+  test("ignores a queued event after the old selection is closed", () => {
+    let closed = false;
+    const stream: HostEventStream = {
+      onmessage: null,
+      onerror: null,
+      close: () => { closed = true; },
+    };
+    const applied: Array<typeof config | null> = [];
+    const dispose = bindSelectedConfigStream(stream, "DEVICE-A", (next) => {
+      applied.push(next as typeof config | null);
+    });
+    const queuedHandler = stream.onmessage!;
+
+    queuedHandler({ data: JSON.stringify(config) });
+    dispose();
+    queuedHandler({ data: "null" });
+
+    expect(closed).toBe(true);
+    expect(applied).toEqual([config]);
+  });
+});

--- a/packages/serve-sim/src/__tests__/simctl-boot.test.ts
+++ b/packages/serve-sim/src/__tests__/simctl-boot.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { simctlBootStatusArguments } from "../simctl";
+
+describe("simctl boot lifecycle", () => {
+  test("monitors an already-requested boot without asking bootstatus to boot again", () => {
+    expect(simctlBootStatusArguments("DEVICE-UDID")).toEqual([
+      "simctl",
+      "bootstatus",
+      "DEVICE-UDID",
+    ]);
+    expect(simctlBootStatusArguments("DEVICE-UDID")).not.toContain("-b");
+  });
+});

--- a/packages/serve-sim/src/__tests__/type-command-sim.test.ts
+++ b/packages/serve-sim/src/__tests__/type-command-sim.test.ts
@@ -8,10 +8,11 @@ import { join } from "path";
  * Native e2e for `serve-sim type`.
  *
  * Boots through the full stack: textToKeyEvents → WS 0x06 frames →
- * SimStreamHelper.ClientManager → HIDInjector.sendKey → CoreSimulator's HID
- * legacy client. The helper logs `[hid] Key <down|up> usage=0x<hex>` for every
- * accepted key event, which is what we assert against — proving the event
- * round-tripped all the way to the sim, not just to the helper's WS reader.
+ * SimStreamHelper.ClientManager → HIDInjector.sendKey → the Xcode 27 Device Hub
+ * route or the legacy CoreSimulator HID fallback. The helper logs the selected
+ * route for every accepted key event, which is what we assert against — proving
+ * the event round-tripped all the way to native injection, not just to the
+ * helper's WS reader.
  *
  * Those per-event HID logs are gated behind `SERVE_SIM_DEBUG_HID` (they otherwise
  * flood stdout), so the server is started with that env set to make them visible.
@@ -51,8 +52,8 @@ describeWithSim(`serve-sim type e2e (booted sim ${bootedUdid ?? "<skipped>"})`, 
       encoding: "utf-8",
       stdio: ["ignore", "pipe", "inherit"],
       timeout: 45_000,
-      // Surface the per-event `[hid] Key …` lines this test asserts on; the
-      // env propagates to the detached `serve` child the CLI re-execs.
+      // Surface the per-event native route lines this test asserts on; the env
+      // propagates to the detached `serve` child the CLI re-execs.
       env: { ...process.env, SERVE_SIM_DEBUG_HID: "1" },
     });
     if (detach.status !== 0 || !detach.stdout) {
@@ -97,7 +98,7 @@ describeWithSim(`serve-sim type e2e (booted sim ${bootedUdid ?? "<skipped>"})`, 
 
     if (afterCount - beforeCount !== 10) {
       throw new Error(
-        `expected 10 new [hid] Key lines, got ${afterCount - beforeCount}.\n` +
+        `expected 10 new native key lines, got ${afterCount - beforeCount}.\n` +
           `new server log output since typing:\n${newLines.trim() || "(none)"}`,
       );
     }
@@ -110,13 +111,13 @@ describeWithSim(`serve-sim type e2e (booted sim ${bootedUdid ?? "<skipped>"})`, 
     }
 
     // And we should see balanced down/up events for the new slice.
-    expect(countMatches(newLines, /\[hid\] Key down /g)).toBe(5);
-    expect(countMatches(newLines, /\[hid\] Key up /g)).toBe(5);
+    expect(countMatches(newLines, /\[hid\] (?:Key|Posted Device Hub key) down /g)).toBe(5);
+    expect(countMatches(newLines, /\[hid\] (?:Key|Posted Device Hub key) up /g)).toBe(5);
   }, 30_000);
 });
 
 function countKeyLines(s: string): number {
-  return countMatches(s, /\[hid\] Key (down|up) /g);
+  return countMatches(s, /\[hid\] (?:Key|Posted Device Hub key) (down|up) /g);
 }
 
 function countMatches(s: string, re: RegExp): number {

--- a/packages/serve-sim/src/client/client.tsx
+++ b/packages/serve-sim/src/client/client.tsx
@@ -73,6 +73,10 @@ import { proxyPreviewConfigForBrowser } from "./utils/preview-config";
 import { selectInitialRightPane } from "../preview-initial-state";
 import { simEndpoint, streamConfigFrom } from "./utils/sim-endpoint";
 import {
+  bindSelectedConfigStream,
+  fetchSelectedStreamConfig,
+} from "./utils/selected-stream-config";
+import {
   SIMULATOR_RESIZE_DRAG_TRANSITION,
   SIMULATOR_RESIZE_LAYOUT_TRANSITION,
   SIMULATOR_RESIZE_PAGE_TRANSITION,
@@ -253,37 +257,69 @@ function App() {
     if (pick) setSelectedUdid(pick.device);
   }, [selectedUdid, config?.device, gridDevices]);
 
+  const applyConfig = useCallback((next: PreviewConfig | null) => {
+    setConfig((prev) => {
+      next = proxyPreviewConfigForBrowser(streamConfigFrom(next), window.location);
+      if (previewConfigKey(prev) === previewConfigKey(next)) return prev;
+      if (next) {
+        window.__SIM_PREVIEW__ = next;
+      } else if (window.__SIM_PREVIEW__) {
+        // Keep the minimal injection: the empty state still routes through
+        // simEndpoint (basePath) and authenticates /exec (execToken).
+        const { basePath, execToken } = window.__SIM_PREVIEW__;
+        window.__SIM_PREVIEW__ = { basePath, execToken } as Window["__SIM_PREVIEW__"];
+      }
+      return next;
+    });
+  }, []);
+
   // Subscribe to the selected device's stream config. Re-runs on selection
   // change so switching devices swaps the stream without reloading the page.
   useEffect(() => {
     const eventsUrl = `${simEndpoint("api/events")}${selectedUdid ? `?device=${encodeURIComponent(selectedUdid)}` : ""}`;
 
-    const applyConfig = (next: PreviewConfig | null) => {
-      setConfig((prev) => {
-        next = proxyPreviewConfigForBrowser(streamConfigFrom(next), window.location);
-        if (previewConfigKey(prev) === previewConfigKey(next)) return prev;
-        if (next) {
-          window.__SIM_PREVIEW__ = next;
-        } else if (window.__SIM_PREVIEW__) {
-          // Keep the minimal injection: the empty state still routes through
-          // simEndpoint (basePath) and authenticates /exec (execToken).
-          const { basePath, execToken } = window.__SIM_PREVIEW__;
-          window.__SIM_PREVIEW__ = { basePath, execToken } as Window["__SIM_PREVIEW__"];
-        }
-        return next;
-      });
-    };
-
     // Server pushes the serve-sim state only when it actually changes (helper
     // boot/shutdown or device selection), so there's no polling loop here.
     const es = openHostEventStream(eventsUrl);
-    es.onmessage = (event) => {
+    return bindSelectedConfigStream(es, selectedUdid, applyConfig);
+  }, [selectedUdid, selectedHasHelper, applyConfig]);
+
+  // A helper can become visible in the grid before a queued state-stream chunk
+  // reaches this selection. Recover directly from /api only while that mismatch
+  // exists; healthy streams never poll, and a missed transition self-heals
+  // without asking the user to reload.
+  useEffect(() => {
+    if (!selectedUdid || !selectedHasHelper || config?.device === selectedUdid) return;
+
+    const controller = new AbortController();
+    let cancelled = false;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    let retryDelay = 750;
+    const recover = async () => {
       try {
-        applyConfig(streamConfigFrom(JSON.parse(event.data) as Window["__SIM_PREVIEW__"]));
-      } catch {}
+        const next = await fetchSelectedStreamConfig(simEndpoint("api"), selectedUdid, {
+          signal: controller.signal,
+        });
+        if (!cancelled && next) {
+          applyConfig(next);
+          return;
+        }
+      } catch {
+        // The next delayed retry handles transient boot/control-channel races.
+      }
+      if (!cancelled) {
+        retryTimer = setTimeout(recover, retryDelay);
+        retryDelay = Math.min(retryDelay * 2, 5_000);
+      }
     };
-    return () => es.close();
-  }, [selectedUdid, selectedHasHelper]);
+    void recover();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+      if (retryTimer) clearTimeout(retryTimer);
+    };
+  }, [selectedUdid, selectedHasHelper, config?.device, applyConfig]);
 
   // Selection drives the view: stream when the selected device's helper config
   // has arrived, otherwise a placeholder (connecting / boot-and-start).

--- a/packages/serve-sim/src/client/utils/selected-stream-config.ts
+++ b/packages/serve-sim/src/client/utils/selected-stream-config.ts
@@ -1,0 +1,64 @@
+import type { HostEventStream } from "./exec";
+import { streamConfigFrom } from "./sim-endpoint";
+
+type PreviewConfig = NonNullable<Window["__SIM_PREVIEW__"]>;
+type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+type FetchSelectedConfigOptions = {
+  fetchImpl?: FetchLike;
+  signal?: AbortSignal;
+};
+
+/** Build the one-shot recovery endpoint without assuming a root middleware mount. */
+export function selectedConfigEndpoint(apiEndpoint: string, device: string): string {
+  const separator = apiEndpoint.includes("?") ? "&" : "?";
+  return `${apiEndpoint}${separator}device=${encodeURIComponent(device)}`;
+}
+
+/**
+ * Fetch the selected helper config directly. This is only used while the grid
+ * reports a helper but the state stream has not delivered its config yet.
+ */
+export async function fetchSelectedStreamConfig(
+  apiEndpoint: string,
+  device: string,
+  options: FetchSelectedConfigOptions = {},
+): Promise<PreviewConfig | null> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const response = await fetchImpl(selectedConfigEndpoint(apiEndpoint, device), {
+    cache: "no-store",
+    signal: options.signal,
+  });
+  if (!response.ok) return null;
+  const config = streamConfigFrom(await response.json() as Window["__SIM_PREVIEW__"] | null);
+  return config?.device === device ? config : null;
+}
+
+/**
+ * Bind one selected-device SSE subscription. The active flag is intentional:
+ * a WebSocket chunk already queued when React cleans up the old selection can
+ * otherwise apply a stale `null` after the new helper config and strand the UI
+ * on Connecting until reload.
+ */
+export function bindSelectedConfigStream(
+  stream: HostEventStream,
+  device: string | null,
+  applyConfig: (config: PreviewConfig | null) => void,
+): () => void {
+  let active = true;
+  stream.onmessage = (event) => {
+    if (!active) return;
+    try {
+      const config = streamConfigFrom(
+        JSON.parse(event.data) as Window["__SIM_PREVIEW__"] | null,
+      );
+      if (config && device && config.device !== device) return;
+      applyConfig(config);
+    } catch {}
+  };
+
+  return () => {
+    active = false;
+    stream.close();
+  };
+}

--- a/packages/serve-sim/src/device-session.ts
+++ b/packages/serve-sim/src/device-session.ts
@@ -127,6 +127,18 @@ function waitForDrain(res: ServerResponse): Promise<void> {
   });
 }
 
+async function writeAndDrain(
+  res: ServerResponse,
+  write: () => boolean,
+): Promise<boolean> {
+  await waitForDrain(res);
+  if (res.writableEnded || res.destroyed) return false;
+
+  const accepted = write();
+  if (!accepted || res.writableNeedDrain) await waitForDrain(res);
+  return !res.writableEnded && !res.destroyed;
+}
+
 type CaptureTransport = Pick<
   NativeCapture,
   "start" | "stop" | "subscribeMjpeg" | "subscribeAvcc"
@@ -167,6 +179,7 @@ export class DeviceSession {
   private latestJpegBuffer: Buffer | null = null;
   private latestJpegLength = 0;
   private readonly hidSockets = new Set<HidSocket>();
+  private readonly streamResponses = new Set<ServerResponse>();
   private touchGestureLog?: TouchGestureLog;
 
   constructor(public readonly udid: string, dependencies?: DeviceSessionDependencies) {
@@ -219,6 +232,10 @@ export class DeviceSession {
     for (const ws of this.hidSockets) {
       this.runCleanup("HID socket close", () => ws.close());
     }
+    for (const res of this.streamResponses) {
+      this.runCleanup("stream response close", () => { res.destroy(); });
+    }
+    this.streamResponses.clear();
     if (this.unsubscribeMjpeg) {
       this.runCleanup("shared MJPEG unsubscribe", this.unsubscribeMjpeg);
     }
@@ -251,10 +268,11 @@ export class DeviceSession {
   }
 
   /** Write a multipart JPEG part (header + shared frame + boundary) without copying the JPEG. */
-  private writeMjpegFrame(res: ServerResponse, jpeg: Uint8Array): void {
-    res.write(mjpegHeader(jpeg.length));
-    res.write(jpeg);
-    res.write(MJPEG_TRAILER);
+  private writeMjpegFrame(res: ServerResponse, jpeg: Uint8Array): boolean {
+    const headerAccepted = res.write(mjpegHeader(jpeg.length));
+    const frameAccepted = res.write(jpeg);
+    const trailerAccepted = res.write(MJPEG_TRAILER);
+    return headerAccepted && frameAccepted && trailerAccepted;
   }
 
   // ── HTTP handlers ────────────────────────────────────────────────────────
@@ -274,6 +292,7 @@ export class DeviceSession {
       Connection: "keep-alive",
       ...CORS,
     });
+    if (!this.trackStreamResponse(res)) return;
 
     // The native subscriber reuses its frame buffer after this callback
     // resolves. Keep the callback pending through HTTP backpressure so the
@@ -289,10 +308,9 @@ export class DeviceSession {
       if (writeInFlight || res.writableEnded || res.destroyed) return;
       writeInFlight = true;
       try {
-        await waitForDrain(res);
-        if (res.writableEnded || res.destroyed) return;
-        this.writeMjpegFrame(res, jpeg);
-        lastSentAt = Date.now();
+        if (await writeAndDrain(res, () => this.writeMjpegFrame(res, jpeg))) {
+          lastSentAt = Date.now();
+        }
       } catch (error) {
         if (!res.destroyed) {
           res.destroy(error instanceof Error ? error : new Error(String(error)));
@@ -337,6 +355,7 @@ export class DeviceSession {
       Connection: "keep-alive",
       ...CORS,
     });
+    if (!this.trackStreamResponse(res)) return;
 
     // Seed with the current screen; the per-client native AVCC subscription
     // starts with its own decoder config and keyframe.
@@ -344,8 +363,7 @@ export class DeviceSession {
     if (latestJpeg) res.write(avccSeed(latestJpeg));
 
     const unsubscribe = await this.capture.subscribeAvcc(async (frame) => {
-      await waitForDrain(res);
-      if (!res.writableEnded && !res.destroyed) res.write(frame.data);
+      await writeAndDrain(res, () => res.write(frame.data));
     });
     this.bindSubscription(res, unsubscribe);
   }
@@ -633,6 +651,7 @@ export class DeviceSession {
     const cleanup = () => {
       if (cleanedUp) return;
       cleanedUp = true;
+      this.streamResponses.delete(res);
       this.runCleanup("stream unsubscribe", unsubscribe);
     };
     if (res.writableEnded || res.destroyed) {
@@ -641,6 +660,23 @@ export class DeviceSession {
     }
     res.once("close", cleanup);
     res.once("error", cleanup);
+  }
+
+  private trackStreamResponse(res: ServerResponse): boolean {
+    if (this.isStopped() || res.writableEnded || res.destroyed) {
+      if (!res.writableEnded && !res.destroyed) res.destroy();
+      return false;
+    }
+
+    this.streamResponses.add(res);
+    const release = () => {
+      res.off("close", release);
+      res.off("error", release);
+      this.streamResponses.delete(res);
+    };
+    res.once("close", release);
+    res.once("error", release);
+    return true;
   }
 
   private runCleanup(operation: string, cleanup: Unsubscribe): void {

--- a/packages/serve-sim/src/device-session.ts
+++ b/packages/serve-sim/src/device-session.ts
@@ -52,6 +52,10 @@ const AVCC_SEED_TAG = 0x04;
 const WS_MSG_CONFIG = 0x82;
 
 const MJPEG_TRAILER = Buffer.from("\r\n", "ascii");
+// Native capture is event-driven, so an unchanged screen can legitimately
+// produce no new JPEGs. Replay the already-encoded frame below the client's
+// 2s liveness window instead of re-encoding identical pixels in Swift.
+const MJPEG_IDLE_REPLAY_MS = 1_000;
 const TOUCH_TAP_MAX_DISTANCE = 0.004;
 
 type TouchGestureLog = {
@@ -123,11 +127,38 @@ function waitForDrain(res: ServerResponse): Promise<void> {
   });
 }
 
+type CaptureTransport = Pick<
+  NativeCapture,
+  "start" | "stop" | "subscribeMjpeg" | "subscribeAvcc"
+>;
+type HidTransport = Pick<
+  NativeHid,
+  | "touch"
+  | "multiTouch"
+  | "button"
+  | "buttonHid"
+  | "key"
+  | "scroll"
+  | "digitalCrown"
+  | "orientation"
+  | "memoryWarning"
+  | "softwareKeyboard"
+  | "caDebug"
+>;
+
+export interface DeviceSessionDependencies {
+  capture: CaptureTransport;
+  hid: HidTransport;
+}
+
+type Unsubscribe = () => void | Promise<void>;
+
 export class DeviceSession {
-  private readonly capture: NativeCapture;
-  private readonly hid: NativeHid;
-  private unsubscribeMjpeg?: () => void;
-  private phase: "unstarted" | "running" | "stopped" = "unstarted";
+  private readonly capture: CaptureTransport;
+  private readonly hid: HidTransport;
+  private unsubscribeMjpeg?: Unsubscribe;
+  private phase: "unstarted" | "starting" | "running" | "failed" | "stopped" = "unstarted";
+  private startPromise?: Promise<void>;
 
   private width = 0;
   private height = 0;
@@ -138,33 +169,61 @@ export class DeviceSession {
   private readonly hidSockets = new Set<HidSocket>();
   private touchGestureLog?: TouchGestureLog;
 
-  constructor(public readonly udid: string) {
-    this.hid = new NativeHid(udid);
-    this.capture = new NativeCapture(udid);
+  constructor(public readonly udid: string, dependencies?: DeviceSessionDependencies) {
+    this.hid = dependencies?.hid ?? new NativeHid(udid);
+    this.capture = dependencies?.capture ?? new NativeCapture(udid);
   }
 
-  /** Begin capture. Throws if the device isn't booted. Idempotent. */
-  start(): void {
-    if (this.phase !== "unstarted") return;
-    this.capture.start();
-    void (async () => {
+  /** Begin capture and retain one shared MJPEG subscription. Idempotent. */
+  start(): Promise<void> {
+    if (this.phase === "stopped") {
+      return Promise.reject(new Error(`Device session ${this.udid} is closed`));
+    }
+    if (this.startPromise) return this.startPromise;
+
+    this.phase = "starting";
+    const startPromise = (async () => {
+      await this.capture.start();
+      if (this.isStopped()) throw new Error(`Device session ${this.udid} closed while starting`);
+
       const unsubscribe = await this.capture.subscribeMjpeg((frame) => this.onSharedMjpegFrame(frame));
-      if (this.phase === "running") { // only if someone hasn't already stopped the capture
-        this.unsubscribeMjpeg = unsubscribe;
-      } else {
-        unsubscribe();
+      if (this.isStopped()) {
+        await unsubscribe();
+        throw new Error(`Device session ${this.udid} closed while starting`);
       }
-    })();
-    this.phase = "running";
+      this.unsubscribeMjpeg = unsubscribe;
+      this.phase = "running";
+    })().catch((error) => {
+      // Failed DeviceSession instances are evicted by the registry below. Keep
+      // this promise latched so concurrent endpoints all observe the same
+      // failure instead of racing a second start on an instance being closed.
+      if (this.phase === "starting") this.phase = "failed";
+      throw error;
+    });
+
+    // A session is started eagerly by the registry, before an HTTP stream has
+    // necessarily awaited it. Attach a rejection observer immediately so a
+    // shutdown race can never become a process-fatal unhandled rejection.
+    void startPromise.catch(() => {});
+    this.startPromise = startPromise;
+    return startPromise;
+  }
+
+  private isStopped(): boolean {
+    return this.phase === "stopped";
   }
 
   close(): void {
-    if (this.phase !== "running") return;
-    for (const ws of this.hidSockets) ws.close();
-    this.unsubscribeMjpeg?.();
-    this.hidSockets.clear();
-    this.capture.stop();
+    if (this.phase === "stopped") return;
     this.phase = "stopped";
+    for (const ws of this.hidSockets) {
+      this.runCleanup("HID socket close", () => ws.close());
+    }
+    if (this.unsubscribeMjpeg) {
+      this.runCleanup("shared MJPEG unsubscribe", this.unsubscribeMjpeg);
+    }
+    this.hidSockets.clear();
+    this.runCleanup("capture stop", () => this.capture.stop());
   }
 
   // ── Frame handling ───────────────────────────────────────────────────────
@@ -201,6 +260,13 @@ export class DeviceSession {
   // ── HTTP handlers ────────────────────────────────────────────────────────
 
   handleMjpeg(req: IncomingMessage, res: ServerResponse): void {
+    void this.serveMjpeg(req, res).catch((error) => this.handleStreamError(res, error));
+  }
+
+  private async serveMjpeg(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    await this.start();
+    if (res.writableEnded || res.destroyed) return;
+
     const raw = new URL(req.url ?? "", "http://x").searchParams.get("raw") === "1";
     res.writeHead(200, {
       "Content-Type": raw ? "application/octet-stream" : "multipart/x-mixed-replace; boundary=frame",
@@ -209,20 +275,62 @@ export class DeviceSession {
       ...CORS,
     });
 
-    void (async () => {
-      const latestJpeg = this.latestJpeg();
-      if (latestJpeg) this.writeMjpegFrame(res, latestJpeg); // paint immediately
-      const unsubscribe = await this.capture.subscribeMjpeg(async (frame) => {
+    // The native subscriber reuses its frame buffer after this callback
+    // resolves. Keep the callback pending through HTTP backpressure so the
+    // bytes cannot be mutated before res.write consumes them. CaptureEngine's
+    // bufferingNewest(1) policy drops stale frames on the native side while a
+    // slow client drains, so this neither interleaves parts nor grows a queue.
+    let writeInFlight = false;
+    let lastSentAt = 0;
+    const writeFrame = async (jpeg: Uint8Array): Promise<void> => {
+      // This can only overlap when the idle replay timer wins the event-loop
+      // turn immediately before a native frame. Prefer the in-flight write and
+      // let the next native frame provide the freshest image.
+      if (writeInFlight || res.writableEnded || res.destroyed) return;
+      writeInFlight = true;
+      try {
         await waitForDrain(res);
-        this.writeMjpegFrame(res, frame.data);
-      });
-      if (res.writableEnded) unsubscribe();
-      res.on("close", unsubscribe);
-      res.on("error", unsubscribe);
-    })();
+        if (res.writableEnded || res.destroyed) return;
+        this.writeMjpegFrame(res, jpeg);
+        lastSentAt = Date.now();
+      } catch (error) {
+        if (!res.destroyed) {
+          res.destroy(error instanceof Error ? error : new Error(String(error)));
+        }
+      } finally {
+        writeInFlight = false;
+      }
+    };
+
+    const latestJpeg = this.latestJpeg();
+    // The shared cache is reused in place. Copy this one on-connect seed before
+    // awaiting backpressure; native subscriber frames below remain zero-copy.
+    if (latestJpeg) await writeFrame(Buffer.from(latestJpeg));
+    const unsubscribe = await this.capture.subscribeMjpeg(async (frame) => {
+      await writeFrame(frame.data);
+    });
+    const idleReplay = setInterval(() => {
+      if (res.writableEnded || res.destroyed) return;
+      if (Date.now() - lastSentAt < MJPEG_IDLE_REPLAY_MS) return;
+      const cached = this.latestJpeg();
+      // The shared cache is reused in place as fresh frames arrive. Copy only
+      // this low-frequency replay so it stays immutable across backpressure.
+      if (cached) void writeFrame(Buffer.from(cached));
+    }, MJPEG_IDLE_REPLAY_MS);
+    this.bindSubscription(res, async () => {
+      clearInterval(idleReplay);
+      await unsubscribe();
+    });
   }
 
   handleAvcc(_req: IncomingMessage, res: ServerResponse): void {
+    void this.serveAvcc(res).catch((error) => this.handleStreamError(res, error));
+  }
+
+  private async serveAvcc(res: ServerResponse): Promise<void> {
+    await this.start();
+    if (res.writableEnded || res.destroyed) return;
+
     res.writeHead(200, {
       "Content-Type": "application/octet-stream",
       "Cache-Control": "no-cache, no-store",
@@ -230,20 +338,16 @@ export class DeviceSession {
       ...CORS,
     });
 
-    void (async () => {
-      // Seed with the current screen; the per-client native AVCC subscription
-      // starts with its own decoder config and keyframe.
-      const latestJpeg = this.latestJpeg();
-      if (latestJpeg) res.write(avccSeed(latestJpeg));
+    // Seed with the current screen; the per-client native AVCC subscription
+    // starts with its own decoder config and keyframe.
+    const latestJpeg = this.latestJpeg();
+    if (latestJpeg) res.write(avccSeed(latestJpeg));
 
-      const unsubscribe = await this.capture.subscribeAvcc(async (frame) => {
-        await waitForDrain(res);
-        res.write(frame.data);
-      });
-      if (res.writableEnded) unsubscribe();
-      res.on("close", unsubscribe);
-      res.on("error", unsubscribe);
-    })();
+    const unsubscribe = await this.capture.subscribeAvcc(async (frame) => {
+      await waitForDrain(res);
+      if (!res.writableEnded && !res.destroyed) res.write(frame.data);
+    });
+    this.bindSubscription(res, unsubscribe);
   }
 
   handleConfig(_req: IncomingMessage, res: ServerResponse): void {
@@ -524,6 +628,48 @@ export class DeviceSession {
     for (const ws of this.hidSockets) ws.send(frame);
   }
 
+  private bindSubscription(res: ServerResponse, unsubscribe: Unsubscribe): void {
+    let cleanedUp = false;
+    const cleanup = () => {
+      if (cleanedUp) return;
+      cleanedUp = true;
+      this.runCleanup("stream unsubscribe", unsubscribe);
+    };
+    if (res.writableEnded || res.destroyed) {
+      cleanup();
+      return;
+    }
+    res.once("close", cleanup);
+    res.once("error", cleanup);
+  }
+
+  private runCleanup(operation: string, cleanup: Unsubscribe): void {
+    try {
+      void Promise.resolve(cleanup()).catch((error) => this.logCleanupError(operation, error));
+    } catch (error) {
+      this.logCleanupError(operation, error);
+    }
+  }
+
+  private logCleanupError(operation: string, error: unknown): void {
+    console.error(
+      `[capture] ${operation} failed for ${this.udid}:`,
+      error instanceof Error ? error.message : error,
+    );
+  }
+
+  private handleStreamError(res: ServerResponse, error: unknown): void {
+    if (res.writableEnded || res.destroyed) return;
+    if (res.headersSent) {
+      res.destroy(error instanceof Error ? error : new Error(String(error)));
+      return;
+    }
+    this.sendJson(res, 503, {
+      error: "capture_unavailable",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+
   private sendJson(res: ServerResponse, status: number, body: unknown): void {
     this.sendJsonString(res, status, JSON.stringify(body));
   }
@@ -545,20 +691,25 @@ export class DeviceSession {
 const sessions = new Map<string, DeviceSession>();
 
 /**
- * Get (lazily creating + starting) the in-process session for `udid`. Throws if
- * the device isn't booted. The session lives until `closeDeviceSession`.
+ * Get (lazily creating + starting) the in-process session for `udid`. Capture
+ * failures are surfaced by stream endpoints and evict the session so the next
+ * request can retry. The session otherwise lives until `closeDeviceSession`.
  */
 export function getDeviceSession(udid: string): DeviceSession {
   let session = sessions.get(udid);
   if (!session) {
-    session = new DeviceSession(udid);
-    try {
-      session.start();
-    } catch (err) {
-      session.close();
-      throw err;
-    }
-    sessions.set(udid, session);
+    const created = new DeviceSession(udid);
+    session = created;
+    sessions.set(udid, created);
+    void created.start().catch(() => {
+      // A reconnect can race `simctl shutdown`: remove the failed session so a
+      // later Start creates a fresh native capture instead of reusing a rejected
+      // promise. The rejection is observed here and by the endpoint that awaited
+      // it, so it cannot terminate Node/Bun as an unhandled rejection.
+      if (sessions.get(udid) !== created) return;
+      sessions.delete(udid);
+      created.close();
+    });
   }
   return session;
 }

--- a/packages/serve-sim/src/index.ts
+++ b/packages/serve-sim/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { Command, InvalidArgumentError } from "commander";
-import { execSync, spawn as nodeSpawn, type ChildProcess } from "child_process";
+import { execFileSync, execSync, spawn as nodeSpawn, type ChildProcess } from "child_process";
 import { existsSync, mkdirSync, openSync, closeSync, readSync, readFileSync, unlinkSync, writeFileSync } from "fs";
 import { createHash } from "crypto";
 import { networkInterfaces } from "os";
@@ -31,6 +31,7 @@ import {
   readInjectedCameraBundles as readInjectedBundles,
   sendCameraHelperCommand as sendHelperCommand,
 } from "./camera-helper";
+import { simctlBootStatusArguments } from "./simctl";
 
 // `import.meta.dir` is Bun-only; resolve once via fileURLToPath so the bundled
 // CLI works under plain `node` too.
@@ -325,10 +326,11 @@ async function findAvailablePort(start: number): Promise<number> {
 
 async function ensureBooted(udid: string): Promise<void> {
   bootDevice(udid);
-  // `simctl bootstatus -b` blocks until the device's services are actually ready
-  // (not just flipped to "Booted"). Much more reliable than polling `simctl list`.
+  // Boot was requested by bootDevice. Passing `-b` redundantly can remain
+  // blocked on Xcode 27 even after the device is Booted. Monitor the existing
+  // transition; bootstatus still waits for services, not merely the state flag.
   try {
-    execSync(`xcrun simctl bootstatus ${udid} -b`, {
+    execFileSync("xcrun", simctlBootStatusArguments(udid), {
       encoding: "utf-8",
       stdio: "pipe",
       timeout: 60_000,

--- a/packages/serve-sim/src/middleware.ts
+++ b/packages/serve-sim/src/middleware.ts
@@ -32,6 +32,7 @@ import {
 import { createExecUpgradeHandler, type UiRequestHandler } from "./exec-ws";
 import { UI_OPTIONS, getUiStatus, normalizeUiValue, setUiOption } from "./ui-settings";
 import type { PreviewInitialState } from "./preview-initial-state";
+import { simctlBootStatusArguments } from "./simctl";
 
 type SimReq = IncomingMessage;
 type SimRes = ServerResponse;
@@ -769,7 +770,10 @@ export async function startDeviceInProcess(udid: string, port: number, base: str
   // `simctl boot` errors when already booted — ignore and let bootstatus confirm.
   await new Promise<void>((resolve) => execFile("xcrun", ["simctl", "boot", udid], () => resolve()));
   const ready = await new Promise<boolean>((resolve) => {
-    execFile("xcrun", ["simctl", "bootstatus", udid, "-b"], { timeout: 180_000 }, (err) => resolve(!err));
+    // Boot was already requested above. Passing `-b` redundantly can remain
+    // blocked on Xcode 27 even after `simctl list` reports Booted, so only
+    // monitor the transition already in progress.
+    execFile("xcrun", simctlBootStatusArguments(udid), { timeout: 180_000 }, (err) => resolve(!err));
   });
   if (!ready) {
     // bootstatus can exit non-zero even when the device is actually ready;

--- a/packages/serve-sim/src/native.ts
+++ b/packages/serve-sim/src/native.ts
@@ -33,9 +33,9 @@ interface SimHIDHandle {
 }
 
 interface SimCaptureHandle {
-  start(): void;
-  stop(): void;
-  subscribe(codec: number, onFrame: RawFrameCallback): Promise<() => void>;
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  subscribe(codec: number, onFrame: RawFrameCallback): Promise<() => void | Promise<void>>;
 }
 
 interface NativeAddon {
@@ -196,18 +196,18 @@ export class NativeCapture {
     this.handle = new (load().SimCapture)(udid);
   }
 
-  /** Begin capturing. Throws if the device isn't booted. */
-  start(): void {
-    this.handle.start();
+  /** Begin capturing. Rejects if the device isn't booted. */
+  start(): Promise<void> {
+    return this.handle.start();
   }
 
-  subscribeMjpeg(onFrame: (frame: MjpegFrame) => Promise<void>): Promise<() => void> {
+  subscribeMjpeg(onFrame: (frame: MjpegFrame) => Promise<void>): Promise<() => void | Promise<void>> {
     return this.handle.subscribe(CODEC_MJPEG, (data, width, height, _flags) => {
       return onFrame({ data, width, height });
     });
   }
 
-  subscribeAvcc(onFrame: (frame: AvccFrame) => Promise<void>): Promise<() => void> {
+  subscribeAvcc(onFrame: (frame: AvccFrame) => Promise<void>): Promise<() => void | Promise<void>> {
     return this.handle.subscribe(CODEC_AVCC, (data, width, height, flags) => {
       return onFrame({
         data,
@@ -220,8 +220,8 @@ export class NativeCapture {
   }
 
   /** Halt frame production. Full teardown happens when this object is GC'd. */
-  stop(): void {
-    this.handle.stop();
+  stop(): Promise<void> {
+    return this.handle.stop();
   }
 }
 

--- a/packages/serve-sim/src/simctl.ts
+++ b/packages/serve-sim/src/simctl.ts
@@ -1,0 +1,11 @@
+/**
+ * Arguments for monitoring a boot that serve-sim has already requested.
+ *
+ * `-b` means "boot if needed". Keeping it out is intentional: after a separate
+ * `simctl boot`, Xcode 27 can leave the redundant boot-and-monitor form blocked
+ * even though the device is already Booted. This form only monitors the boot
+ * transition that serve-sim requested.
+ */
+export function simctlBootStatusArguments(udid: string): [string, string, string] {
+  return ["simctl", "bootstatus", udid];
+}


### PR DESCRIPTION
## Summary

- Select the simulator's native framebuffer when Xcode 27 Device Hub exposes an additional resize/presentation surface.
- Restore browser keyboard forwarding on Xcode 27 through a guarded Device Hub route, while preserving the legacy HID path.
- Harden simulator boot, native capture startup, and selected-stream recovery so newly started devices do not remain stuck on Connecting.

## Why

When Device Hub enters Resize Mode, Xcode 27 can expose a large presentation IOSurface alongside the simulator's native framebuffer. `serve-sim` previously selected the largest live surface, which could send the presentation surface to VideoToolbox and repeatedly fail with:

`error encoding frame: encodingFailed`

There were additional startup and input regressions:

- a redundant `simctl bootstatus -b` could remain blocked after `simctl boot` had already been requested;
- native capture startup rejections could escape asynchronously and leave the preview or process in an invalid lifecycle state;
- iOS 27 did not consume the legacy Indigo keyboard path used by the browser preview;
- a queued state-stream event could overwrite the selected helper config after switching devices, leaving the UI on Connecting until a manual reload.

## What changed

### Frame capture

- Resolve the simulator device type's native screen dimensions.
- Prefer the live IOSurface matching those dimensions, including rotated matches.
- Preserve the previous largest-live-surface fallback when metadata is unavailable or has no live match, with one-time diagnostics.
- Ignore and log larger Device Hub presentation surfaces only once.
- Treat VideoToolbox's non-error `FrameDropped` callback as a skipped frame instead of reporting `encodingFailed`.

### Keyboard input

- On Xcode 27+, route supported keyboard events to the Device Hub application from the selected Xcode installation.
- Require exactly one matching Device Hub process and one visible, focused simulator window whose Accessibility title exactly matches the target device and runtime.
- Read window metadata through Accessibility, avoiding an additional Screen Recording permission.
- Fail closed on partial or ambiguous Accessibility snapshots.
- Keep key-down/up sequences latched to one route so chords cannot split between transports.
- Preserve legacy Indigo HID behavior on older Xcode versions and whenever the guarded route cannot be used.
- Add `SERVE_SIM_DISABLE_DEVICE_HUB_KEYBOARD=1` as an exact-value opt-out.

### Startup and stream recovery

- Model native capture `start`, `stop`, and unsubscribe operations as asynchronous.
- Await capture startup, clean partially initialized native state after failure, and prevent concurrent stop/start races from resurrecting a closed session.
- Return a controlled 503 for capture startup failures and evict failed sessions so later requests can retry with a fresh native instance.
- Monitor an already-requested simulator boot without passing another `-b`.
- Ignore stale selected-device stream events after subscription cleanup.
- Recover a missing selected config directly from `/api` with capped backoff only while the grid reports that helper as available.
- Replay the latest already-encoded JPEG below the client liveness timeout when the simulator is static.
- Preserve native MJPEG and AVCC frame-buffer lifetime through post-write HTTP drain without unbounded per-client queues.
- Terminate active stream responses, replay timers, and native subscriptions when a device session closes.

## Compatibility and safety

- Xcode 26 and older continue using legacy keyboard HID.
- Frame capture retains the historical largest-surface fallback when native screen metadata is unavailable.
- Device Hub keyboard routing verifies the selected Xcode bundle and fails closed when the process, focused window, title, or Accessibility snapshot is ambiguous.
- No package version bump is included.

## Validation

- Bun: 359 pass, 3 skip, 0 fail across 63 files.
- Swift support: 13 pass, 0 fail.
- `tsc --noEmit`
- `npm run build`
- `npm pack --dry-run --json`
- `git diff --check`

Manual validation on Xcode 27.0 (27A5218g):

- Device Hub Resize Mode exposes a 7680x4320 presentation surface, while the native 1206x2622 framebuffer streams without `encodingFailed`.
- The Browser reports the selected simulator as live and receives AVCC description/keyframe data.
- Browser-originated keyboard events use the guarded Device Hub route for the focused target simulator.
- Start -> Shutdown -> Start leaves the server running and reconnects successfully.
- A newly started iOS 26.1 simulator leaves Connecting without requiring a page reload.
- Static MJPEG streams remain live without re-encoding identical frames.
